### PR TITLE
fix #347: Switch default-directory after project-switch

### DIFF
--- a/modules/feature/workspaces/autoload/workspaces.el
+++ b/modules/feature/workspaces/autoload/workspaces.el
@@ -5,6 +5,7 @@
 
 (defvar +workspace--last nil)
 (defvar +workspace--index 0)
+(defvar +workspace--current-directory default-directory)
 
 ;;
 (defface +workspace-tab-selected-face '((t (:inherit 'highlight)))
@@ -504,10 +505,20 @@ Ensures the scratch (or dashboard) buffers are CDed into the project's root."
     (let ((cwd default-directory))
       (+workspace-switch (projectile-project-name) t)
       (switch-to-buffer (doom-fallback-buffer))
-      (setq default-directory cwd)
+      (setq +workspace--current-directory cwd)
       (+workspace-message
        (format "Switched to '%s' in new workspace" (+workspace-current-name))
        'success))))
+
+;;;###autoload
+(defun +workspaces|set-default-directory ()
+  "Ensures that scratch (or dashboard) buffers are CDed into the project's root
+  after switching projects."
+  (when persp-mode
+    (setq default-directory +workspace--current-directory)
+    (+workspace-message
+      (format "Switched to project root directory '%s' in new workspace" (+workspace-current-name))
+      'success)))
 
 ;;;###autoload
 (defun +workspaces|cleanup-unassociated-buffers ()

--- a/modules/feature/workspaces/config.el
+++ b/modules/feature/workspaces/config.el
@@ -56,7 +56,7 @@ renamed.")
   (add-hook 'delete-frame-functions #'+workspaces|delete-associated-workspace-maybe)
   ;; Per-project workspaces
   (setq projectile-switch-project-action #'+workspaces|per-project)
-
+  (setq projectile-after-switch-project-hook #'+workspaces|set-default-directory)
   ;;
   (defun +workspaces|init (&optional frame)
     (unless persp-mode


### PR DESCRIPTION
Fixed issue #347 by setting default-dir using `projectile-after-switch-project-hook`.

I am not sure how elegant a solution this is since i am quite new to emacs and lisp, maybe it could be done better. Suggest any improvements if they can be made. 

But the existing problem was that projectile is let binding default-directory in it's `projectile-switch-project-by-name` function inside of which the switch-project-action was called where the default-directory was originally being set. 

```
(defun projectile-switch-project-by-name (project-to-switch &optional arg)
  "Switch to project by project name PROJECT-TO-SWITCH.
Invokes the command referenced by `projectile-switch-project-action' on switch.
With a prefix ARG invokes `projectile-commander' instead of
`projectile-switch-project-action.'"
  (let ((switch-project-action (if arg
                                   'projectile-commander
                                 projectile-switch-project-action)))
    (run-hooks 'projectile-before-switch-project-hook)
    (let ((default-directory project-to-switch))
      ;; use a temporary buffer to load PROJECT-TO-SWITCH's dir-locals before calling SWITCH-PROJECT-ACTION
      (with-temp-buffer
        (hack-dir-local-variables-non-file-buffer))
      ;; Normally the project name is determined from the current
      ;; buffer. However, when we're switching projects, we want to
      ;; show the name of the project being switched to, rather than
      ;; the current project, in the minibuffer. This is a simple hack
      ;; to tell the `projectile-project-name' function to ignore the
      ;; current buffer and the caching mechanism, and just return the
      ;; value of the `projectile-project-name' variable.  We also
      ;; need to ignore the cached project-root value otherwise we end
      ;; up still showing files from the current project rather than
      ;; the new project
      (let ((projectile-cached-project-root nil)
            (projectile-project-name (funcall projectile-project-name-function
                                              project-to-switch)))
        (funcall switch-project-action)))
    (run-hooks 'projectile-after-switch-project-hook)))
```
To avoid this i decided to move the setting of default-directory in the `projectile-after-switch-project-hook` by using a variable.

`(defvar +workspace--current-directory default-directory)`

And then setting this variable in the `+workspaces|per-project` function to store the project directory`.
 


