### PR TITLE
Add missing buffer name to kill confirmation

### DIFF
--- a/core/core-ui.el
+++ b/core/core-ui.el
@@ -597,7 +597,8 @@ windows, switch to `doom-fallback-buffer'. Otherwise, delegate to original
           ((doom-real-buffer-p buf)
            (if (and buffer-file-name
                     (buffer-modified-p buf)
-                    (not (y-or-n-p "Buffer %s is modified; kill anyway?")))
+                    (not (y-or-n-p
+                          (format "Buffer %s is modified; kill anyway?" buf))))
                (message "Aborted")
              (set-buffer-modified-p nil)
              (when (or ;; if there aren't more real buffers than visible buffers,


### PR DESCRIPTION
I see "Buffer %s is modified; kill anyway?" quite often. Looks like `buf` is missing from the call to `y-or-n-p`.