### PR TITLE
Basic support for Nim

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -83,6 +83,7 @@
        ledger            ; an accounting system in Emacs
        lua               ; one-based indices? one-based indices
        markdown          ; writing docs for people to ignore
+       nim               ; python+list at the speed of c
        nix               ; I hereby declare "nix geht mehr!"
        ocaml             ; an objective camel
        (org              ; organize your plain life in plain text

--- a/init.example.el
+++ b/init.example.el
@@ -83,7 +83,7 @@
        ledger            ; an accounting system in Emacs
        lua               ; one-based indices? one-based indices
        markdown          ; writing docs for people to ignore
-       nim               ; python+list at the speed of c
+       nim               ; python + lisp at the speed of c
        nix               ; I hereby declare "nix geht mehr!"
        ocaml             ; an objective camel
        (org              ; organize your plain life in plain text

--- a/modules/lang/nim/README.org
+++ b/modules/lang/nim/README.org
@@ -1,0 +1,42 @@
+#+TITLE: :lang Nim
+
+#+begin_quote
+This module is a work in progress.
+#+end_quote
+
+This module adds [[https://nim-lang.org][Nim]] support to Emacs.
+
++ Code completion (~nimsuggest+company~)
++ Syntax checking (~nimsugges+flycheck~)
++ Babel support (~ob-nim~)
+#+begin_quote
+...
+#+end_quote
+
+* Table of Contents :TOC:
+- [[Install][Install]]
+  - [[Nim][Nim]]
+
+* Install
+** Nim
+To get started with Nim, you can either use =choosenim= and install nim with:
+
+~curl https://nim-lang.org/choosenim/init.sh -sSf | sh~
+
+Or through your package manager:
+
+*** MacOS
+#+BEGIN_SRC sh :tangle (if (doom-system-os 'macos) "yes")
+brew install nim
+#+END_SRC
+
+*** 
+*** Arch Linux
+#+BEGIN_SRC sh :dir /sudo:: :tangle (if (doom-system-os 'arch) "yes")
+sudo pacman --needed --noconfirm -S nim
+#+END_SRC
+
+*** Arch Linux
+#+BEGIN_SRC sh :dir /sudo:: :tangle (if (doom-system-os 'arch) "yes")
+sudo pacman --needed --noconfirm -S nim
+#+END_SRC

--- a/modules/lang/nim/README.org
+++ b/modules/lang/nim/README.org
@@ -30,13 +30,8 @@ Or through your package manager:
 brew install nim
 #+END_SRC
 
-*** 
 *** Arch Linux
 #+BEGIN_SRC sh :dir /sudo:: :tangle (if (doom-system-os 'arch) "yes")
 sudo pacman --needed --noconfirm -S nim
 #+END_SRC
 
-*** Arch Linux
-#+BEGIN_SRC sh :dir /sudo:: :tangle (if (doom-system-os 'arch) "yes")
-sudo pacman --needed --noconfirm -S nim
-#+END_SRC

--- a/modules/lang/nim/config.el
+++ b/modules/lang/nim/config.el
@@ -1,0 +1,23 @@
+;;; lang/nim/config.el -*- lexical-binding: t; -*-
+
+(def-package! nim-mode
+  :init
+  (add-hook 'nim-mode-hook #'nimsuggest-mode))
+
+(def-package! flycheck-nim
+  :when (featurep! :feature syntax-checker)
+  :after nim-mode
+  :config
+  (add-hook 'nimsuggest-mode-hook #'flycheck-mode)
+
+  (map! :map nim-mode-map
+        :localleader
+        :n "b" #'+nim/build-menu)
+
+  (def-menu! +nim/build-menu
+    "Building commands for `nim-mode' buffers."
+    '(("Build & run" :exec nim-compile))
+    :prompt "Build"))
+
+(when (featurep! :completion company)
+  (add-hook 'nimsuggest-mode-hook #'company-mode))

--- a/modules/lang/nim/packages.el
+++ b/modules/lang/nim/packages.el
@@ -1,0 +1,9 @@
+;; -*- no-byte-compile: t; -*-
+;;; lang/nim/packages.el
+
+;;; requires nim nimsuggest nimble
+
+(package! nim-mode)
+
+(when (featurep! :feature syntax-checker)
+  (package! flycheck-nim))

--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -18,6 +18,8 @@
   (package! ob-sql-mode)
   (package! ob-translate)
 
+  (when (featurep! :lang nim)
+    (package! ob-nim))
   (when (featurep! :lang crystal)
     (package! ob-crystal))
   (when (featurep! :lang go)


### PR DESCRIPTION
Add basic support for the [nim](nim-lang.org) programming language.

Adds:

- `<localleader>` Build menu
- Syntax checking and highlighting (`nim-mode`)
- Code completion (`nim-mode`)
- Org babel support (`ob-nim`)