### PR TITLE
Add modules: Window-Zoom and Dimmer

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -30,6 +30,7 @@
         +childframe)     ; uses childframes for popups (Emacs 26+ only)
 
        :ui
+       dimmer            ; interactively highlight which buffer is active by dimming the others
        doom              ; what makes DOOM look the way it does
        doom-dashboard    ; a nifty splash screen for Emacs
        doom-modeline     ; a snazzy Atom-inspired mode-line
@@ -41,6 +42,7 @@
       ;unicode           ; extended unicode support for various languages
        vi-tilde-fringe   ; fringe tildes to mark beyond EOB
        window-select     ; visually switch windows
+       window-zoom       ; automatically resize windows
 
        :tools
        dired             ; making dired pretty [functional]

--- a/modules/ui/dimmer/README.org
+++ b/modules/ui/dimmer/README.org
@@ -1,0 +1,13 @@
+#+TITLE: :ui dimmer
+
+This module uses ~Dimmer~ to darken windows that are not focused.
+
+* Table of Contents :TOC:
+- [[Configure][Configure]]
+
+* Configure
+By default, dimmer is activated on startup. If you wish to manually use this functionality you can deactivate dimmer-mode by calling:
+#+BEGIN_SRC emacs-lisp
+(dimmer-mode -1)
+#+END_SRC
+

--- a/modules/ui/dimmer/config.el
+++ b/modules/ui/dimmer/config.el
@@ -1,0 +1,9 @@
+;;; ui/dimmer/config.el -*- lexical-binding: t; -*-
+
+(def-package! dimmer
+  :config
+  (setq dimmer-exclusion-regexp "\*"
+        dimmer-fraction 0.50)
+  (dimmer-mode 1)
+  (remove-hook 'focus-in-hook 'dimmer-config-change-hook)
+  (remove-hook 'focus-out-hook 'dimmer-dim-all))

--- a/modules/ui/dimmer/packages.el
+++ b/modules/ui/dimmer/packages.el
@@ -1,0 +1,4 @@
+;; -*- no-byte-compile: t; -*-
+;;; ui/dimmer/packages.el
+
+(package! dimmer)

--- a/modules/ui/window-zoom/README.org
+++ b/modules/ui/window-zoom/README.org
@@ -1,0 +1,9 @@
+#+TITLE: :ui window-zoom
+
+This module uses ~zoom~ or ~golden-ratio~ to automatically resize windows.
+
+* Table of Contents :TOC:
+- [[Configure][Configure]]
+
+* Configure
+By default, ~golden-ratio~ will be enabled. If you dislike this package and would prefer ~zoom~, then you can add +zoom. ~Zoom~ appears to me more refined, but there is a bug reported here https://debbugs.gnu.org/cgi/bugreport.cgi?bug=31312 affecting doom-emacs that might persuade you to use golden-ratio if you are not using the latest Emacs build.

--- a/modules/ui/window-zoom/config.el
+++ b/modules/ui/window-zoom/config.el
@@ -1,0 +1,39 @@
+;;; ui/window-zoom/config.el -*- lexical-binding: t; -*-
+
+;; FIXME zoom breaks with doom's popup system
+(def-package! zoom
+  :when (featurep! +zoom)
+  :config
+  (setq zoom-ignored-buffer-name-regexps '("\*")
+        zoom-size '(0.618 . 0.618)
+        zoom-ignored-major-modes '(+popup-mode))
+  (zoom-mode 1))
+
+(def-package! golden-ratio
+  :unless (featurep! +zoom)
+  :config
+  (setq golden-ratio-auto-scale t
+        golden-ratio-exclude-buffer-regexp '("\*")
+        ;; golden ratio needs to know evil windows exists
+        golden-ratio-extra-commands
+        (append golden-ratio-extra-commands
+                '(evil-window-left
+                  evil-window-right
+                  evil-window-up
+                  evil-window-down
+                  buf-move-left
+                  buf-move-right
+                  buf-move-up
+                  buf-move-down
+                  window-number-select
+                  select-window
+                  select-window-1
+                  select-window-2
+                  select-window-3
+                  select-window-4
+                  select-window-5
+                  select-window-6
+                  select-window-7
+                  select-window-8
+                  select-window-9)))
+  (golden-ratio-mode 1))

--- a/modules/ui/window-zoom/packages.el
+++ b/modules/ui/window-zoom/packages.el
@@ -1,0 +1,10 @@
+;; -*- no-byte-compile: t; -*-
+;;; ui/window-zoom/packages.el
+
+(cond ((featurep! +zoom)
+       ;; Install zoom if the user indicated the '+zoom' module flag
+       (package! zoom))
+      ((or (featurep! +golden-ratio) t)
+       ;; Install golden-ratio if the user selects the flag '+golden-ratio' or by default
+       ;; ... if the user did not specify a module flag
+       (package! golden-ratio)))


### PR DESCRIPTION
Modules Window-Zoom and Dimmer have been added to the ui section. Window-Zoom enables automatic window resizing through golden-ratio and Dimmer allows for dimming unfocused windows.