### PR TITLE
Fix: restore the correct display of current and total pages in PDFs

### DIFF
--- a/modules/tools/pdf/config.el
+++ b/modules/tools/pdf/config.el
@@ -16,7 +16,7 @@
   ;; Custom modeline that removes useless info and adds page numbers
   (when (featurep! :ui doom-modeline)
     (load! "+modeline")
-    (add-hook! #'pdf-tools-enabled-hook (doom-set-modeline 'pdf-tools-modeline)))
+    (add-hook! 'pdf-tools-enabled-hook (doom-set-modeline 'pdf-tools-modeline)))
   ;; Handle PDF-tools related popups better
   (set! :popup "^\\*Outline*" '((side . right) (size . 40)) '((select)))
   ;; TODO: Add additional important windows that should be handled differently


### PR DESCRIPTION
A refactoring spree introduced a bug by incorrectly making a hook symbol a function. This fixes this.
Let there be page numbers again!