### PR TITLE
Fix: app/email: only add unique contexts

### DIFF
--- a/modules/app/email/config.el
+++ b/modules/app/email/config.el
@@ -38,7 +38,8 @@ default/fallback account."
                            (string-prefix-p (format "/%s" ,label)
                                             (mu4e-message-field msg :maildir))))
                        :vars ,letvars)))
-         (push context mu4e-contexts)
+         (unless (seq-contains (seq-map #'mu4e-context-name mu4e-contexts) ,label)
+           (push context mu4e-contexts))
          ,(when default-p
             `(setq-default mu4e-context-current context))))))
 


### PR DESCRIPTION
for some reasons the settings are being invoked several times which causes the context to be duplicated in the context switcher.

The bug did not affect functionality.