### PR TITLE
Remove the trailing space of doom dashboard

### DIFF
--- a/modules/ui/doom-dashboard/config.el
+++ b/modules/ui/doom-dashboard/config.el
@@ -134,7 +134,7 @@ whose dimensions may not be fully initialized by the time this is run."
 (defun doom-dashboard-widget--banner ()
   (mapc (lambda (line)
           (insert (propertize (+doom-dashboard-center +doom-dashboard--width line)
-                              'face 'font-lock-comment-face) " ")
+                              'face 'font-lock-comment-face))
           (insert "\n"))
         '("=================     ===============     ===============   ========  ========"
           "\\\\ . . . . . . .\\\\   //. . . . . . .\\\\   //. . . . . . .\\\\  \\\\. . .\\\\// . . //"


### PR DESCRIPTION
This is a bit weird when displaying trailing white spaces is on.