### PR TITLE
doom/sudo-find-file work on remote files

### DIFF
--- a/core/autoload/files.el
+++ b/core/autoload/files.el
@@ -7,7 +7,9 @@
    (list (read-file-name "Open as root: ")))
   (find-file (if (file-writable-p file)
                  file
-               (concat "/sudo:root@localhost:" file))))
+               (if (file-remote-p file)
+                   (concat "/" (file-remote-p file 'method) ":" (file-remote-p file 'user) "@" (file-remote-p file 'host)  "|sudo:root@" (file-remote-p file 'host) ":" (file-remote-p file 'localname))
+                 (concat "/sudo:root@localhost:" file)))))
 
 ;;;###autoload
 (defun doom/sudo-this-file ()


### PR DESCRIPTION
This allows remote files to be used with TRAMP's multi-hop syntax. The changes also allow `doom/sudo-this-file` to work on remote files, which is really nice when you are doing sysadmin stuff on remote servers.