### PR TITLE
Fix keybinding

### DIFF
--- a/modules/private/default/+bindings.el
+++ b/modules/private/default/+bindings.el
@@ -286,7 +286,7 @@
           :desc "Flyspell"               :n "s" #'flyspell-mode
           :desc "Flycheck"               :n "f" #'flycheck-mode
           :desc "Line numbers"           :n "l" #'doom/toggle-line-numbers
-          :desc "Frame fullscreen"       :n "f" #'toggle-frame-fullscreen
+          :desc "Frame fullscreen"       :n "F" #'toggle-frame-fullscreen
           :desc "Indent guides"          :n "i" #'highlight-indentation-mode
           :desc "Indent guides (column)" :n "I" #'highlight-indentation-current-column-mode
           :desc "Impatient mode"         :n "h" #'+impatient-mode/toggle


### PR DESCRIPTION
Both flycheck-mode and toggle-frame-fullscreen seem to be bound to "SPC t f", which means that only the second binding gets applied and there's no binding to toggle flycheck. This PR simply changes the fullscreen binding to capital F.