### PR TITLE
Fix 'Wrong type argument: commandp' in +workspace/kill-session-and-quit.

### DIFF
--- a/modules/feature/workspaces/autoload/workspaces.el
+++ b/modules/feature/workspaces/autoload/workspaces.el
@@ -315,6 +315,7 @@ workspace to delete."
 ;;;###autoload
 (defun +workspace/kill-session-and-quit ()
   "Forgets current session and quits."
+  (interactive)
   (+workspace/kill-session)
   (save-buffers-kill-terminal))
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/193264/32571157-8305b848-c4d7-11e7-86df-f8ae943fc073.png)

After pressing SPC q Q, I get this error. Seems, that `(interactive)` fixes the problem.