### PR TITLE
Make +wakatime-init interactive

### DIFF
--- a/modules/tools/wakatime/autoload.el
+++ b/modules/tools/wakatime/autoload.el
@@ -1,10 +1,13 @@
 ;;; tools/wakatime/autoload.el -*- lexical-binding: t; -*-
 
 ;;;###autoload
-(add-hook 'doom-after-switch-buffer-hook #'+wakatime-init)
+(add-hook 'doom-after-switch-buffer-hook #'+wakatime|autostart)
 
 ;;;###autoload
-(defun +wakatime-init ()
+(defalias '+wakatime/start '+wakatime|autostart)
+
+;;;###autoload
+(defun +wakatime|autostart ()
   "Initialize wakatime (if `wakatime-api-key' is set, otherwise no-op with a
 warning)."
   (interactive)

--- a/modules/tools/wakatime/autoload.el
+++ b/modules/tools/wakatime/autoload.el
@@ -7,6 +7,7 @@
 (defun +wakatime-init ()
   "Initialize wakatime (if `wakatime-api-key' is set, otherwise no-op with a
 warning)."
+  (interactive)
   (if (boundp 'wakatime-api-key)
       (global-wakatime-mode +1)
     (message "No `wakatime-api-key' set! wakaktime-mode will stay disabled."))


### PR DESCRIPTION
Sometimes it doesn't prompt to decrypt gpg, etc etc. Regardless, I think this
should be interactive so it's easily re-initialized