### PR TITLE
Better looking default indentation for nested latex lists

### DIFF
--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -6,7 +6,7 @@
 (defvar +latex-bibtex-dir ""
   "Where bibtex files are kept.")
 
-(defvar +latex-indent-level-item-continuation 8
+(defvar +latex-indent-level-item-continuation 4
   "Custom indentation level for items in enumeration-type environments")
 
 


### PR DESCRIPTION
By default, nested enumerates are indented with too many spaces (relative to how things are indented in DOOM).
This small PR changes the defaults to match DOOM indentation standards.