### PR TITLE
Add keybinding for ace-link in mu4e message view mode

### DIFF
--- a/modules/app/email/config.el
+++ b/modules/app/email/config.el
@@ -235,6 +235,7 @@ default/fallback account."
             :n "q" #'mu4e~view-quit-buffer
             :n "r" #'mu4e-compose-reply
             :n "c" #'mu4e-compose-edit
+            :n "o" #'ace-link-mu4e
 
             :n "<M-Left>"  #'mu4e-view-headers-prev
             :n "<M-Right>" #'mu4e-view-headers-next


### PR DESCRIPTION
Hey!

I just got a pull request into ace-link that supports highlighting and opening various types of links in the mu4e message view mode. It works for opening mu4e links, shr rendered links, and email attachments. If your interested in using it, I've bound it to 'o' in when in mu4e-view-mode in this PR.