### PR TITLE
literate: Allow literate packages [HACKY]

### DIFF
--- a/modules/config/literate/init.el
+++ b/modules/config/literate/init.el
@@ -2,6 +2,8 @@
 
 ;;; config/literate/config.el -*- lexical-binding: t; -*-
 
+;;; config/literate/packages.el -*- lexical-binding: t; -*-
+
 (defvar +literate-config-file
   (expand-file-name "config.org" doom-private-dir)
   "The file path of your literate config file.")
@@ -11,14 +13,24 @@
   "The file path that `+literate-config-file' will be tangled to, then
 byte-compiled from.")
 
+(defvar +literate-packages-file
+  (expand-file-name "packages.org" doom-private-dir)
+  "The file path of your literate packages file.")
+
+(defvar +literate-packages-dest-file
+  (expand-file-name "packages.el" doom-private-dir)
+  "The file path that `+literate-packages-file' will be tangled to, then
+byte-compiled from.")
 
 ;;
 (defun +literate-compile (&optional load)
-  "Tangles & compiles `+literate-config-file' if it has changed. If LOAD is
-non-nil, load it too!"
-  (let ((org +literate-config-file)
-        (el  +literate-config-dest-file))
-    (when (file-newer-than-file-p org el)
+  "Tangles & compiles `+literate-config-file' and `+literate-packages-file' if
+ it has changed. If LOAD is non-nil, load it too!"
+  (let ((orgConf +literate-config-file)
+        (orgPack +literate-packages-file)
+        (elConf  +literate-config-dest-file)
+        (elPack +literate-packages-dest-file))
+    (when  (file-newer-than-file-p orgConf elConf)
       (message "Compiling your literate config...")
 
       ;; We tangle in a separate, blank process because loading it here would
@@ -27,8 +39,21 @@ non-nil, load it too!"
                   "emacs" nil nil nil
                   "-q" "--batch" "-l" "ob-tangle" "--eval"
                   (format "(org-babel-tangle-file \"%s\" \"%s\" \"emacs-lisp\")"
-                          org el)))
+                          orgConf elConf)))
           (warn "There was a problem tangling your literate config!"))
+
+      (message "Done!"))
+    (when  (file-newer-than-file-p orgPack elPack)
+      (message "Compiling your literate packages...")
+
+      ;; We tangle in a separate, blank process because loading it here would
+      ;; load all of :lang org (very expensive!). We only need ob-tangle.
+      (or (zerop (call-process
+                  "emacs" nil nil nil
+                  "-q" "--batch" "-l" "ob-tangle" "--eval"
+                  (format "(org-babel-tangle-file \"%s\" \"%s\" \"emacs-lisp\")"
+                          orgPack elPack)))
+          (warn "There was a problem tangling your literate packages!"))
 
       (message "Done!"))))
 

--- a/modules/config/literate/init.el
+++ b/modules/config/literate/init.el
@@ -26,11 +26,11 @@ byte-compiled from.")
 (defun +literate-compile (&optional load)
   "Tangles & compiles `+literate-config-file' and `+literate-packages-file' if
  it has changed. If LOAD is non-nil, load it too!"
-  (let ((orgConf +literate-config-file)
-        (orgPack +literate-packages-file)
-        (elConf  +literate-config-dest-file)
-        (elPack +literate-packages-dest-file))
-    (when  (file-newer-than-file-p orgConf elConf)
+  (let ((org-conf +literate-config-file)
+        (org-pack +literate-packages-file)
+        (el-conf  +literate-config-dest-file)
+        (el-pack +literate-packages-dest-file))
+    (when  (file-newer-than-file-p org-conf el-conf)
       (message "Compiling your literate config...")
 
       ;; We tangle in a separate, blank process because loading it here would
@@ -39,11 +39,11 @@ byte-compiled from.")
                   "emacs" nil nil nil
                   "-q" "--batch" "-l" "ob-tangle" "--eval"
                   (format "(org-babel-tangle-file \"%s\" \"%s\" \"emacs-lisp\")"
-                          orgConf elConf)))
+                          org-conf el-conf)))
           (warn "There was a problem tangling your literate config!"))
 
       (message "Done!"))
-    (when  (file-newer-than-file-p orgPack elPack)
+    (when  (file-newer-than-file-p org-pack el-pack)
       (message "Compiling your literate packages...")
 
       ;; We tangle in a separate, blank process because loading it here would
@@ -52,7 +52,7 @@ byte-compiled from.")
                   "emacs" nil nil nil
                   "-q" "--batch" "-l" "ob-tangle" "--eval"
                   (format "(org-babel-tangle-file \"%s\" \"%s\" \"emacs-lisp\")"
-                          orgPack elPack)))
+                          org-pack el-pack)))
           (warn "There was a problem tangling your literate packages!"))
 
       (message "Done!"))))


### PR DESCRIPTION
Basically I was really enjoying the literate configuration, however the doom-emacs way is to split packages and config, so this way I can keep a literate `packages.org` file with a short description of why I need the package, while describing the keymap and other features in `config.org`.

Please feel free to edit the way this has been implemented, as I have basically 0 lisp knowledge.