### PR TITLE
Disable flycheck for emacs-lisp in +private-config-path

### DIFF
--- a/modules/lang/emacs-lisp/config.el
+++ b/modules/lang/emacs-lisp/config.el
@@ -56,7 +56,10 @@
   (defun +emacs-lisp|init-flycheck ()
     "Initialize flycheck-mode if not in emacs.d."
     (when (and buffer-file-name
-               (not (file-in-directory-p buffer-file-name doom-emacs-dir)))
+               (and (not (file-in-directory-p buffer-file-name doom-emacs-dir))
+                    (if (featurep! :config private)
+                        (not (file-in-directory-p buffer-file-name +private-config-path))
+                      't)))
       (flycheck-mode +1))))
 
 


### PR DESCRIPTION
With the addition of +private-config-path we've moved our elisp outside of doom-emacs-dir and flycheck gets turned on for these files. This change keeps flycheck behavior consistent. I'm not sure if this is the best way to do it, though. I'm still learning elisp.
