### PR TITLE
feature/evil: fix +evil/matchit-or-toggle-fold in magit modes

### DIFF
--- a/modules/feature/evil/autoload/folds.el
+++ b/modules/feature/evil/autoload/folds.el
@@ -88,7 +88,7 @@
   (interactive)
   (ignore-errors
     (call-interactively
-     (cond ((string-prefix-p "magit" (symbol-name major-mode))
+     (cond ((derived-mode-p 'magit-mode)
             #'magit-section-toggle)
            ((+evil-fold-p)
             #'+evil:fold-toggle)

--- a/modules/feature/evil/autoload/folds.el
+++ b/modules/feature/evil/autoload/folds.el
@@ -88,7 +88,7 @@
   (interactive)
   (ignore-errors
     (call-interactively
-     (cond ((eq major-mode 'magit-status-mode)
+     (cond ((string-prefix-p "magit" (symbol-name major-mode))
             #'magit-section-toggle)
            ((+evil-fold-p)
             #'+evil:fold-toggle)


### PR DESCRIPTION
- this function only worked in magit-status-mode but not other modes like
  magit-log-mode, magit-process-mode, etc.
