### PR TITLE
Add rspec-mode to ruby-mode hook

### DIFF
--- a/modules/lang/ruby/config.el
+++ b/modules/lang/ruby/config.el
@@ -75,6 +75,7 @@ environment variables."
 
 (def-package! rspec-mode
   :mode ("/\\.rspec$" . text-mode)
+  :hook ruby-mode
   :init
   (associate! rspec-mode :match "/\\.rspec$")
   (associate! rspec-mode :modes (ruby-mode yaml-mode) :files ("/spec/"))


### PR DESCRIPTION
Turns out, rspec mode wasnt being loaded because there wasnt anything in the
def-package! call that would initialize it. Its pretty common to add rspec mode
to the ruby-mode hook, and use-package makes this a simple one-liner in the
definition.
