### PR TITLE
Add language support for Erlang

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -93,6 +93,7 @@
        clojure           ; java with a lisp
        csharp            ; unity, .NET, and mono shenanigans
        data              ; config/data formats
+      ;erlang            ; an elegant language for a more civilized age
        elixir            ; erlang done right
        elm               ; care for a cup of TEA?
        emacs-lisp        ; drown in parentheses

--- a/modules/lang/erlang/config.el
+++ b/modules/lang/erlang/config.el
@@ -1,0 +1,29 @@
+;;; private/erlang/config.el -*- lexical-binding: t; -*-
+
+(def-package! erlang
+  ;; customizations
+  :mode "\\.erlang$"
+  ;; rebar files
+  :mode "/rebar\\.config\\(?:\\.script\\)?$"
+  ;; erlang configs
+  :mode "/\\(?:app\\|sys\\)\\.config$")
+
+(def-package! flycheck-rebar3
+  :when (featurep! :feature syntax-checker)
+  :after erlang
+  :config
+  (flycheck-rebar3-setup))
+
+;; Completion via Ivy
+(def-package! ivy-erlang-complete
+  :when (featurep! :completion ivy)
+  :hook (erlang-mode . ivy-erlang-complete-init)
+  :config
+  (add-hook! 'erlang-mode-hook
+    (add-hook 'after-save-hook #'ivy-erlang-complete-reparse nil t)))
+
+
+;; Completion via Company
+(def-package! company-erlang
+  :when (featurep! :completion company)
+  :hook (erlang-mode . company-erlang-init))

--- a/modules/lang/erlang/packages.el
+++ b/modules/lang/erlang/packages.el
@@ -1,0 +1,13 @@
+;; -*- no-byte-compile: t; -*-
+;;; private/erlang/packages.el
+
+(package! erlang)
+
+(when (featurep! :feature syntax-checker)
+  (package! flycheck-rebar3))
+
+(when (featurep! :completion ivy)
+  (package! ivy-erlang-complete))
+
+(when (featurep! :completion company)
+  (package! company-erlang))


### PR DESCRIPTION
Since Elixir is supported out of the box, it seems unfair to leave out Erlang :). I'm still relatively new to working with elisp, so let me know if I could be doing things differently. I added some customizations which add some additional support for rebar3 and some common Erlang files (e.g. `sys.config`). I think there is probably room here to expand this to maybe provide EDTS/Wrangler or something along those lines, but I wanted to start simple - this module is basically what I built for myself so far.