### PR TITLE
Fix typo causing startup error in helm module

### DIFF
--- a/modules/completion/helm/config.el
+++ b/modules/completion/helm/config.el
@@ -15,7 +15,7 @@
   :config
   (helm-mode +1)
   ;; helm is too heavy for find-file-at-point
-  (map-put helm-completing-read-handlers-alist 'find-file-at-point nilk))
+  (map-put helm-completing-read-handlers-alist 'find-file-at-point nil))
 
 
 (def-package! helm


### PR DESCRIPTION
It looks like an extra letter snuck into a `nil` in 67dab98. This is causing a
startup error on develop.
