### PR TITLE
[WIP] Add: reference flag to org module

### DIFF
--- a/modules/lang/org/autoload/contrib-ref-applescript.el
+++ b/modules/lang/org/autoload/contrib-ref-applescript.el
@@ -1,0 +1,202 @@
+;;; lang/org/autoload/contrib-ref-applescript.el -*- lexical-binding: t; -*-
+;;;###if (and IS-MAC (featurep! +ref))
+;;;###autoload
+(defun +org-reference-org-mac-skim-open (uri)
+  "Visit page of pdf in Skim"
+  (let* ((note (when (string-match ";;\\(.+\\)\\'" uri) (match-string 1 uri)))
+         (page (when (string-match "::\\(.+\\);;" uri) (match-string 1 uri)))
+         (document (substring uri 0 (match-beginning 0))))
+    (do-applescript
+     (concat
+      "tell application \"Skim\"\n"
+      "activate\n"
+      "set theDoc to \"" document "\"\n"
+      "set thepage to " page "\n"
+      "set theNote to " note "\n"
+      "open theDoc\n"
+      "go document 1 to page thePage of document 1\n"
+      "if theNote is not 0\n"
+      "    go document 1 to item theNote of notes of page thePage of document 1\n"
+      "    set active note of document 1 to item theNote of notes of page thePage of document 1\n"
+      "end if\n"
+      "end tell"))))
+;;;###autoload
+(defun +org-reference-append-org-id-to-skim (id)
+  (do-applescript (concat
+                   "tell application \"Skim\"\n"
+                   "set runstatus to \"not set\"\n"
+                   "set theDoc to front document\n"
+                   "try\n"
+                   "    set theNote to active note of theDoc\n"
+                   "end try\n"
+                   "if theNote is not missing value then\n"
+                   "    set newText to text of theNote\n"
+                   "    set startpoint to  (offset of \"org-id:{\" in newtext)\n"
+                   "    set endpoint to  (offset of \"}:org-id\" in newtext)\n"
+                   "    if (startpoint is equal to endpoint) and (endpoint is equal to 0) then\n"
+                   "        set newText to text of theNote & \"\norg-id:{\" & "
+                   (applescript-quote-string id)
+                   " & \"}:org-id\"\n"
+                   "        set text of theNote to newText\n"
+                   "        return \"set success\"\n"
+                   "    end if\n"
+                   "end if\n"
+                   "end tell\n"
+                   "return \"unset\"\n"
+                   )))
+;;;###autoload
+(defun +org-reference-get-skim-page-link ()
+  (do-applescript
+   (concat
+    "tell application \"Skim\"\n"
+    "set theDoc to front document\n"
+    "set theTitle to (name of theDoc)\n"
+    "set thePath to (path of theDoc)\n"
+    "set thePage to (get index for current page of theDoc)\n"
+    "set theSelection to selection of theDoc\n"
+    "set theContent to (contents of (get text for theSelection))\n"
+    "try\n"
+    "    set theNote to active note of theDoc\n"
+    "end try\n"
+    "if theNote is not missing value then\n"
+    "    set theContent to contents of (get text for theNote)\n"
+    "    set theNotePage to get page of theNote\n"
+    "    set thePage to (get index for theNotePage)\n"
+    "    set theNoteIndex to (get index for theNote on theNotePage)\n"
+    "else\n"
+    "    if theContent is missing value then\n"
+    "        set theContent to theTitle & \", p. \" & thePage\n"
+    "        set theNoteIndex to 0\n"
+    "    else\n"
+    "        tell theDoc\n"
+    "            set theNote to make new note with data theSelection with properties {type:highlight note}\n"
+    "            set active note of theDoc to theNote\n"
+    "            set text of theNote to (get text for theSelection)\n"
+    "            set theNotePage to get page of theNote\n"
+    "            set thePage to (get index for theNotePage)\n"
+    "            set theNoteIndex to (get index for theNote on theNotePage)\n"
+    "            set theContent to contents of (get text for theNote)\n"
+    "        end tell\n"
+    "    end if\n"
+    "end if\n"
+    "set theLink to \"skim://\" & thePath & \"::\" & thePage & \";;\" & theNoteIndex & "
+    "\"::split::\" & theContent\n"
+    "end tell\n"
+    "return theLink as string\n")))
+;;;###autoload
+(defun +org-reference-skim-get-bibtex-key ()
+  (let* ((name (do-applescript
+                (concat
+                 "tell application \"Skim\"\n"
+                 "set theDoc to front document\n"
+                 "set theTitle to (name of theDoc)\n"
+                 "end tell\n"
+                 "return theTitle as string\n")))
+         (key (when (string-match "\\(.+\\).pdf" name) (match-string 1 name))))
+    key)
+  )
+;;;###autoload
+(defun +org-reference-get-skim-page-number ()
+  (let* ((page (do-applescript
+                (concat
+                 "tell application \"Skim\"\n"
+                 "set theDoc to front document\n"
+                 "set thePage to (get index for current page of theDoc)\n"
+                 "end tell\n"
+                 "return thePage as integer\n"))))
+    (cond ((integerp page)
+           (int-to-string page))
+          ((numberp page)
+           (number-to-string page))
+          ((stringp page) page))))
+;;;###autoload
+(defun +org-reference-clean-skim-page-link (link)
+  (let* ((link (replace-regexp-in-string "\n" " " link))
+         (link (replace-regexp-in-string "- " " " link)))
+    link))
+
+
+;;;###autoload
+  (defun +org-reference-skim-get-annotation ()
+    (interactive)
+    (message
+     "Applescript: Getting Skim page link...")
+    (org-mac-paste-applescript-links
+     (+org-reference-clean-skim-page-link
+      (+org-reference-get-skim-page-link))))
+;;;###autoload
+  (defun +org-reference-org-mac-skim-insert-page ()
+    (interactive)
+    (insert
+     (+org-reference-skim-get-annotation)))
+;;;###autoload
+  (defun +org-reference-org-ref-find-entry-in-notes (key)
+    "Find or create bib note for KEY"
+    (let* ((entry (bibtex-completion-get-entry
+                   key)))
+      (widen)
+      (goto-char (point-min))
+      (unless (derived-mode-p 'org-mode)
+        (error
+         "Target buffer \"%s\" for jww/find-journal-tree should be in Org mode"
+         (current-buffer)))
+      (let* ((headlines (org-element-map
+                            (org-element-parse-buffer)
+                            'headline
+                          'identity))
+             (keys (mapcar
+                    (lambda (hl)
+                      (org-element-property
+                       :CUSTOM_ID hl))
+                    headlines)))
+        ;; put new entry in notes if we don't find it.
+        (if (-contains? keys key)
+            (progn
+              (org-open-link-from-string
+               (format "[[#%s]]" key))
+              (lambda nil
+                (cond ((org-at-heading-p)
+                       (org-beginning-of-line))
+                      (t
+                       (org-previous-visible-heading
+                        1)))))
+          ;; no entry found, so add one
+          (goto-char (point-max))
+          (insert
+           (org-ref-reftex-format-citation
+            entry
+            (concat
+             "\n"
+             org-ref-note-title-format)))
+          (mapc
+           (lambda (x)
+             (save-restriction
+               (save-excursion (funcall x))))
+           org-ref-create-notes-hook)
+          (org-open-link-from-string
+           (format "[[#%s]]" key))
+          (lambda nil
+            (cond ((org-at-heading-p)
+                   (org-beginning-of-line))
+                  (t
+                   (org-previous-visible-heading
+                    1))))))))
+;;;###autoload
+  (defun +org-reference-org-move-point-to-capture-skim-annotation ()
+    (let* ((keystring (+org-reference-skim-get-bibtex-key)))
+      (+org-reference-org-ref-find-entry-in-notes
+       keystring)))
+
+;;;###autoload
+  (defun bibtex-completion-quicklook (keys)
+    "Open the associated URL or DOI in a browser."
+    (dolist (key keys)
+      (let* ((pdf (car (bibtex-completion-find-pdf
+                        key
+                        bibtex-completion-find-additional-pdfs))))
+        (start-process
+         "Live Preview"
+         nil
+         "/usr/bin/qlmanage"
+         "-p"
+         pdf))))

--- a/modules/lang/org/autoload/contrib-ref-applescript.el
+++ b/modules/lang/org/autoload/contrib-ref-applescript.el
@@ -1,5 +1,5 @@
 ;;; lang/org/autoload/contrib-ref-applescript.el -*- lexical-binding: t; -*-
-;;;###if (and IS-MAC (featurep! +ref))
+;;;###if (and IS-MAC (featurep! +note))
 ;;;###autoload
 (defun +org-reference-org-mac-skim-open (uri)
   "Visit page of pdf in Skim"
@@ -114,89 +114,86 @@
   (let* ((link (replace-regexp-in-string "\n" " " link))
          (link (replace-regexp-in-string "- " " " link)))
     link))
-
-
 ;;;###autoload
-  (defun +org-reference-skim-get-annotation ()
-    (interactive)
-    (message
-     "Applescript: Getting Skim page link...")
-    (org-mac-paste-applescript-links
-     (+org-reference-clean-skim-page-link
-      (+org-reference-get-skim-page-link))))
+(defun +org-reference-skim-get-annotation ()
+  (interactive)
+  (message
+   "Applescript: Getting Skim page link...")
+  (org-mac-paste-applescript-links
+   (+org-reference-clean-skim-page-link
+    (+org-reference-get-skim-page-link))))
 ;;;###autoload
-  (defun +org-reference-org-mac-skim-insert-page ()
-    (interactive)
-    (insert
-     (+org-reference-skim-get-annotation)))
+(defun +org-reference-org-mac-skim-insert-page ()
+  (interactive)
+  (insert
+   (+org-reference-skim-get-annotation)))
 ;;;###autoload
-  (defun +org-reference-org-ref-find-entry-in-notes (key)
-    "Find or create bib note for KEY"
-    (let* ((entry (bibtex-completion-get-entry
-                   key)))
-      (widen)
-      (goto-char (point-min))
-      (unless (derived-mode-p 'org-mode)
-        (error
-         "Target buffer \"%s\" for jww/find-journal-tree should be in Org mode"
-         (current-buffer)))
-      (let* ((headlines (org-element-map
-                            (org-element-parse-buffer)
-                            'headline
-                          'identity))
-             (keys (mapcar
-                    (lambda (hl)
-                      (org-element-property
-                       :CUSTOM_ID hl))
-                    headlines)))
-        ;; put new entry in notes if we don't find it.
-        (if (-contains? keys key)
-            (progn
-              (org-open-link-from-string
-               (format "[[#%s]]" key))
-              (lambda nil
-                (cond ((org-at-heading-p)
-                       (org-beginning-of-line))
-                      (t
-                       (org-previous-visible-heading
-                        1)))))
-          ;; no entry found, so add one
-          (goto-char (point-max))
-          (insert
-           (org-ref-reftex-format-citation
-            entry
-            (concat
-             "\n"
-             org-ref-note-title-format)))
-          (mapc
-           (lambda (x)
-             (save-restriction
-               (save-excursion (funcall x))))
-           org-ref-create-notes-hook)
-          (org-open-link-from-string
-           (format "[[#%s]]" key))
-          (lambda nil
-            (cond ((org-at-heading-p)
-                   (org-beginning-of-line))
-                  (t
-                   (org-previous-visible-heading
-                    1))))))))
+(defun +org-reference-org-ref-find-entry-in-notes (key)
+  "Find or create bib note for KEY"
+  (let* ((entry (bibtex-completion-get-entry
+                 key)))
+    (widen)
+    (goto-char (point-min))
+    (unless (derived-mode-p 'org-mode)
+      (error
+       "Target buffer \"%s\" for jww/find-journal-tree should be in Org mode"
+       (current-buffer)))
+    (let* ((headlines (org-element-map
+                          (org-element-parse-buffer)
+                          'headline
+                        'identity))
+           (keys (mapcar
+                  (lambda (hl)
+                    (org-element-property
+                     :CUSTOM_ID hl))
+                  headlines)))
+      ;; put new entry in notes if we don't find it.
+      (if (-contains? keys key)
+          (progn
+            (org-open-link-from-string
+             (format "[[#%s]]" key))
+            (lambda nil
+              (cond ((org-at-heading-p)
+                     (org-beginning-of-line))
+                    (t
+                     (org-previous-visible-heading
+                      1)))))
+        ;; no entry found, so add one
+        (goto-char (point-max))
+        (insert
+         (org-ref-reftex-format-citation
+          entry
+          (concat
+           "\n"
+           org-ref-note-title-format)))
+        (mapc
+         (lambda (x)
+           (save-restriction
+             (save-excursion (funcall x))))
+         org-ref-create-notes-hook)
+        (org-open-link-from-string
+         (format "[[#%s]]" key))
+        (lambda nil
+          (cond ((org-at-heading-p)
+                 (org-beginning-of-line))
+                (t
+                 (org-previous-visible-heading
+                  1))))))))
 ;;;###autoload
-  (defun +org-reference-org-move-point-to-capture-skim-annotation ()
-    (let* ((keystring (+org-reference-skim-get-bibtex-key)))
-      (+org-reference-org-ref-find-entry-in-notes
-       keystring)))
-
+(defun +org-reference-org-move-point-to-capture-skim-annotation ()
+  (let* ((keystring (+org-reference-skim-get-bibtex-key)))
+    (+org-reference-org-ref-find-entry-in-notes
+     keystring)))
 ;;;###autoload
-  (defun bibtex-completion-quicklook (keys)
-    "Open the associated URL or DOI in a browser."
-    (dolist (key keys)
-      (let* ((pdf (car (bibtex-completion-find-pdf
-                        key
-                        bibtex-completion-find-additional-pdfs))))
-        (start-process
-         "Live Preview"
-         nil
-         "/usr/bin/qlmanage"
-         "-p"
-         pdf))))
+(defun +org-reference-bibtex-completion-quicklook (keys)
+  "Open the associated URL or DOI in a browser."
+  (dolist (key keys)
+    (let* ((pdf (car (bibtex-completion-find-pdf
+                      key
+                      bibtex-completion-find-additional-pdfs))))
+      (start-process
+       "Live Preview"
+       nil
+       "/usr/bin/qlmanage"
+       "-p"
+       pdf))))

--- a/modules/lang/org/autoload/contrib-ref.el
+++ b/modules/lang/org/autoload/contrib-ref.el
@@ -1,0 +1,85 @@
+;; lang/org/autoload/contrib-ref.el -*- lexical-binding: t; -*-
+;;;###if (featurep! +ref)
+;; * batch
+;;;###autoload
+(defun +org-reference-bibtex-wash--bibtex ()
+  (interactive)
+  (while (parsebib-find-next-item)
+    (if (and (not (string-equal
+                   "bioRxiv"
+                   (bibtex-completion-get-value
+                    "journal"
+                    (bibtex-completion-get-entry
+                     (bibtex-completion-key-at-point)))))
+             (not (string-equal
+                   "bioRxiv"
+                   (bibtex-completion-get-value
+                    "location"
+                    (bibtex-completion-get-entry
+                     (bibtex-completion-key-at-point)))))
+             (not (string-equal
+                   "arXiv.org"
+                   (bibtex-completion-get-value
+                    "journal"
+                    (bibtex-completion-get-entry
+                     (bibtex-completion-key-at-point)))))
+             (not (string-equal
+                   ""
+                   (bibtex-completion-get-value
+                    "journal"
+                    (bibtex-completion-get-entry
+                     (bibtex-completion-key-at-point)))))
+             (not (string-equal
+                   ""
+                   (bibtex-completion-get-value
+                    "doi"
+                    (bibtex-completion-get-entry
+                     (bibtex-completion-key-at-point))))))
+        (progn
+          (condition-case nil
+              (call-interactively
+               'doi-utils-update-bibtex-entry-from-doi)
+            (error t))
+          (parsebib-find-next-item)))))
+;;;###autoload
+(defun +org-reference-bibtex-wash--biorxiv ()
+  (interactive)
+  (while (parsebib-find-next-item)
+    (if (and (or (string-equal
+                  "bioRxiv"
+                  (bibtex-completion-get-value
+                   "journal"
+                   (bibtex-completion-get-entry
+                    (bibtex-completion-key-at-point))))
+                 (string-equal
+                  "bioRxiv"
+                  (bibtex-completion-get-value
+                   "location"
+                   (bibtex-completion-get-entry
+                    (bibtex-completion-key-at-point)))))
+             (not (string-equal
+                   ""
+                   (bibtex-completion-get-value
+                    "url"
+                    (bibtex-completion-get-entry
+                     (bibtex-completion-key-at-point))))))
+        (progn
+          (condition-case nil
+              (call-interactively
+               '+org-reference-biorxiv-update-bibtex)
+            (error t))
+          (parsebib-find-next-item))
+      (parsebib-find-next-item))))
+;;;###autoload
+(defun +org-reference-bibtex-get-all-pdf ()
+  (interactive)
+  (while (parsebib-find-next-item)
+    (if (not (bibtex-completion-find-pdf
+              (bibtex-completion-key-at-point)))
+        (progn
+          (call-interactively
+           'doi-utils-get-bibtex-entry-pdf)
+          (parsebib-find-next-item))
+      (parsebib-find-next-item))))
+
+

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -846,6 +846,7 @@ compelling reason, so..."
   (if (featurep! +dragndrop) (load! "contrib/dragndrop"))
   (if (featurep! +ipython)   (load! "contrib/ipython"))
   (if (featurep! +present)   (load! "contrib/present"))
+  (if (featurep! +ref)       (load! "contrib/ref"))
 
   :config
   (add-hook 'org-open-at-point-functions #'doom-set-jump-h)

--- a/modules/lang/org/contrib/ref.el
+++ b/modules/lang/org/contrib/ref.el
@@ -1,7 +1,7 @@
 ;;; lang/org/contrib/ref.el -*- lexical-binding: t; -*-
 ;;;###if (featurep! +ref)
 
-(def-package! org-ref
+(use-package! org-ref
   :commands (org-ref-bibtex-next-entry
              org-ref-bibtex-previous-entry
              doi-utils-get-bibtex-entry-pdf
@@ -60,7 +60,7 @@
     (add-to-list 'doi-utils-pdf-url-functions 'generic-as-get-pdf-url t)))
 
 
-(def-package! bibtex
+(use-package! bibtex
   :defer t
   :config
   (setq bibtex-dialect 'biblatex
@@ -70,7 +70,7 @@
         [fill-paragraph] #'bibtex-fill-entry))
 
 
-(def-package! bibtex-completion
+(use-package! bibtex-completion
   :defer t
   :config
   (setq bibtex-completion-format-citation-functions
@@ -92,7 +92,7 @@
           (lambda (fpath)
             (async-start-process "open-pdf" "xdg-open" nil fpath))))))
 
-(def-package! ivy-bibtex
+(use-package! ivy-bibtex
   :when (featurep! :completion ivy)
   :commands (ivy-bibtex)
   :config
@@ -103,11 +103,11 @@
     (ivy-add-actions 'ivy-bibtex '(("SPC" ivy-bibtex-quicklook "Quick look")))))
 
 
-(def-package! helm-bibtex
+(use-package! helm-bibtex
   :when (featurep! :completion helm)
   :commands helm-bibtex)
 
-(def-package! org-ref-elfeed
+(use-package! org-ref-elfeed
   :when (featurep! :app rss)
   :after elfeed
   :commands (org-ref-elfeed-add))

--- a/modules/lang/org/contrib/ref.el
+++ b/modules/lang/org/contrib/ref.el
@@ -1,0 +1,113 @@
+;;; lang/org/contrib/ref.el -*- lexical-binding: t; -*-
+;;;###if (featurep! +ref)
+
+(def-package! org-ref
+  :commands (org-ref-bibtex-next-entry
+             org-ref-bibtex-previous-entry
+             doi-utils-get-bibtex-entry-pdf
+             org-ref-ivy-insert-cite-link
+             org-ref-find-bibliography
+             org-ref-open-in-browser
+             org-ref-open-bibtex-notes
+             org-ref-open-bibtex-pdf
+             org-ref-bibtex-hydra/body
+             org-ref-bibtex-hydra/org-ref-bibtex-new-entry/body-and-exit
+             org-ref-sort-bibtex-entry
+             arxiv-add-bibtex-entry
+             arxiv-get-pdf-add-bibtex-entry
+             doi-utils-add-bibtex-entry-from-doi
+             isbn-to-bibtex
+             pubmed-insert-bibtex-from-pmid)
+  :init
+  (when (featurep! :completion helm)
+    (setq org-ref-completion-library 'org-ref-helm-bibtex))
+  (when (featurep! :completion ivy)
+    (setq org-ref-completion-library 'org-ref-ivy-cite))
+
+  :config
+  (setq
+    orhc-bibtex-cache-file (concat doom-cache-dir "org-ref.cache")
+    org-ref-get-pdf-filename-function
+    (lambda (key) (car (bibtex-completion-find-pdf key)))
+    org-ref-notes-function
+    (lambda (thekey)
+      (let* ((results (org-ref-get-bibtex-key-and-file thekey))
+             (key (car results))
+             (bibfile (cdr results)))
+        (save-excursion
+          (with-temp-buffer
+            (insert-file-contents bibfile)
+            (bibtex-set-dialect (parsebib-find-bibtex-dialect) t)
+            (bibtex-search-entry key)
+            (org-ref-open-bibtex-notes)))))
+    org-ref-create-notes-hook
+    '((lambda ()
+        (org-narrow-to-subtree)
+        (insert (format "cite:%s\n" (org-entry-get (point) "CUSTOM_ID")))))
+    org-ref-note-title-format "* TODO %t
+ :PROPERTIES:
+  :CUSTOM_ID: %k
+ :END:
+")
+  (when (eq +reference-field 'bioinfo)
+    (require 'org-ref-biorxiv)
+    (add-to-list 'doi-utils-pdf-url-functions 'oup-pdf-url)
+    (add-to-list 'doi-utils-pdf-url-functions 'bmc-pdf-url)
+    (add-to-list 'doi-utils-pdf-url-functions 'biorxiv-pdf-url))
+  (when IS-MAC
+    (setq doi-utils-pdf-url-functions
+          (delete 'generic-full-pdf-url doi-utils-pdf-url-functions))
+    (add-to-list 'doi-utils-pdf-url-functions 'generic-as-get-pdf-url t)))
+
+
+(def-package! bibtex
+  :defer t
+  :config
+  (setq bibtex-dialect 'biblatex
+        bibtex-align-at-equal-sign t
+        bibtex-text-indentation 20)
+  (map! :map bibtex-mode-map
+        [fill-paragraph] #'bibtex-fill-entry))
+
+
+(def-package! bibtex-completion
+  :defer t
+  :config
+  (setq bibtex-completion-format-citation-functions
+        '((org-mode . bibtex-completion-format-citation-pandoc-citeproc)
+          (latex-mode . bibtex-completion-format-citation-cite)
+          (default . bibtex-completion-format-citation-default))
+        bibtex-completion-pdf-field "file"
+        bibtex-completion-additional-search-fields '("journaltitle")
+        bibtex-completion-pdf-symbol "@"
+        bibtex-completion-notes-symbol "#"
+        bibtex-completion-display-formats '((t . "${=has-pdf=:1}${=has-note=:1} ${author:20} ${journaltitle:10} ${year:4} ${title:*} ${=type=:3}")))
+  (cond
+   (IS-MAC
+    (setq bibtex-completion-pdf-open-function
+          (lambda (fpath)
+            (async-start-process "open" "open" "open" fpath))))
+   (IS-LINUX
+    (setq bibtex-completion-pdf-open-function
+          (lambda (fpath)
+            (async-start-process "open-pdf" "xdg-open" nil fpath))))))
+
+(def-package! ivy-bibtex
+  :when (featurep! :completion ivy)
+  :commands (ivy-bibtex)
+  :config
+  (setq ivy-bibtex-default-action 'ivy-bibtex-insert-key)
+  (add-to-list 'ivy-re-builders-alist '(ivy-bibtex . ivy--regex-plus))
+  (when IS-MAC
+    (ivy-bibtex-ivify-action bibtex-completion-quicklook ivy-bibtex-quicklook)
+    (ivy-add-actions 'ivy-bibtex '(("SPC" ivy-bibtex-quicklook "Quick look")))))
+
+
+(def-package! helm-bibtex
+  :when (featurep! :completion helm)
+  :commands helm-bibtex)
+
+(def-package! org-ref-elfeed
+  :when (featurep! :app rss)
+  :after elfeed
+  :commands (org-ref-elfeed-add))

--- a/modules/lang/org/contrib/ref.el
+++ b/modules/lang/org/contrib/ref.el
@@ -5,7 +5,6 @@
   :commands (org-ref-bibtex-next-entry
              org-ref-bibtex-previous-entry
              doi-utils-get-bibtex-entry-pdf
-             org-ref-ivy-insert-cite-link
              org-ref-find-bibliography
              org-ref-open-in-browser
              org-ref-open-bibtex-notes
@@ -22,7 +21,8 @@
   (when (featurep! :completion helm)
     (setq org-ref-completion-library 'org-ref-helm-bibtex))
   (when (featurep! :completion ivy)
-    (setq org-ref-completion-library 'org-ref-ivy-cite))
+    (setq org-ref-completion-library nil
+          org-ref-insert-cite-function 'ivy-bibtex))
 
   :config
   (setq
@@ -49,7 +49,7 @@
   :CUSTOM_ID: %k
  :END:
 ")
-  (when (eq +reference-field 'bioinfo)
+  (when (eq +org-reference-field 'bioinfo)
     (require 'org-ref-biorxiv)
     (add-to-list 'doi-utils-pdf-url-functions 'oup-pdf-url)
     (add-to-list 'doi-utils-pdf-url-functions 'bmc-pdf-url)
@@ -99,7 +99,7 @@
   (setq ivy-bibtex-default-action 'ivy-bibtex-insert-key)
   (add-to-list 'ivy-re-builders-alist '(ivy-bibtex . ivy--regex-plus))
   (when IS-MAC
-    (ivy-bibtex-ivify-action bibtex-completion-quicklook ivy-bibtex-quicklook)
+    (ivy-bibtex-ivify-action +org-reference-bibtex-completion-quicklook ivy-bibtex-quicklook)
     (ivy-add-actions 'ivy-bibtex '(("SPC" ivy-bibtex-quicklook "Quick look")))))
 
 

--- a/modules/lang/org/contrib/ref.org
+++ b/modules/lang/org/contrib/ref.org
@@ -1,0 +1,143 @@
+#+TITLE: Org Reference
+
+This is a ~doom-emacs~ org module flag made for managing and reading academic papers.
+Under the hood it use ~org-ref~ and ~ivy-bibtex~ for managing bibtex, and a
+bunch of applescripts to work with the ~macos~ PDF reader ~Skim.app~ to add
+notes in ~org-mode~. Notice that currently most PDF-related function in this
+module does not work under Linux, as they were based on Applescript.
+
+* Getting start
+In ~.doom.d/config.el~
+#+BEGIN_SRC elisp
+(setq bibtex-completion-bibliography "~/Dropbox/org/reference/Bibliography.bib" ;the major bibtex file
+      bibtex-completion-library-path "~/Dropbox/org/reference/pdf/" ;the directory to store pdfs
+      bibtex-completion-notes-path "~/Dropbox/org/ref.org" ;the note file for reference notes
+      )
+#+END_SRC
+
+* Collect
+I got the paper from two sources. 
+
+1. ~Elfeed~. I subscribed some journal's (and also bioRxiv's) RSS. And I scan
+   through the title, once I found something interesting I check it's abstract
+   (usually in RSS content). If it's really interesting, I use
+   ~org-ref-elfeed-add~. Which will automatically download that paper's bibtex
+   and PDF (if it can handle the journal) and add it to the ivy-bibtex libraray.
+2. Second source is manually searching, after searching I will copy the doi of
+   that paper and use ~doi-utils-add-bibtex-entry-from-doi~ to save the bibtex
+   and PDF of that paper.
+   
+* Read and note taking
+After I download a paper's PDF file locally to my ~reference folder~, I can find
+and open them using ~org-ref-ivy-insert-cite-link~. I bound that to ~command-p~
+in ~org-mode~. Through the ~ivy-action~ provided by ~org-ref~ and ~ivy-bibtex~,
+I can easily open the PDF of a target papar in my system default PDF viewer,
+~Skim.app~.
+
+I use ~Skim.app~ mainly for it's fast rendering and ~Applescript~ support. I've
+came up with a set of helper function to interact with ~Skim.app~ in ~Emacs~.
+With those function, I can have the following two types of workflow:
+
+1. If I'm dedicately reading a important paper, I open it's companion notes
+   (also using ~ivy-action~ in ~org-ref-ivy-insert-cite-link~). Usually I'll
+   setup headings / sections like "Highlights", "Results", "Methods", etc.. Then
+   I use the openned note as the main front. 
+   
+   Even better, if you have ~bettertouchtool/alfred/launchpad/...~ installed,
+   you can use the following two applescript to jump from the ~Skim.app~
+   annotation to the exact corresponding heading in Emacs (You need to enable
+   ~org-id~  in your notes for that).
+   
+   If I find a couple of sentences is worth noting, I select the region using
+   mouse in ~Skim.app~, then went back to the ~org~ notes, and press ~,=~ in
+   ~normal-mode~. That keybinding will automatically have the selected region
+   highlighted with background color in ~Skim.app~ and automatically setup a
+   "magic link" at current point in the notes. Click that link will bring you
+   to exactly to that highlight in ~Skim.app~, even you haven't openned that
+   PDF before.
+   #+BEGIN_SRC applescript
+   tell application "Skim"
+       set thedoc to the front document
+       set anno to the active note of thedoc
+       set newtext to text of anno
+       set startpoint to (offset of "org-id:{" in newtext) + 8
+       set endpoint to (offset of "}:org-id" in newtext) - 1
+       if (startpoint - 8 is not equal to endpoint + 1) and (endpoint + 1 is not 0) then
+         set orgid to characters startpoint thru endpoint of newtext as string
+         do shell script "/usr/local/bin/emacsclient -n -e \"(progn (org-id-goto \\\"" & orgid & "\\\") (x-focus-frame (selected-frame)) (evil-exit-visual-state))\""
+       end if
+   end tell
+   #+END_SRC
+   
+2. If I'm just casually reading a paper, I simply open the PDF, selecting any
+   sentence that I find worth noting, and I press <kbd>command-e</kbd> (bound to
+   the following shell command) to setup a note for that reference.
+   This workflow is based on two ~org-capture~ templates:
+   #+BEGIN_SRC elisp
+   (setq org-capture-templates
+         `(
+           ("GSA" "General Skim Annotation" entry
+            (file+function (lambda () (buffer-file-name)) +org-move-point-to-heading)
+            "* %^{Logging for...} :skim_annotation:read:
+   :PROPERTIES:
+   :Created: %U
+   :SKIM_NOTE: %(+reference/skim-get-annotation)
+   :SKIM_PAGE: %(+reference/get-skim-page-number)
+   :END:
+   %i
+   %?")
+           ("SA" "Skim Annotation" entry
+            (file+function org-ref-bibliography-notes +reference/org-move-point-to-capture-skim-annotation)
+            "* %^{Logging for...} :skim_annotation:read:literature:
+   :PROPERTIES:
+   :Created: %U
+   :CITE: cite:%(+reference/skim-get-bibtex-key)
+   :SKIM_NOTE: %(+reference/skim-get-annotation)
+   :SKIM_PAGE: %(+reference/get-skim-page-number)
+   :END:
+   %i
+   %?")))
+   #+END_SRC
+   One can call those capture templates outside Emacs using bash script:
+   #+BEGIN_SRC bash
+   /usr/local/bin/emacsclient -n -e '(progn (x-focus-frame (selected-frame)) (org-capture nil "SA"))'
+   #+END_SRC
+   Another two scripts is also useful:
+   - General PDF notes, not associated with bibtex entry
+     #+BEGIN_SRC bash
+   /usr/local/bin/emacsclient -n -e '(progn
+  (x-focus-frame (selected-frame))
+  (with-selected-frame (selected-frame)
+    (with-current-buffer (window-buffer (frame-selected-window))
+      (org-capture nil "GSA"))))'
+     #+END_SRC
+   
+   - Insert selected text with link to corresponding PDF location
+     #+BEGIN_SRC bash
+    /usr/local/bin/emacsclient -n -e '(progn
+    (x-focus-frame (selected-frame))
+    (with-selected-frame (selected-frame)
+        (with-current-buffer (window-buffer (frame-selected-window))
+        (insert (+reference/skim-get-annotation)) (+reference/append-org-id-to-skim (org-id-get-create)))))'
+     #+END_SRC
+3. Later when I want to review a note, I can also jump from the PDF note to the
+   corresponding org headings using the following applescript. (~org-id~ need
+   to be enabled).
+   #+BEGIN_SRC applescript
+   tell application "Skim"
+       set thedoc to the front document
+       set anno to the active note of thedoc
+       set newtext to text of anno
+       set startpoint to (offset of "org-id:{" in newtext) + 8
+       set endpoint to (offset of "}:org-id" in newtext) - 1
+       if (startpoint - 8 is not equal to endpoint + 1) and (endpoint + 1 is not 0) then
+           set orgid to characters startpoint thru endpoint of newtext as string
+           do shell script "/usr/local/bin/emacsclient -n -e \"(progn (org-id-goto \\\"" & orgid & "\\\") (x-focus-frame (selected-frame)) (evil-exit-visual-state))\""
+       end if
+   end tell
+   #+END_SRC
+* Reference
+~ivy-bibtex~ is a bibtex-collection interface from where you can search, tag,
+and take notes on particular reference items. However, I mainly use it as a
+searching interface and part of ~org-ref~, which is a full-fledged reference
+management system written by @jkitchen. 

--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -41,3 +41,10 @@
   (package! centered-window :recipe (:host github :repo "anler/centered-window-mode"))
   (package! org-tree-slide)
   (package! ox-reveal))
+
+(when (featurep! +ref)
+  (when (featurep! :completion ivy)
+    (package! ivy-bibtex))
+  (when (featurep! :completion helm)
+    (package! helm-bibtex))
+  (package! org-ref :recipe (:fetcher github :repo "fuxialexander/org-ref" :files ("*"))))

--- a/modules/tools/pdf/autoload/skim.el
+++ b/modules/tools/pdf/autoload/skim.el
@@ -1,0 +1,186 @@
+;;; lang/org/autoload/contrib-ref-applescript.el -*- lexical-binding: t; -*-
+;;;###if (and IS-MAC (featurep! +note))
+;;;###autoload
+(defun +org-reference-org-mac-skim-open (uri)
+  "Visit page of pdf in Skim"
+  (let* ((note (when (string-match ";;\\(.+\\)\\'" uri) (match-string 1 uri)))
+         (page (when (string-match "::\\(.+\\);;" uri) (match-string 1 uri)))
+         (document (substring uri 0 (match-beginning 0))))
+    (do-applescript
+     (concat
+      "tell application \"Skim\"\n"
+      "activate\n"
+      "set theDoc to \"" document "\"\n"
+      "set thepage to " page "\n"
+      "set theNote to " note "\n"
+      "open theDoc\n"
+      "go document 1 to page thePage of document 1\n"
+      "if theNote is not 0\n"
+      "    go document 1 to item theNote of notes of page thePage of document 1\n"
+      "    set active note of document 1 to item theNote of notes of page thePage of document 1\n"
+      "end if\n"
+      "end tell"))))
+;;;###autoload
+(defun +org-reference-append-org-id-to-skim (id)
+  (do-applescript (concat
+                   "tell application \"Skim\"\n"
+                   "set runstatus to \"not set\"\n"
+                   "set theDoc to front document\n"
+                   "try\n"
+                   "    set theNote to active note of theDoc\n"
+                   "end try\n"
+                   "if theNote is not missing value then\n"
+                   "    set newText to text of theNote\n"
+                   "    set startpoint to  (offset of \"org-id:{\" in newtext)\n"
+                   "    set endpoint to  (offset of \"}:org-id\" in newtext)\n"
+                   "    if (startpoint is equal to endpoint) and (endpoint is equal to 0) then\n"
+                   "        set newText to text of theNote & \"\norg-id:{\" & "
+                   (applescript-quote-string id)
+                   " & \"}:org-id\"\n"
+                   "        set text of theNote to newText\n"
+                   "        return \"set success\"\n"
+                   "    end if\n"
+                   "end if\n"
+                   "end tell\n"
+                   "return \"unset\"\n"
+                   )))
+;;;###autoload
+(defun +org-reference-get-skim-page-link ()
+  (do-applescript
+   (concat
+    "tell application \"Skim\"\n"
+    "set theDoc to front document\n"
+    "set theTitle to (name of theDoc)\n"
+    "set thePath to (path of theDoc)\n"
+    "set thePage to (get index for current page of theDoc)\n"
+    "set theSelection to selection of theDoc\n"
+    "set theContent to (contents of (get text for theSelection))\n"
+    "try\n"
+    "    set theNote to active note of theDoc\n"
+    "end try\n"
+    "if theNote is not missing value then\n"
+    "    set theContent to contents of (get text for theNote)\n"
+    "    set theNotePage to get page of theNote\n"
+    "    set thePage to (get index for theNotePage)\n"
+    "    set theNoteIndex to (get index for theNote on theNotePage)\n"
+    "else\n"
+    "    if theContent is missing value then\n"
+    "        set theContent to theTitle & \", p. \" & thePage\n"
+    "        set theNoteIndex to 0\n"
+    "    else\n"
+    "        tell theDoc\n"
+    "            set theNote to make new note with data theSelection with properties {type:highlight note}\n"
+    "            set active note of theDoc to theNote\n"
+    "            set text of theNote to (get text for theSelection)\n"
+    "            set theNotePage to get page of theNote\n"
+    "            set thePage to (get index for theNotePage)\n"
+    "            set theNoteIndex to (get index for theNote on theNotePage)\n"
+    "            set theContent to contents of (get text for theNote)\n"
+    "        end tell\n"
+    "    end if\n"
+    "end if\n"
+    "set theLink to \"skim://\" & thePath & \"::\" & thePage & \";;\" & theNoteIndex & "
+    "\"::split::\" & theContent\n"
+    "end tell\n"
+    "return theLink as string\n")))
+;;;###autoload
+(defun +org-reference-skim-get-bibtex-key ()
+  (let* ((name (do-applescript
+                (concat
+                 "tell application \"Skim\"\n"
+                 "set theDoc to front document\n"
+                 "set theTitle to (name of theDoc)\n"
+                 "end tell\n"
+                 "return theTitle as string\n")))
+         (key (when (string-match "\\(.+\\).pdf" name) (match-string 1 name))))
+    key)
+  )
+;;;###autoload
+(defun +org-reference-get-skim-page-number ()
+  (let* ((page (do-applescript
+                (concat
+                 "tell application \"Skim\"\n"
+                 "set theDoc to front document\n"
+                 "set thePage to (get index for current page of theDoc)\n"
+                 "end tell\n"
+                 "return thePage as integer\n"))))
+    (cond ((integerp page)
+           (int-to-string page))
+          ((numberp page)
+           (number-to-string page))
+          ((stringp page) page))))
+;;;###autoload
+(defun +org-reference-clean-skim-page-link (link)
+  (let* ((link (replace-regexp-in-string "\n" " " link))
+         (link (replace-regexp-in-string "- " " " link)))
+    link))
+;;;###autoload
+(defun +org-reference-skim-get-annotation ()
+  (interactive)
+  (message
+   "Applescript: Getting Skim page link...")
+  (org-mac-paste-applescript-links
+   (+org-reference-clean-skim-page-link
+    (+org-reference-get-skim-page-link))))
+;;;###autoload
+(defun +org-reference-org-mac-skim-insert-page ()
+  (interactive)
+  (insert
+   (+org-reference-skim-get-annotation)))
+;;;###autoload
+(defun +org-reference-org-ref-find-entry-in-notes (key)
+  "Find or create bib note for KEY"
+  (let* ((entry (bibtex-completion-get-entry
+                 key)))
+    (widen)
+    (goto-char (point-min))
+    (unless (derived-mode-p 'org-mode)
+      (error
+       "Target buffer \"%s\" for jww/find-journal-tree should be in Org mode"
+       (current-buffer)))
+    (let* ((headlines (org-element-map
+                          (org-element-parse-buffer)
+                          'headline
+                        'identity))
+           (keys (mapcar
+                  (lambda (hl)
+                    (org-element-property
+                     :CUSTOM_ID hl))
+                  headlines)))
+      ;; put new entry in notes if we don't find it.
+      (if (-contains? keys key)
+          (progn
+            (org-open-link-from-string
+             (format "[[#%s]]" key))
+            (lambda nil
+              (cond ((org-at-heading-p)
+                     (org-beginning-of-line))
+                    (t
+                     (org-previous-visible-heading
+                      1)))))
+        ;; no entry found, so add one
+        (goto-char (point-max))
+        (insert
+         (org-ref-reftex-format-citation
+          entry
+          (concat
+           "\n"
+           org-ref-note-title-format)))
+        (mapc
+         (lambda (x)
+           (save-restriction
+             (save-excursion (funcall x))))
+         org-ref-create-notes-hook)
+        (org-open-link-from-string
+         (format "[[#%s]]" key))
+        (lambda nil
+          (cond ((org-at-heading-p)
+                 (org-beginning-of-line))
+                (t
+                 (org-previous-visible-heading
+                  1))))))))
+;;;###autoload
+(defun +org-reference-org-move-point-to-capture-skim-annotation ()
+  (let* ((keystring (+org-reference-skim-get-bibtex-key)))
+    (+org-reference-org-ref-find-entry-in-notes
+     keystring)))

--- a/modules/tools/pdf/config.el
+++ b/modules/tools/pdf/config.el
@@ -30,3 +30,12 @@
   ;; (set-popup-rule! "* annots\\*$" :side 'left :size 40 :select nil)
   ;; Fix #1107: flickering pdfs when evil-mode is enabled
   (setq-hook! 'pdf-view-mode-hook evil-normal-state-cursor (list nil)))
+
+(use-package! org-pdftools)
+
+(use-package! org-noter
+  :when (featurep! +note)
+  :commands (org-noter)
+  (after! pdf-tools
+    (setq pdf-annot-activate-handler-functions #'org-noter-jump-to-note)))
+

--- a/modules/tools/pdf/packages.el
+++ b/modules/tools/pdf/packages.el
@@ -2,3 +2,7 @@
 ;;; tools/pdf/packages.el
 
 (package! pdf-tools)
+
+(when (featurep! +note)
+  (package! org-pdftools :recipe (:host github :repo "fuxialexander/org-pdftools" :files ("*")))
+  (package! org-noter :recipe (:host github :repo "fuxialexander/org-noter" :branch "pdf-notes-booster" :files ("*"))))


### PR DESCRIPTION
This module add reference (bibtex) support to org-mode and elfeed, it can also replace the bibtex settings in the latex module.
Features and workflows is documented in the `readme.org` file. Mainly:
1. Async download of bibtex entry and PDF from DOI or elfeed feeds
2. Ivy-bibtex frontend for org-ref (originally only comes with helm-bibtex)
3. A library of applescript to interact with `Skim.app` in `macOS` to create highlights and link to notes in org-mode. The links are bi-directional between PDF and org-mode.