### PR TITLE
Fix helm bug caused by old evil-collection

### DIFF
--- a/modules/completion/helm/config.el
+++ b/modules/completion/helm/config.el
@@ -62,7 +62,7 @@
 
   (defun +helm*hide-minibuffer-maybe ()
     "Hide minibuffer in Helm session if we use the header line as input field."
-    (when (buffer-local-value 'helm-echo-input-in-header-line (helm-buffer-get))
+    (when (with-helm-buffer helm-echo-input-in-header-line)
       (let ((ov (make-overlay (point-min) (point-max) nil nil t)))
         (overlay-put ov 'window (selected-window))
         (overlay-put ov 'face

--- a/modules/feature/evil/packages.el
+++ b/modules/feature/evil/packages.el
@@ -4,7 +4,7 @@
 (package! evil)
 (package! evil-args)
 (package! evil-commentary)
-(package! evil-collection)
+(package! evil-collection :recipe (:fetcher github :repo "emacs-evil/evil-collection"))
 (package! evil-easymotion)
 (package! evil-embrace)
 (package! evil-escape)


### PR DESCRIPTION
Issue #503 is caused by a bug in evil-collection regarding 3rd party macros (described here: https://github.com/emacs-evil/evil-collection/issues/101). It is fixed in upstream but not on elpa (yet?). This pull request gets evil-collection from github and reverts the change to the helm module which was unnecessary. I suggest this change is reverted as soon as the bug fix in evil-collection makes it's way to elpa. It would also probably be advantageous to only pull from github if helm is enabled and otherwise from elpa but I do not know how to accomplish that.
