### PR TITLE
add :ui/vinegar support

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -41,6 +41,7 @@
       ;tabbar            ; FIXME an (incomplete) tab bar for Emacs
       ;unicode           ; extended unicode support for various languages
        vi-tilde-fringe   ; fringe tildes to mark beyond EOB
+      ;vinegar           ; the salad dressing of file browsers
        window-select     ; visually switch windows
 
        :emacs

--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -2,6 +2,7 @@
 
 (def-package! dired
   :defer t
+  :commands (dired-jump)
   :init
   (setq ;; Always copy/delete recursively
         dired-recursive-copies  'always

--- a/modules/ui/vinegar/config.el
+++ b/modules/ui/vinegar/config.el
@@ -1,0 +1,14 @@
+;;; ui/vinegar/config.el -*- lexical-binding: t; -*-
+
+(defun +vinegar|dired-setup ()
+  "Setup custom dired settings for vinegar"
+  (setq dired-omit-verbose nil)
+  (setq dired-hide-details-hide-symlink-targets nil)
+  (make-local-variable 'dired-hide-symlink-targets)
+  (dired-hide-details-mode t))
+
+(after! dired
+  :config
+  (add-hook 'dired-mode-hook '+vinegar|dired-setup))
+
+(map! :n "-" 'dired-jump)


### PR DESCRIPTION
Adds a vinegar mode to doom-emacs. Pressing `-` pops up a minimal dired in the current buffer.