### PR TITLE
Added Zathura as a viewer option

### DIFF
--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -93,6 +93,10 @@
               "Skim" '("/Applications/Skim.app/Contents/SharedSupport/displayline -b -g %n %o %b"))
     (map-put TeX-view-program-selection 'output-pdf '("Skim")))
 
+  ;; Or Zathura
+  (when (featureep! +zathura)
+    (map-put TeX-view-program-selection 'output-pdf '("Zathura")))
+
   ;; Or PDF-tools, but only if the module is also loaded
   (when (and (featurep! :tools pdf)
               (featurep! +pdf-tools))

--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -94,7 +94,7 @@
     (map-put TeX-view-program-selection 'output-pdf '("Skim")))
 
   ;; Or Zathura
-  (when (featureep! +zathura)
+  (when (featurep! +zathura)
     (map-put TeX-view-program-selection 'output-pdf '("Zathura")))
 
   ;; Or PDF-tools, but only if the module is also loaded


### PR DESCRIPTION
Note that zathura with synctex is already supported as a viewer option by AUCTeX, making this a simple one-liner.