### PR TITLE
[*] Removes tern in favor of tide, adds local node modules to path

### DIFF
--- a/modules/lang/javascript/autoload.el
+++ b/modules/lang/javascript/autoload.el
@@ -74,3 +74,31 @@ Run this for any buffer you want to skewer."
       (if skewer-css-mode (skewer-css-mode -1))
       (if skewer-html-mode (skewer-html-mode -1)))))
 
+;;;###autoload
+(defun add-node-modules-path ()
+  "Search the current buffer's parent directories for `node_modules/.bin`.
+If it's found, then add it to the `exec-path'."
+(defvar add-node-modules-path-debug nil)
+  (interactive)
+  (let* ((root (locate-dominating-file
+                (or (buffer-file-name) default-directory)
+                "node_modules"))
+         (path (and root
+                    (expand-file-name "node_modules/.bin/" root))))
+    (if root
+        (progn
+          (make-local-variable 'exec-path)
+          (add-to-list 'exec-path path)
+          (when add-node-modules-path-debug
+            (message (concat "added " path  " to exec-path"))))
+      (when add-node-modules-path-debug
+        (message (concat "node_modules not found in " root))))))
+
+;;;###autoload
+(defun set-up-tide-mode ()
+  (interactive)
+  (tide-setup)
+  (if company-mode (push 'company-tide company-backends))
+  (eldoc-mode +1)
+  (tide-hl-identifier-mode +1)
+  )

--- a/modules/lang/javascript/config.el
+++ b/modules/lang/javascript/config.el
@@ -11,7 +11,7 @@
         js2-mode-show-parse-errors nil
         js2-mode-show-strict-warnings nil)
 
-  (add-hook! 'js2-mode-hook #'(flycheck-mode rainbow-delimiters-mode))
+  (add-hook! 'js2-mode-hook #'(flycheck-mode set-up-tide-mode add-node-modules-path rainbow-delimiters-mode))
 
   (set! :repl 'js2-mode #'+javascript/repl)
   (set! :electric 'js2-mode :chars '(?\} ?\) ?.))
@@ -95,20 +95,6 @@
       ("Reformat buffer (eslint_d)"      :exec eslintd-fix :region nil :when (fboundp 'eslintd-fix)))
     :prompt "Refactor: "))
 
-
-(def-package! tern
-  :hook (js2-mode . tern-mode)
-  :config
-  (advice-add #'tern-project-dir :override #'doom-project-root))
-
-
-(def-package! company-tern
-  :when (featurep! :completion company)
-  :after tern
-  :config
-  (set! :company-backend 'js2-mode '(company-tern)))
-
-
 (def-package! rjsx-mode
   :commands rjsx-mode
   :mode "\\.jsx$"
@@ -132,6 +118,8 @@
         "<" nil
         "C-d" nil)
   (add-hook! rjsx-mode
+
+    #'(flycheck-mode set-up-tide-mode add-node-modules-path rainbow-delimiters-mode)
     ;; jshint doesn't really know how to deal with jsx
     (push 'javascript-jshint flycheck-disabled-checkers)))
 

--- a/modules/lang/javascript/packages.el
+++ b/modules/lang/javascript/packages.el
@@ -8,13 +8,13 @@
 (package! js2-refactor)
 (package! rjsx-mode)
 (package! nodejs-repl)
-(package! tern)
 (package! web-beautify)
+(package! tide)
 (package! skewer-mode)
 (package! eslintd-fix)
 
 (when (featurep! :completion company)
-  (package! company-tern))
+  (package! company-tide))
 
 (when (featurep! :feature lookup)
   (package! xref-js2))


### PR DESCRIPTION
Tide provides much better support for code intel and completion and it is actively maintained unlike tern. Tide also does not require users to install outside dependencies such as the tern javascript package in order for it to work. Adding the local node_modules to the emacs exec path allows for users to then use the project versions of flow, prettier, jest, eslint, etc.