### PR TITLE
Added basic +pandoc feature to markdown module

### DIFF
--- a/modules/lang/markdown/config.el
+++ b/modules/lang/markdown/config.el
@@ -3,6 +3,9 @@
 (def-package! markdown-mode
   :mode ("/README\\(?:\\.\\(?:markdown\\|md\\)\\)?\\'" . gfm-mode)
   :init
+  (when (featurep! +pandoc)
+    (setq markdown-command "pandoc --from=markdown --to=html --standalone --mathjax --highlight-style=pygments"))
+
   (setq markdown-enable-wiki-links t
         markdown-italic-underscore t
         markdown-asymmetric-header t
@@ -47,3 +50,10 @@
           :nv "t" #'markdown-toc-generate-toc
           :nv "i" #'markdown-insert-image
           :nv "l" #'markdown-insert-link)))
+
+(def-package! pandoc-mode
+  :when (featurep! +pandoc)
+  :commands
+  pandoc-mode
+  :hook
+  (markdown-mode . conditionally-turn-on-pandoc))

--- a/modules/lang/markdown/doctor.el
+++ b/modules/lang/markdown/doctor.el
@@ -1,0 +1,6 @@
+;; -*- lexical-binding: t; no-byte-compile: t; -*-
+;;; lang/markdown/doctor.el
+
+(when (featurep! +pandoc)
+  (unless (executable-find "pandoc")
+    (warn! "Couldn't find pandoc, markdown-mode may have issues"))

--- a/modules/lang/markdown/packages.el
+++ b/modules/lang/markdown/packages.el
@@ -4,3 +4,7 @@
 (package! markdown-mode)
 (package! markdown-toc)
 
+(when (featurep! +pandoc)
+  (package! pandoc-mode))
+
+


### PR DESCRIPTION
The `markdown` module currently comes with no option to set a compilation method. This PR adds the `+pandoc` feature to the `markdown` module, adding basic integration between `markdown-mode` and `pandoc-mode` as recommended in Jason Blevins' (author of `markdown-mode`) [guide to markdown mode](https://jblevins.org/projects/markdown-mode/).

- `pandoc --from=markdown --to=html --standalone --mathjax --highlight-style=pygments` is set as the default markdown command.
- `pandoc-mode` is automatically enabled for a markdown file iff a pandoc settings file is present.
- added a doom doctor check for the `pandoc` binary, iff the `+pandoc` feature is enabled.

 
