### PR TITLE
tools/magit: Show word-granularity on chosen hunk

### DIFF
--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -22,6 +22,7 @@ load everything.")
             #'ivy-completing-read
           #'magit-builtin-completing-read)
         magit-revision-show-gravatars '("^Author:     " . "^Commit:     ")
+        magit-diff-refine-hunk t ;; Show word-granularity on the currently selected hunk
         magit-display-buffer-function
         #'magit-display-buffer-fullframe-status-v1)
 


### PR DESCRIPTION
This really seems like it should be a default, it's so handy to get better
diffs, sort of like how github does it. if set to 'all then it'll show on all of
them, but I think t is good enough.