### PR TITLE
Fix rss module.

### DIFF
--- a/core/autoload/buffers.el
+++ b/core/autoload/buffers.el
@@ -170,7 +170,7 @@ If DERIVED-P, test with `derived-mode-p', otherwise use `eq'."
 regex PATTERN. Returns the number of killed buffers."
   (let ((buffers (doom-matching-buffers pattern buffer-list)))
     (dolist (buf buffers (length buffers))
-      (kill-buffer buf t))))
+      (kill-buffer buf))))
 
 
 ;;

--- a/modules/app/rss/config.el
+++ b/modules/app/rss/config.el
@@ -53,7 +53,7 @@
 
 
 (def-package! elfeed-org
-  :after (:all org elfeed)
+  :after (elfeed)
   :config
   (setq rmh-elfeed-org-files
         (let ((default-directory +org-dir))


### PR DESCRIPTION
Hi there. I have turned on rss module and found two bugs.
1. After fresh start of emacs org is not loaded. This prevents elfeed-org to be invoked when I start elfeed.
2. When I press `q` in elfeed I get error message about `kill-buffer` arguments.