### PR TITLE
Fix init.example `electric` module

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -51,7 +51,7 @@
        :emacs
        dired             ; making dired pretty [functional]
        ediff             ; comparing files in Emacs
-       electric-indent   ; smarter, keyword-based electric-indent
+       electric          ; smarter, keyword-based electric-indent
       ;eshell            ; a consistent, cross-platform shell (WIP)
        imenu             ; an imenu sidebar and searchable code index
       ;term              ; terminals in Emacs


### PR DESCRIPTION
I've been keeping my init up-to-date with the example, but the example
still has `electric-indent` whereas `make` warns me it's been renamed to
`electric`. This provides the correct module name in the example.
