### PR TITLE
Custom LaTeX modeline indicating how many words are in a region

### DIFF
--- a/modules/lang/latex/+modeline.el
+++ b/modules/lang/latex/+modeline.el
@@ -1,0 +1,29 @@
+;;; lang/latex/+modeline.el -*- lexical-binding: t; -*-
+
+
+(def-modeline-segment! +latex-selection-info
+  "Information about the current selection customized for LaTeX
+buffers, such as how many characters, words and lines are
+selected, or the NxM dimensions of a block selection."
+  (when (and (active) (or mark-active (eq evil-state 'visual)))
+    (let ((reg-beg (region-beginning))
+          (reg-end (region-end)))
+      (propertize
+       (let ((lines (count-lines reg-beg (min (1+ reg-end) (point-max))))
+             (words (count-words reg-beg (min (1+ reg-end) (point-max)))))
+         (cond ((or (bound-and-true-p rectangle-mark-mode)
+                    (eq 'block evil-visual-selection))
+                (let ((cols (abs (- (doom-column reg-end)
+                                    (doom-column reg-beg)))))
+                  (format "%dx%dB" lines cols)))
+               ((eq 'line evil-visual-selection)
+                (format "%dL" lines))
+               ((> lines 1)
+                (format "%dC %dL %dW" (- (1+ reg-end) reg-beg) lines words))
+               (t
+                (format "%dC %dW" (- (1+ reg-end) reg-beg) words))))
+       'face 'doom-modeline-highlight))))
+
+(def-modeline! latex-main
+  (bar matches " " buffer-info "  %l:%c %p  " +latex-selection-info)
+  (buffer-encoding major-mode vcs flycheck))

--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -81,6 +81,10 @@
                           (TeX-PDF-mode t) (visual-line-mode +1))
     (when (featurep! :feature spellcheck)
       (add-hook! LaTeX-mode (flyspell-mode t)))
+    ;; Set a custom modeline indicating how many words are in a region.
+    (when (featurep! :ui doom-modeline)
+      (load! +modeline)
+      (add-hook! LaTeX-mode (doom-set-modeline 'latex-main)))
     ;; Default language setting.
     (setq ispell-dictionary "english")
     ;; Use chktex to search for errors in a latex file.


### PR DESCRIPTION
When writing text, it is often useful to know how many words are being written.
This change adds a custom modeline that indicates, with the character "W", how
many words are in a region.

@hlissner, I didn't want to change the **main** modeline for all buffers, so I created a custom one. However, it could be of interest to display also the number of words in the main modeline, maybe?