### PR TITLE
Fix term functions to have optional arguments so they work again

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -48,7 +48,7 @@
        electric-indent   ; smarter, keyword-based electric-indent
        eshell            ; a consistent, cross-platform shell (WIP)
        imenu             ; an imenu sidebar and searchable code index
-      ;term              ; terminals in Emacs
+       term              ; terminals in Emacs
 
        :tools
        editorconfig      ; let someone else argue about tabs vs spaces

--- a/modules/emacs/term/autoload.el
+++ b/modules/emacs/term/autoload.el
@@ -16,7 +16,7 @@ non-nil, cd into the current project's root."
     (switch-to-buffer (save-window-excursion (multi-term)))))
 
 ;;;###autoload
-(defun +term/open-popup (arg)
+(defun +term/open-popup (&optional arg)
   "Open a terminal popup window. If ARG (universal argument) is
 non-nil, cd into the current project's root."
   (interactive "P")
@@ -27,7 +27,7 @@ non-nil, cd into the current project's root."
     (pop-to-buffer (save-window-excursion (multi-term)))))
 
 ;;;###autoload
-(defun +term/open-popup-in-project (arg)
+(defun +term/open-popup-in-project (&optional arg)
   "Open a terminal popup window in the root of the current project.
 
 If ARG (universal argument) is non-nil, open it in `default-directory' instead."


### PR DESCRIPTION
In current `develop` the keybinding for opening `multi-term` in both current window (`SPC o t`) and in a popup (`SPC o T`) are broken and throwing the error message:

```
Wrong type argument: commandp, +term/open
```

The patch is pretty simple, so I hope it can get in and save other people this trouble! Part of it is also that the keybindings are in default but by default `term` is not enabled in the `init.example.el`.