### PR TITLE
Add ESS / R module

### DIFF
--- a/modules/lang/ess/README.org
+++ b/modules/lang/ess/README.org
@@ -1,0 +1,52 @@
+* map!
+:PROPERTIES:
+:ID:       E27AED84-4D2D-4F67-B9D9-6A26026D4C65
+:END:
+** :map ess-doc-map
+:PROPERTIES:
+:ID:       23857C0C-25BC-4DBA-8360-E2CAB2F98135
+:END:
+| key | command                    |
+|-----+----------------------------|
+| "h" | ess-display-help-on-object |
+| "p" | ess-R-dv-pprint            |
+| "t" | ess-R-dv-ctable            |
+** :map ess-mode-map
+:PROPERTIES:
+:ID:       A5EA8086-C7BF-41BB-BFC4-9D8CC9A79163
+:END:
+| key          | command               |
+|--------------+-----------------------|
+| "<s-return>" | ess-eval-line         |
+| "<up>"       | comint-next-input     |
+| "<down>"     | comint-previous-input |
+*** :localleader
+:PROPERTIES:
+:ID:       7F84D0BD-2F1B-4F1D-92F6-5559A2D0741D
+:END:
+| state | key         | command                                           |
+|-------+-------------+---------------------------------------------------|
+| :nv   | ","         | ess-eval-region-or-function-or-paragraph-and-step |
+| :n    | "'"         | R                                                 |
+| :n    | "<tab>"     | ess-switch-to-inferior-or-script-buffer           |
+| :n    | "<backtab>" | ess-switch-process                                |
+| :n    | "B"         | ess-eval-buffer-and-go                            |
+| :n    | "b"         | ess-eval-buffer                                   |
+| :nv   | "d"         | ess-eval-region-or-line-and-step                  |
+| :n    | "D"         | ess-eval-function-or-paragraph-and-step           |
+| :n    | "L"         | ess-eval-line-and-go                              |
+| :n    | "l"         | ess-eval-line                                     |
+| :nv   | "R"         | ess-eval-region-and-go                            |
+| :nv   | "r"         | ess-eval-region                                   |
+| :n    | "F"         | ess-eval-function-and-go                          |
+| :n    | "f"         | ess-eval-function                                 |
+| :n    | "h"         | ess-doc-map                                       |
+| :n    | "x"         | ess-extra-map                                     |
+| :n    | "p"         | ess-r-package-dev-map                             |
+| :n    | "v"         | ess-dev-map                                       |
+| :n    | "cC"        | ess-eval-chunk-and-go                             |
+| :n    | "cc"        | ess-eval-chunk                                    |
+| :n    | "cd"        | ess-eval-chunk-and-step                           |
+| :n    | "cm"        | ess-noweb-mark-chunk                              |
+| :n    | "cp"        | ess-noweb-previous-chunk                          |
+| :n    | "cn"        | ess-noweb-next-chunk                              |

--- a/modules/lang/ess/autoloads.el
+++ b/modules/lang/ess/autoloads.el
@@ -1,0 +1,6 @@
+;;; private/r/autoload.el -*- lexical-binding: t; -*-
+;;;###autoload
+(defun +r/repl ()
+  "Open the R REPL."
+  (interactive)
+  (inferior-ess nil nil t))

