### PR TITLE
Fix a spelling mistake during variable assignment

### DIFF
--- a/core/core-editor.el
+++ b/core/core-editor.el
@@ -142,7 +142,7 @@ with functions that require it (like modeline segments)."
 
 ;; savehist / saveplace
 (setq savehist-file (concat doom-cache-dir "savehist")
-      savehist-save-minibuffer-hisstory t
+      savehist-save-minibuffer-history t
       savehist-autosave-interval nil ; save on kill only
       savehist-additional-variables '(kill-ring search-ring regexp-search-ring)
       save-place-file (concat doom-cache-dir "saveplace"))


### PR DESCRIPTION
_savehist-save-minibuffer-history_  was misspelled as _savehist-save-minibuffer-his**s**tory_. I assume that this was not intentional, so I fixed it.

I could not find any information about contributing (the link at the bottom of the readme is broken), so I hope that this is fine. If I made some kind of mistake, just tell me.