### PR TITLE
Update webpack file template for latest version

### DIFF
--- a/modules/feature/file-templates/templates/js-mode/__webpack.config.js
+++ b/modules/feature/file-templates/templates/js-mode/__webpack.config.js
@@ -7,9 +7,15 @@ module.exports = {
         filename: "app.bundle.js"
     },
     module: {
-        loaders: [
-            { test: /\.js$/, include: __dirname + '/app', loader: 'babel-loader' }$0
+        rules: [
+            {
+              test: /\.js$/,
+              exclude: /node_modules/,
+              use: {
+                  loader: "babel-loader"
+              }
+            }
         ]
-    }
+  },
     // plugins: []
 };


### PR DESCRIPTION
Webpack 4 has some syntax changes, mainly using `rules` key instead of `loaders`.