### PR TITLE
Add edn to Clojure mode extensions

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -3,6 +3,7 @@
 (def-package! clojure-mode
   :mode "\\.clj$"
   :mode "\\.edn$"
+  :mode "\\(?:build\\|profile\\)\\.boot$"
   :mode ("\\.cljs$" . clojurescript-mode)
   :mode ("\\.cljc$" . clojurec-mode)
   :config

--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -2,6 +2,7 @@
 
 (def-package! clojure-mode
   :mode "\\.clj$"
+  :mode "\\.edn$"
   :mode ("\\.cljs$" . clojurescript-mode)
   :mode ("\\.cljc$" . clojurec-mode)
   :config


### PR DESCRIPTION
When opening an EDN file in Emacs I noticed Clojure code wasn't automatically applied. I think this is because the mode is deferred and Doom doesn't tell Emacs that `.edn` files belong to Clojure.

Fingers crossed I've fixed this in an idiomatic way!