### PR TITLE
Add 'counsel-descbinds' to councel defer commands.

### DIFF
--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -79,7 +79,8 @@ immediately runs it on the current candidate (ending the ivy session)."
              counsel-describe-function counsel-describe-variable
              counsel-describe-face counsel-M-x counsel-file-jump
              counsel-find-file counsel-find-library counsel-info-lookup-symbol
-             counsel-imenu counsel-recentf counsel-yank-pop)
+             counsel-imenu counsel-recentf counsel-yank-pop
+             counsel-descbinds)
   :init
   (map! [remap apropos]                  #'counsel-apropos
         [remap bookmark-jump]            #'counsel-bookmark


### PR DESCRIPTION
Small fix: make counsel-descbinds an autoload function.

'counsel-descbinds' can now be called without having to wait until counsel is loaded by some other command.