### PR TITLE
Call flycheck-popup-tip-mode correctly

### DIFF
--- a/modules/feature/syntax-checker/config.el
+++ b/modules/feature/syntax-checker/config.el
@@ -40,5 +40,5 @@
 
 (after! flycheck
   (if IS-MAC
-      (flycheck-popup-tip)
+      (flycheck-popup-tip-mode)
     (flycheck-pos-tip-mode)))


### PR DESCRIPTION
- Fix issue: Symbol’s function definition is void: flycheck-popup-tip