### PR TITLE
enable which-key's evil support

### DIFF
--- a/core/core-keybinds.el
+++ b/core/core-keybinds.el
@@ -52,7 +52,9 @@ If any hook returns non-nil, all hooks after it are ignored.")
         which-key-add-column-padding 1
         which-key-max-display-columns nil
         which-key-min-display-lines 5
-        which-key-side-window-slot -10)
+        which-key-side-window-slot -10
+        which-key-allow-evil-operators t
+        which-key-show-operator-state-maps t)
   ;; embolden local bindings
   (set-face-attribute 'which-key-local-map-description-face nil :weight 'bold)
   (which-key-setup-side-window-bottom)


### PR DESCRIPTION
Note: which-key says `which-key-show-operator-state-maps` is hacky, but imo it should be enabled anyways