### PR TITLE
Cut: ui/posframe: don't set ivy-posframe-font

### DIFF
--- a/modules/ui/posframe/config.el
+++ b/modules/ui/posframe/config.el
@@ -51,11 +51,6 @@
         ivy-fixed-height-minibuffer nil
         ivy-posframe-parameters `((min-width . 90)
                                   (min-height . ,ivy-height)
-                                  (internal-border-width . 10)))
-  (when (and (not ivy-posframe-font) doom-font)
-    (setq ivy-posframe-font
-          (font-spec :family (font-get doom-font :family)
-                     :size 18))))
-
+                                  (internal-border-width . 10))))
 
 ;; TODO helm-posframe?


### PR DESCRIPTION
Do not assume the :size is 18.

That confused me for a bit because I use 20 and was wondering why posframe child frames didn't fit right in with the rest of my Emacs.

I think this is a more reasonable default.