### PR TITLE
ruby: Fix an odd error

### DIFF
--- a/modules/lang/ruby/config.el
+++ b/modules/lang/ruby/config.el
@@ -74,7 +74,7 @@ environment variables."
   :mode ("/\\.rspec\\'" . text-mode)
   :init
   (associate! rspec-mode :match "/\\.rspec$")
-  (associate! rspec-mode :in (ruby-mode yaml-mode) :files ("spec/"))
+  (associate! rspec-mode :modes (ruby-mode yaml-mode) :files ("spec/"))
 
   (defvar evilmi-ruby-match-tags
     '((("unless" "if") ("elsif" "else") "end")


### PR DESCRIPTION
The error being:

```bash
Error (use-package): rspec-mode/:init: Keyword argument :in not one of (:modes :match :files :when)
```


This only shows up recently.. Maybe some sort of upstream change?