### PR TITLE
add +bindings feature for private/default

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -138,5 +138,7 @@
        ;; the defaults module. It contains a Spacemacs-inspired keybinding
        ;; scheme and additional ex commands for evil-mode. Use it as a reference
        ;; for your own.
-       :private default)
+       :private
+	   (default +bindings))
+
 

--- a/modules/private/default/config.el
+++ b/modules/private/default/config.el
@@ -1,6 +1,6 @@
 ;;; private/default/config.el -*- lexical-binding: t; -*-
 
-(load! +bindings)
+(if (featurep! +bindings) (load! +bindings))
 
 
 ;;


### PR DESCRIPTION
private/default module is convinience, but if I want create bindings for
my own, it's seems that change prefix key is not handy. for example:

(!map
(:leader
(:prefix "t"
....
)))

change all keybind prefix with "t" to prefix with "f" ....

thou, +bindings feature can disable load default binding, then I can load
binding in my private module ,but still use default module's others part.