### PR TITLE
Allow for evil-org todo feature set

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -90,6 +90,7 @@
        (org              ; organize your plain life in plain text
         +attach          ; custom attachment system
         +babel           ; running code in org
+       ;+evil-org-todo   ; `t d' and done
         +capture         ; org-capture in and outside of Emacs
         +export          ; Exporting org to whatever you want
         +present         ; Emacs for presentations

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -29,7 +29,10 @@
   :hook (org-load . evil-org-set-key-theme)
   :init
   (setq evil-org-key-theme '(navigation insert textobjects))
-  (add-hook 'org-load-hook #'+org|setup-evil))
+  (add-hook 'org-load-hook #'+org|setup-evil)
+  :config
+  (if (featurep! +evil-org-todo)
+      (evil-org--populate-todo-bindings)))
 
 (def-package! evil-org-agenda
   :after org-agenda


### PR DESCRIPTION
If enabled adds the following keys to the normal mode in org:

-  `t`  :: `org-todo`
-  `T`  :: `org-insert-todo-heading`
- `M-t` :: `org-insert-todo-subheading`

This is useful if you want to quickly toggle TODO --> DONE. It is just `t d`
instead of `C-x C-t d`.

See https://github.com/Somelauw/evil-org-mode/blob/master/doc/keythemes.org#todo
