### PR TITLE
Small fixes for go-mode

### DIFF
--- a/modules/lang/go/config.el
+++ b/modules/lang/go/config.el
@@ -15,11 +15,11 @@
   (when-let* ((goimports (executable-find "goimports")))
     (setq gofmt-command goimports))
 
-  (setq gofmt-show-errors nil) ; Leave it to flycheck
-  (if (featurep! :feature syntax-checker)
-      (add-hook! 'go-mode-hook #'flycheck-mode))
+  (when (featurep! :feature syntax-checker)
+    (setq gofmt-show-errors nil) ; Leave it to flycheck
+    (add-hook 'go-mode-hook #'flycheck-mode))
 
-  (add-hook! 'go-mode-hook #'go-eldoc-setup)
+  (add-hook 'go-mode-hook #'go-eldoc-setup)
   (add-hook! go-mode
     (add-hook 'before-save-hook #'gofmt-before-save nil t))
 

--- a/modules/lang/go/config.el
+++ b/modules/lang/go/config.el
@@ -16,8 +16,10 @@
     (setq gofmt-command goimports))
 
   (setq gofmt-show-errors nil) ; Leave it to flycheck
+  (if (featurep! :feature syntax-checker)
+      (add-hook! 'go-mode-hook #'flycheck-mode))
 
-  (add-hook! 'go-mode-hook #'(flycheck-mode go-eldoc-setup))
+  (add-hook! 'go-mode-hook #'go-eldoc-setup)
   (add-hook! go-mode
     (add-hook 'before-save-hook #'gofmt-before-save nil t))
 

--- a/modules/lang/go/doctor.el
+++ b/modules/lang/go/doctor.el
@@ -9,5 +9,5 @@
 
 (when (featurep! :completion company)
   (require 'company-go)
-  (unless (executable-find command-go-gocode-command)
+  (unless (executable-find company-go-gocode-command)
     (warn! "Couldn't find gocode. Code completion won't work")))


### PR DESCRIPTION
- Fixed typo for gocode command in `doctor.el`
- Only enable flycheck mode if the syntax-checker feature is enabled
