### PR TITLE
Update password-store +auth to only use auth-source-pass

### DIFF
--- a/modules/tools/password-store/autoload.el
+++ b/modules/tools/password-store/autoload.el
@@ -12,9 +12,7 @@
 
 ;;;###autoload
 (defalias '+pass--get-entry
-  (if (featurep 'auth-store-pass)
-      #'auth-source-pass-parse-entry
-    #'auth-pass-parse-entry))
+  #'auth-source-pass-parse-entry)
 
 ;;;###autoload
 (defun +pass-get-field (entry fields)

--- a/modules/tools/password-store/config.el
+++ b/modules/tools/password-store/config.el
@@ -36,8 +36,6 @@
 
 
 ;; Is built into Emacs 26+
-(when (featurep! +auth)
-  (if (require 'auth-store-pass nil t)
-      (auth-source-pass-enable)
-    (def-package! auth-source-store
-      :config (auth-source-pass-enable))))
+(def-package! auth-source-pass
+  :when (featurep! +auth)
+  :config (auth-source-pass-enable))

--- a/modules/tools/password-store/packages.el
+++ b/modules/tools/password-store/packages.el
@@ -3,7 +3,9 @@
 
 (package! pass)
 (package! password-store)
-(package! auth-source-pass)
+
+(when (featurep! +auth)
+  (package! auth-source-pass))
 
 (when (featurep! :completion helm)
   (package! helm-pass))


### PR DESCRIPTION
Now that auth-password-store has been renamed to auth-source-pass and it matches
the name and functionality of the feature included in emacs 26 I've removed the conditional loading and use of different packages. 

I was getting an error on emacs load because `auth-source-store` wasn't loaded (and couldn't because the name is incorrect) but was defined with `def-package!`. There were several incorrect variations of the correct package names (e.g. `auth-store-pass`, `auth-source-store`) causing problems. Now that `auth-source-pass` works for both emacs 25 & 26 life should be better.

I updated auth-source-pass to only be installed when the +auth flag is set. I also moved the condition into the :when of the !def-package. If there is any reason to leave it as it was I'd appreciate any education you're willing to provide.

NOTE: I accidentally used incorrect variations of auth-password-store and auth-source-pass more than once working on this so I'm damn happy the package was renamed and updated to match emacs 26. I have to guess a lot of people are 😄 (see:  https://github.com/DamienCassou/auth-password-store/commit/e8d8733b1af67e4ea088d1ed015c554171feecb9#r23381057)