### PR TITLE
Look for the correct feature name for org+rest

### DIFF
--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -26,7 +26,7 @@
     (package! ob-go))
   (when (featurep! :lang rust)
     (package! ob-rust))
-  (when (featurep! :lang restclient)
+  (when (featurep! :lang rest)
     (package! ob-restclient))
   (when (featurep! :lang crystal)
     (package! ob-crystal))


### PR DESCRIPTION
the feature is in `init.el` as `rest` not `restclient`; the way this was `ob-restclient` will never get installed