### PR TITLE
Fix evil-collection support

### DIFF
--- a/modules/feature/evil/config.el
+++ b/modules/feature/evil/config.el
@@ -23,10 +23,11 @@
 
 (def-package! evil-collection
   :when (featurep! +everywhere)
-  :after evil
+  :after (company evil)
   :preface
   (setq evil-want-integration nil) ; must be set before evil is loaded
   :config
+  (require 'company-tng)
   (evil-collection-init)
   ;; don't interfere with leader key
   (map! :after compile :map compilation-mode-map doom-leader-key nil)


### PR DESCRIPTION
Just tried out `(evil +everywhere)`, it doesn't load because it depends upon `company-tng`. This fixes it, dunno if you have any more specific requirements for PRs tho, sorry if this isn't good enough.