### PR TITLE
Fix typo in OCaml module.

### DIFF
--- a/modules/lang/ocaml/config.el
+++ b/modules/lang/ocaml/config.el
@@ -8,6 +8,6 @@
   :after tuareg
   :hook (tuareg-mode . merlin-mode)
   :config
-  (set! :company-backend 'tuareg-mode 'merlin-compand-backend)
+  (set! :company-backend 'tuareg-mode 'merlin-company-backend)
   (after! company
-    (remove-hook 'company-backends 'merlin-compand-backend)))
+    (remove-hook 'company-backends 'merlin-company-backend)))


### PR DESCRIPTION
Just a typo in config (although it seems working fine on my machine).