### PR TITLE
Don't use HTTPS when INSECURE variable is set

### DIFF
--- a/core/core-packages.el
+++ b/core/core-packages.el
@@ -96,9 +96,13 @@ missing) and shouldn't be deleted.")
       package-user-dir (expand-file-name "elpa" doom-packages-dir)
       package-enable-at-startup nil
       package-archives
-      '(("gnu"   . "https://elpa.gnu.org/packages/")
-        ("melpa" . "https://melpa.org/packages/")
-        ("org"   . "https://orgmode.org/elpa/"))
+      (if (getenv "INSECURE")
+          '(("gnu"   . "http://elpa.gnu.org/packages/")
+            ("melpa" . "http://melpa.org/packages/")
+            ("org"   . "http://orgmode.org/elpa/"))
+        '(("gnu"   . "https://elpa.gnu.org/packages/")
+          ("melpa" . "https://melpa.org/packages/")
+          ("org"   . "https://orgmode.org/elpa/")))
       ;; I omit Marmalade because its packages are manually submitted rather
       ;; than pulled, so packages are often out of date with upstream.
 


### PR DESCRIPTION
When working with a proxy or other insecure environment, the environment variable `INSECURE` will prevent TLS certificate check, but Doom still tries to use HTTPS repo's for packages. This prevents users without HTTPS from installing Doom. We can fix this by checking for this variable and using the the HTTP versions for `package-archives`.
