### PR TITLE
Fix private module readme's links

### DIFF
--- a/modules/private/README.org
+++ b/modules/private/README.org
@@ -5,4 +5,4 @@ Use this directory to store your private configuration modules.
 Mine is included as a reference. I recommend you neither delete nor rename it, to avoid merge conflicts upstream.
 
 -----
-You'll find [[/wiki/Customization][more information about customizing Doom]] on the [[/wiki][wiki]].
+You'll find [[https://github.com/hlissner/doom-emacs/wiki/Customization][more information about customizing Doom]] on the [[https://github.com/hlissner/doom-emacs/wiki][wiki]].


### PR DESCRIPTION
Currently the links in [modules/private/README.org](https://github.com/hlissner/doom-emacs/blob/3d323e6ecfca571e1e4d66f0b466711e6a108d6f/modules/private/README.org) are broken. I propose using absolute links, since they work in forks and locally.

Feel free to use relative links if you want.