### PR TITLE
feature/evil: add mapping for evil-numbers

### DIFF
--- a/modules/feature/evil/config.el
+++ b/modules/feature/evil/config.el
@@ -229,6 +229,14 @@
   (add-hook 'doom-escape-hook #'+evil|escape-exchange))
 
 
+(def-package! evil-numbers
+  :commands (evil-numbers/inc-at-pt evil-numbers/dec-at-pt)
+  :init
+  (map!
+   :nv "C-a" #'evil-numbers/inc-at-pt
+   :nv "C-x" #'evil-numbers/dec-at-pt))
+
+
 (def-package! evil-matchit
   :commands (evilmi-jump-items evilmi-text-object global-evil-matchit-mode)
   :config (global-evil-matchit-mode 1)

--- a/modules/feature/evil/config.el
+++ b/modules/feature/evil/config.el
@@ -230,11 +230,7 @@
 
 
 (def-package! evil-numbers
-  :commands (evil-numbers/inc-at-pt evil-numbers/dec-at-pt)
-  :init
-  (map!
-   :nv "C-a" #'evil-numbers/inc-at-pt
-   :nv "C-x" #'evil-numbers/dec-at-pt))
+  :commands (evil-numbers/inc-at-pt evil-numbers/dec-at-pt))
 
 
 (def-package! evil-matchit

--- a/modules/private/default/+bindings.el
+++ b/modules/private/default/+bindings.el
@@ -314,6 +314,8 @@
       ;; paste from recent yank register (which isn't overwritten)
       :v  "C-p" "\"0p"
 
+      :nv "C-a" #'evil-numbers/inc-at-pt
+      :nv "C-x" #'evil-numbers/dec-at-pt
 
       ;; --- Plugin bindings ------------------------------
       ;; auto-yasnippet


### PR DESCRIPTION
1. `evil-numbers` is in the `packages.el` of feature/evil, but not configured with any `def-package!` statements
2. About the keybinding, I think it would be better to use the same keybindings as vim (since doom is "An Emacs configuration for the stubborn martian vimmer"). It might be uncomfortable for Emacs users (since it takes `C-x`), but I've been using this config for some time, and it works fine for me (a former vim user and spacemacs user)