### PR TITLE
Fix magithub not loading after magit

### DIFF
--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -20,7 +20,6 @@
 
 
 (def-package! magithub
-  :commands magithub-feature-autoinject
   :after magit
   :preface
   (setq magithub-dir (concat doom-etc-dir "magithub/"))


### PR DESCRIPTION
I'd have to run a magithub command to get everything to pop up like pull
requests and what not. I think this was an oversight -- just removing
this will still lazyload it, but instead when magit runs!