### PR TITLE
Fix org-tree-slide-mode keybindings

### DIFF
--- a/modules/org/org-present/config.el
+++ b/modules/org/org-present/config.el
@@ -26,8 +26,8 @@
         org-tree-slide-modeline-display nil)
 
   (map! :map org-tree-slide-mode-map
-        [right] #'org-tree-slide-move-next-tree
-        [left]  #'org-tree-slide-move-previous-tree)
+        :n [right] #'org-tree-slide-move-next-tree
+        :n [left]  #'org-tree-slide-move-previous-tree)
 
   (add-hook! 'org-tree-slide-mode-after-narrow-hook
     #'(+org-present|detect-slide +org-present|add-overlays org-display-inline-images))


### PR DESCRIPTION
This is a pretty simple commit that just fixes the keybindings for `org-tree-slide-mode`.

One thing I find a bit curious is that additional keybindings are added identically to org-mode below in the file, yet those seem to work propertly without the mode specifiers:

```emacs-lisp
  (map! :map org-mode-map
        "<f8>" #'+org-present/org-tree-slides
        "<f7>" #'+org-present/next)
```

Also, note that the `+org-present/next` function seems to be missing.

Used this mode successfully while giving a talk at an Emacs meetup last night, thanks for implementing it! :+1: 