### PR TITLE
Fix magic require of clojure.string

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -15,7 +15,7 @@
   (nconc cljr-magic-require-namespaces
          '(("re-frame" . "re-frame.core")
            ("reagent"  . "reagent.core")
-           ("str"      . "clojure.str"))))
+           ("str"      . "clojure.string"))))
 
 
 (def-package! cider


### PR DESCRIPTION
Quick change that I've been running locally as the namespace is [`clojure.string`](https://clojure.github.io/clojure/clojure.string-api.html) as opposed to `clojure.str`.

My full list right now looks like this:

``` emacs-lisp
(nconc cljr-magic-require-namespaces
       '(("async" . "clojure.core.async")
         ("byte-streams" . "byte-streams")
         ("cache" . "clojure.core.cache")
         ("cli" . "clojure.tools.cli")
         ("codec" . "ring.util.codec")
         ("component" . "com.stuartsierra.component")
         ("d" . "datomic.api")
         ("data" . "clojure.data")
         ("deferred" . "manifold.deferred")
         ("gen" . "clojure.test.check.generators")
         ("jmx" . "clojure.java.jmx")
         ("json" . "cheshire.core")
         ("medley" . "medley.core")
         ("prop" . "clojure.test.check.properties")
         ("r" . "clojure.core.reducers")
         ("random" . "crypto.random")
         ("s" . "clojure.spec.alpha")
         ("sgen" . "clojure.spec.gen.alpha")))
```

I think some of the above is entirely subjective however and wonder where you draw the line on good defaults for all/what belongs in a private configuration…

Thanks for Doom BTW. It's super quick and has been very nice to work/play with.