### PR TITLE
Fix adding evil-set-jump to rtags-jump-hook when evil is not enabled

### DIFF
--- a/modules/lang/cc/config.el
+++ b/modules/lang/cc/config.el
@@ -220,7 +220,7 @@ compilation database is present in the project.")
   ;; Use rtags-imenu instead of imenu/counsel-imenu
   (map! :map (c-mode-map c++-mode-map) [remap imenu] #'rtags-imenu)
 
-  (add-hook 'rtags-jump-hook #'evil-set-jump)
+  (when (featurep 'evil) (add-hook 'rtags-jump-hook #'evil-set-jump))
   (add-hook 'rtags-after-find-file-hook #'recenter))
 
 (def-package! ivy-rtags


### PR DESCRIPTION
When evil is disabled functions like `rtags-find-symbol-at-point` don't work because the function evil-set-jump isn't defined. I'm proposing the simple fix of only adding the hook when `(featurep 'evil)`