--- a/modules/lang/ess/config.el
+++ b/modules/lang/ess/config.el
@@ -1,0 +1,81 @@
+;; ** ESS
+(setq ess-path (car (file-expand-wildcards "~/.emacs.d/.local/packages/elpa/ess*/lisp")))
+(def-package! ess-site :load-path ess-path
+  :mode (("\\.sp\\'"           . S-mode)
+         ("/R/.*\\.q\\'"       . R-mode)
+         ("\\.[qsS]\\'"        . S-mode)
+         ("\\.ssc\\'"          . S-mode)
+         ("\\.SSC\\'"          . S-mode)
+         ("\\.[rR]\\'"         . R-mode)
+         ("\\.[rR]nw\\'"       . Rnw-mode)
+         ("\\.[sS]nw\\'"       . Snw-mode)
+         ("\\.[rR]profile\\'"  . R-mode)
+         ("NAMESPACE\\'"       . R-mode)
+         ("CITATION\\'"        . R-mode)
+         ("\\.omg\\'"          . omegahat-mode)
+         ("\\.hat\\'"          . omegahat-mode)
+         ("\\.lsp\\'"          . XLS-mode)
+         ("\\.do\\'"           . STA-mode)
+         ("\\.ado\\'"          . STA-mode)
+         ("\\.[Ss][Aa][Ss]\\'" . SAS-mode)
+         ("\\.jl\\'"           . ess-julia-mode)
+         ("\\.[Ss]t\\'"        . S-transcript-mode)
+         ("\\.Sout"            . S-transcript-mode)
+         ("\\.[Rr]out"         . R-transcript-mode)
+         ("\\.Rd\\'"           . Rd-mode)
+         ("\\.[Bb][Uu][Gg]\\'" . ess-bugs-mode)
+         ("\\.[Bb][Oo][Gg]\\'" . ess-bugs-mode)
+         ("\\.[Bb][Mm][Dd]\\'" . ess-bugs-mode)
+         ("\\.[Jj][Aa][Gg]\\'" . ess-jags-mode)
+         ("\\.[Jj][Oo][Gg]\\'" . ess-jags-mode)
+         ("\\.[Jj][Mm][Dd]\\'" . ess-jags-mode))
+  :commands (R stata julia SAS)
+  :config
+  (setq ess-first-continued-statement-offset 2
+        ess-continued-statement-offset 0
+        ess-expression-offset 2
+        ess-nuke-trailing-whitespace-p t
+        ess-default-style 'DEFAULT)
+  (ess-toggle-underscore t)
+  (set! :repl 'ess-mode #'+r/repl)
+  (map!
+   (:map ess-doc-map
+     "h"             #'ess-display-help-on-object
+     "p"             #'ess-R-dv-pprint
+     "t"             #'ess-R-dv-ctable)
+   (:map ess-mode-map
+     "<s-return>"    #'ess-eval-line
+     "<up>"          #'comint-next-input
+     "<down>"        #'comint-previous-input
+     (:localleader
+      :nv ","        #'ess-eval-region-or-function-or-paragraph-and-step
+      :n "'"         #'R
+      :n "<tab>"     #'ess-switch-to-inferior-or-script-buffer
+      :n "<backtab>" #'ess-switch-process
+      :n ;; REPL
+      :n "B"         #'ess-eval-buffer-and-go
+      :n "b"         #'ess-eval-buffer
+      :nv "d"        #'ess-eval-region-or-line-and-step
+      :n "D"         #'ess-eval-function-or-paragraph-and-step
+      :n "L"         #'ess-eval-line-and-go
+      :n "l"         #'ess-eval-line
+      :nv "R"        #'ess-eval-region-and-go
+      :nv "r"        #'ess-eval-region
+      :n "F"         #'ess-eval-function-and-go
+      :n "f"         #'ess-eval-function
+      ;; predefined keymaps
+      :n "h"         #'ess-doc-map
+      :n "x"         #'ess-extra-map
+      :n "p"         #'ess-r-package-dev-map
+      :n "v"         #'ess-dev-map
+      ;; noweb
+      :n "cC"        #'ess-eval-chunk-and-go
+      :n "cc"        #'ess-eval-chunk
+      :n "cd"        #'ess-eval-chunk-and-step
+      :n "cm"        #'ess-noweb-mark-chunk
+      :n "cp"        #'ess-noweb-previous-chunk
+      :n "cn"        #'ess-noweb-next-chunk))))
+
+(def-package! ess-smart-equals
+  :hook ((ess-mode . ess-smart-equals-mode)
+         (inferior-ess-mode . ess-smart-equals-mode)))

--- a/modules/lang/ess/packages.el
+++ b/modules/lang/ess/packages.el
@@ -1,0 +1,3 @@
+(package! ess)
+(package! ess-smart-equals)
+(package! ess-R-data-view)


### PR DESCRIPTION
This is a `ESS / R` ported from `spacemacs`. 
Currently I only added extremely basic `+eval/repl` support 
(+eval code with `quickrun`). But the ordinary ESS inferior mode is pretty 
usable (start `R` with `localleader-'` and send code use `localleader-,`).

Check the README.org for other keybindings.