### PR TITLE
Fix "z o".

### DIFF
--- a/modules/feature/evil/autoload/folds.el
+++ b/modules/feature/evil/autoload/folds.el
@@ -52,7 +52,7 @@
   (interactive)
   (if (+evil--vimish-fold-p)
       (vimish-fold-unfold)
-    (+evil-from-eol (hs-hide-block))))
+    (+evil-from-eol (hs-show-block))))
 
 ;;;###autoload (autoload '+evil:fold-close "feature/evil/autoload/folds" nil t)
 (evil-define-command +evil:fold-close ()


### PR DESCRIPTION
PS: "d %" never works. Disabling evil-matchit fixes that.