### PR TITLE
delete unused find-in-snippets menu item

### DIFF
--- a/modules/config/default/+bindings.el
+++ b/modules/config/default/+bindings.el
@@ -298,8 +298,7 @@
         (:desc "snippets" :prefix "s"
           :desc "New snippet"            :n  "n" #'yas-new-snippet
           :desc "Insert snippet"         :nv "i" #'yas-insert-snippet
-          :desc "Find snippet for mode"  :n  "s" #'yas-visit-snippet-file
-          :desc "Find snippet"           :n  "S" #'+default/find-in-snippets)
+          :desc "Find snippet for mode"  :n  "s" #'yas-visit-snippet-file)
 
         (:desc "toggle" :prefix "t"
           :desc "Flyspell"               :n "s" #'flyspell-mode


### PR DESCRIPTION
find in snippets seems to be replaced by 'browse snippets' or  it lack of corresponding function.
