### PR TITLE
Fix latex C-g quitting latex after opening the reftex table of contents

### DIFF
--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -152,8 +152,7 @@
           :e "j"   #'next-line
           :e "k"   #'previous-line
           :e "q"   #'kill-buffer-and-window
-          :e "ESC" #'kill-buffer-and-window
-          "C-g"    #'reftex-toc-quit)))
+          :e "ESC" #'kill-buffer-and-window)))
 
 
 (def-package! bibtex


### PR DESCRIPTION
After opening the reftex TOC in a latex document, every call to `C-g` would mess up the open windows.
Remove the binding that was causing this problem.