### PR TITLE
Fix race between eldoc and flycheck by delaying flycheck

### DIFF
--- a/modules/feature/syntax-checker/config.el
+++ b/modules/feature/syntax-checker/config.el
@@ -33,7 +33,7 @@
         ;; fallback to flycheck-popup-tip in terminal Emacs
         flycheck-pos-tip-display-errors-tty-function
         #'flycheck-popup-tip-show-popup
-        flycheck-display-errors-delay 0.5))
+        flycheck-display-errors-delay 0.7))
 
 (def-package! flycheck-popup-tip
   :commands (flycheck-popup-tip-mode flycheck-popup-tip-show-popup))


### PR DESCRIPTION
Eldoc uses a default idle delay timer of 0.5.
In your cc module flycheck also is using a `flycheck-display-errors-delay` of 0.5.

This is leading to a race between flycheck and eldoc for the minibuffer, and in my case flycheck never displays the error message and eldoc is showing the docstring even though there is an error in the function parameters.

So i have delayed the flycheck display from 0.5 to 0.7 so that it overrides eldoc in case of errors.