### PR TITLE
lang/cc: set rtags-install-path to ${doom-etc-dir}/rtags/

### DIFF
--- a/modules/lang/cc/config.el
+++ b/modules/lang/cc/config.el
@@ -192,6 +192,8 @@ compilation database is present in the project.")
 
 (def-package! rtags
   :commands rtags-executable-find
+  :preface
+  (setq rtags-install-path (concat doom-etc-dir "rtags/"))
   :init
   (defun +cc|init-rtags ()
     "Start an rtags server in c-mode and c++-mode buffers."


### PR DESCRIPTION
To keep rtags protocol consistency, I think it's better to use `rtags-install` to install or update rtags instead of compile it by ourselves. So put rtags with others tools under doom-etc-dir maybe a good idea.