### PR TITLE
Add project-mode +javascript-eslintd-fix-mode

### DIFF
--- a/modules/lang/javascript/config.el
+++ b/modules/lang/javascript/config.el
@@ -6,7 +6,8 @@
   :config
   (setq js2-skip-preprocessor-directives t
         js2-highlight-external-variables nil
-        js2-mode-show-parse-errors nil)
+        js2-mode-show-parse-errors nil
+        js2-strict-trailing-comma-warning nil)
 
   (add-hook! 'js2-mode-hook
     #'(flycheck-mode highlight-indentation-mode rainbow-delimiters-mode))
@@ -136,6 +137,17 @@
   :init
   (map! :map* (json-mode js2-mode-map) :n "gQ" #'web-beautify-js))
 
+(def-package! eslintd-fix
+  :commands (eslintd-fix-mode eslintd-fix)
+  :init
+  (defun +javascript|init-eslintd-fix ()
+    (when (bound-and-true-p +javascript-eslintd-fix-mode)
+      (eslintd-fix-mode)
+      ;; update flycheck to use eslintd for more consistent results
+      (when-let (eslintd-executable (executable-find "eslint_d"))
+        (setq flycheck-javascript-eslint-executable eslintd-executable))))
+  (add-hook! (js2-mode rjsx-mode) #'+javascript|init-eslintd-fix))
+
 
 ;;
 ;; Skewer-mode
@@ -176,6 +188,9 @@
   :match "/screeps/.+$"
   :modes (+javascript-npm-mode)
   :init (load! +screeps))
+
+(def-project-mode! +javascript-eslintd-fix-mode
+  :modes (+javascript-npm-mode))
 
 (def-project-mode! +javascript-gulp-mode
   :files "gulpfile.js")

--- a/modules/lang/javascript/config.el
+++ b/modules/lang/javascript/config.el
@@ -6,8 +6,7 @@
   :config
   (setq js2-skip-preprocessor-directives t
         js2-highlight-external-variables nil
-        js2-mode-show-parse-errors nil
-        js2-strict-trailing-comma-warning nil)
+        js2-mode-show-parse-errors nil)
 
   (add-hook! 'js2-mode-hook
     #'(flycheck-mode highlight-indentation-mode rainbow-delimiters-mode))
@@ -20,14 +19,16 @@
   (set! :editorconfig :add '(js2-mode js2-basic-offset js-switch-indent-offset))
 
   ;; Favor local eslint over global, if available
-  (defun +javascript|init-flycheck-elint ()
+  (defun +javascript|init-flycheck-eslint ()
     (when (derived-mode-p 'js-mode)
       (when-let ((eslint (expand-file-name "node_modules/eslint/bin/eslint.js"
                                            (doom-project-root)))
                  (exists-p (file-exists-p eslint))
                  (executable-p (file-executable-p eslint)))
-        (setq-local flycheck-javascript-eslint-executable eslint))))
-  (add-hook 'flycheck-mode-hook #'+javascript|init-flycheck-elint)
+        (setq-local flycheck-javascript-eslint-executable eslint)
+        (setq-local js2-strict-trailing-comma-warning nil)
+        (setq-local js2-strict-missing-semi-warning nil))))
+  (add-hook 'flycheck-mode-hook #'+javascript|init-flycheck-eslint)
 
   (sp-with-modes '(js2-mode rjsx-mode)
     (sp-local-pair "/* " " */" :post-handlers '(("| " "SPC"))))
@@ -98,6 +99,11 @@
   :config
   (set! :company-backend 'js2-mode '(company-tern)))
 
+(def-package! company-flow
+  :when (featurep! :completion company)
+  :after company
+  :config
+  (set! :company-backend 'js2-mode '(company-flow)))
 
 (def-package! rjsx-mode
   :commands rjsx-mode
@@ -137,8 +143,10 @@
   :init
   (map! :map* (json-mode js2-mode-map) :n "gQ" #'web-beautify-js))
 
+
 (def-package! eslintd-fix
-  :commands (eslintd-fix-mode eslintd-fix)
+  :commands
+  (eslintd-fix-mode eslintd-fix)
   :init
   (defun +javascript|init-eslintd-fix ()
     (when (bound-and-true-p +javascript-eslintd-fix-mode)
@@ -198,6 +206,9 @@
 (def-project-mode! +javascript-npm-mode
   :modes (html-mode css-mode web-mode js2-mode markdown-mode)
   :files "package.json")
+
+(def-project-mode! +javascript-eslintd-fix-mode
+  :modes (+javascript-npm-mode))
 
 (def-project-mode! +javascript-lb6-mode
   :modes (web-mode js2-mode nxml-mode markdown-mode)

--- a/modules/lang/javascript/config.el
+++ b/modules/lang/javascript/config.el
@@ -99,11 +99,6 @@
   :config
   (set! :company-backend 'js2-mode '(company-tern)))
 
-(def-package! company-flow
-  :when (featurep! :completion company)
-  :after company
-  :config
-  (set! :company-backend 'js2-mode '(company-flow)))
 
 (def-package! rjsx-mode
   :commands rjsx-mode
@@ -206,9 +201,6 @@
 (def-project-mode! +javascript-npm-mode
   :modes (html-mode css-mode web-mode js2-mode markdown-mode)
   :files "package.json")
-
-(def-project-mode! +javascript-eslintd-fix-mode
-  :modes (+javascript-npm-mode))
 
 (def-project-mode! +javascript-lb6-mode
   :modes (web-mode js2-mode nxml-mode markdown-mode)

--- a/modules/lang/javascript/packages.el
+++ b/modules/lang/javascript/packages.el
@@ -11,6 +11,7 @@
 (package! tern)
 (package! web-beautify)
 (package! skewer-mode)
+(package! eslintd-fix)
 
 (when (featurep! :completion company)
   (package! company-tern))


### PR DESCRIPTION
This the following features mentioned in #185 have been implemented using the `def-project-mode!`:

 - Auto Format Code: eslint w/ prettier
 - Use eslint_d if available otherwise fallback to eslint

I didn't know how you prefer the documentation for this feature be added so I am leaving it here in pull request. 

# Documentation
This project mode enables automatic formatting of javascript source on save using `eslint --fix`.

## Install
This project mode requires `eslint_d` for auto formatting.
```sh
npm -g install eslint_d
```

## Setup
To enable this feature for a specific project you can use `.dir-locals.el` to set `doom-project` to include `+javascript-eslintd-fix-mode`. Here is an example of my `.dir-locals.el` file which is located next to `package.json` in the root of my JS project: 
```elisp
;;; Directory Local Variables
;;; For more information see (info "(emacs) Directory Variables")

((nil . ((doom-project . (+javascript-eslintd-fix-mode)))))
```

### Prettier code formatter
You can get [Prettier](https://github.com/prettier/prettier)'s great AST based code formatting using this project mode with this eslint pluging that runs Prettier as an ESLint rule:
 - https://github.com/prettier/eslint-plugin-prettier