### PR TITLE
fix(lang/javascript): add flycheck-mode to typescript-mode hooks

### DIFF
--- a/modules/lang/javascript/config.el
+++ b/modules/lang/javascript/config.el
@@ -37,7 +37,7 @@
 (def-package! typescript-mode
   :mode "\\.ts$"
   :config
-  (add-hook 'typescript-mode-hook #'rainbow-delimiters-mode)
+  (add-hook! 'typescript-mode-hook #'(flycheck-mode rainbow-delimiters-mode))
   (set! :electric 'typescript-mode :chars '(?\} ?\)) :words '("||" "&&")))
 
 


### PR DESCRIPTION
Add flycheck-mode to typescript. The hook has been probably lost in the last refactor of the javascript module.
