### PR TITLE
inf-haskell: fix mode-map name

### DIFF
--- a/modules/lang/haskell/config.el
+++ b/modules/lang/haskell/config.el
@@ -14,7 +14,7 @@
 
   (autoload 'switch-to-haskell "inf-haskell" nil t)
   (after! inf-haskell
-    (map! :map inf-haskell-mode-map "ESC ESC" #'doom/popup-close)))
+    (map! :map inferior-haskell-mode-map "ESC ESC" #'doom/popup-close)))
 
 
 (def-package! company-ghc


### PR DESCRIPTION
I'll need someone to double-check this for me, but on my computer, I don't have any `inf-haskell-mode-map`, so I was getting errors like `(void-variable inf-haskell-mode-map)`.

There is however an `inferior-haskell-mode-map` (seems like poor naming convention on their side...), which at least seems to remove the error when I replace it with.