### PR TITLE
bindings: magit | add `file-delete` as `SPC g x`

### DIFF
--- a/modules/config/default/+bindings.el
+++ b/modules/config/default/+bindings.el
@@ -582,6 +582,7 @@
         :desc "Magit dispatch"        :n  "d" #'magit-dispatch-popup
         :desc "Magit find-file"       :n  "f" #'magit-find-file
         :desc "Magit status"          :n  "g" #'magit-status
+        :desc "Magit file delete"     :n  "x" #'magit-file-delete
         :desc "List gists"            :n  "G" #'+gist:list
         :desc "Initialize repo"       :n  "i" #'magit-init
         :desc "Browse issues tracker" :n  "I" #'+vcs/git-browse-issues

--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -15,7 +15,7 @@ load everything.")
 ;;
 
 (def-package! magit
-  :defer t
+  :commands magit-file-delete
   :config
   (setq magit-completing-read-function
         (if (featurep! :completion ivy)


### PR DESCRIPTION
Relatively often I find myself in need to remove some files from a Git repository. I submit for your consideration the following binding (`SPC g x`) to make it conveniently available right under the fingers. ;)
