### PR TITLE
feature/evil: add org-agenda-mode to evil-snipe-disabled-modes

### DIFF
--- a/modules/feature/evil/config.el
+++ b/modules/feature/evil/config.el
@@ -319,7 +319,7 @@ the new algorithm is confusing, like in python or ruby."
         evil-snipe-scope 'line
         evil-snipe-repeat-scope 'visible
         evil-snipe-char-fold t
-        evil-snipe-disabled-modes '(magit-mode elfeed-show-mode elfeed-search-mode)
+        evil-snipe-disabled-modes '(org-agenda-mode magit-mode elfeed-show-mode elfeed-search-mode)
         evil-snipe-aliases '((?\[ "[[{(]")
                              (?\] "[]})]")
                              (?\; "[;:]")))


### PR DESCRIPTION
Before this commit, pressing `t` in org-agenda buffer resulted in activation of evil-snipe instead of setting todo state as how it is intended by [evil-org](https://github.com/Somelauw/evil-org-mode/tree/491b0b302b95d44ceb73d291dedbb9d5517ccee2#agenda)

(If this was on purpose and Doom has some custom way for setting todo states from org-agenda buffers I am not aware, I apology for pointless pull request)