### PR TITLE
Fix commands that would depend on 'git-link' being loaded.

### DIFF
--- a/modules/feature/version-control/+git.el
+++ b/modules/feature/version-control/+git.el
@@ -85,5 +85,7 @@
 
 
 (def-package! git-link
-  :commands (git-link git-link-commit git-link-homepage))
+  :commands (git-link git-link-commit git-link-homepage
+             git-link--select-remote git-link--remote-host
+             git-link--remote-dir git-link--get-region))
 


### PR DESCRIPTION
Some commands, e.g. `+vcs-root`, assume that "git-link" is loaded.
I have added all commands needed from "git-link" in the :commands declaration of its `def-package!`.

