### PR TITLE
When calling +vcs-root, load git-link first.

### DIFF
--- a/modules/feature/version-control/autoload.el
+++ b/modules/feature/version-control/autoload.el
@@ -3,6 +3,7 @@
 ;;;###autoload
 (defun +vcs-root ()
   "Get git url root."
+  (require 'git-link)
   (let ((remote (git-link--select-remote)))
     (if (git-link--remote-host remote)
         (format "https://%s/%s"


### PR DESCRIPTION
loading `git-link` when `+vcs-root` is called.