### PR TITLE
haskell/+intero: Fix goto-definition

### DIFF
--- a/modules/lang/haskell/+intero.el
+++ b/modules/lang/haskell/+intero.el
@@ -14,7 +14,7 @@ This is necessary because `intero-mode' doesn't do its own error checks."
   (add-hook 'haskell-mode-hook #'+haskell|init-intero)
   :config
   (add-hook 'intero-mode-hook #'flycheck-mode)
-  (set! :lookup 'haskell-mode :definition #'intero-goto-definition))
+  (set! :lookup 'intero-mode :definition #'intero-goto-definition))
 
 
 (def-package! hindent


### PR DESCRIPTION
`intero-goto-definition` doesn't get called with `:lookup` set to
`'haskell-mode`. I'm not entirely sure why, but it works when I set it to `'intero-mode`.