### PR TITLE
Refactored +dante feature

### DIFF
--- a/modules/lang/haskell/+dante.el
+++ b/modules/lang/haskell/+dante.el
@@ -2,17 +2,8 @@
 ;;;###if (featurep! +dante)
 
 (def-package! dante
-  :after haskell-mode
   :hook (haskell-mode . dante-mode)
   :config
-  (add-hook 'haskell-mode-hook #'interactive-haskell-mode))
-
-
-(def-package! company-ghc
-  :when (featurep! :completion company)
-  :after haskell-mode
-  :init
-  (add-hook 'haskell-mode-hook #'ghc-comp-init)
-  :config
-  (setq company-ghc-show-info 'oneline)
-  (set-company-backend! 'haskell-mode #'company-ghc))
+  (when (featurep! :feature syntax-checker)
+    (add-hook! 'dante-mode-hook
+      (flycheck-add-next-checker 'haskell-dante '(warning . haskell-hlint)))))

--- a/modules/lang/haskell/+dante.el
+++ b/modules/lang/haskell/+dante.el
@@ -2,7 +2,7 @@
 ;;;###if (featurep! +dante)
 
 (def-package! dante
-  :hook (haskell-mode . dante-mode)
+  :hook haskell-mode
   :config
   (when (featurep! :feature syntax-checker)
     (add-hook! 'dante-mode-hook

--- a/modules/lang/haskell/doctor.el
+++ b/modules/lang/haskell/doctor.el
@@ -4,9 +4,8 @@
 (when (featurep! +dante)
   (unless (executable-find "cabal")
     (warn! "Couldn't find cabal, haskell-mode may have issues"))
-
-  (unless (executable-find "ghc-mod")
-    (warn! "Couldn't find ghc-mod on PATH. Code completion will not work")))
+  (unless (executable-find "hlint")
+    (warn! "Couldn't find hlint. Flycheck may have issues in haskell-mode/")))
 
 (when (featurep! +intero)
   (unless (executable-find "stack")

--- a/modules/lang/haskell/packages.el
+++ b/modules/lang/haskell/packages.el
@@ -5,9 +5,7 @@
 
 ;;
 (cond ((featurep! +dante)
-       (package! dante)
-       (when (featurep! :completion company)
-         (package! company-ghc)))
+       (package! dante))
       (t
        (package! intero)
        (package! hindent)))


### PR DESCRIPTION
- removed dependency on `company-ghc` (`dante` supports `company`)
- enable `dante-mode` automatically in `haskell-mode`
- add `flycheck` and `hlint` support to `dante-mode`
- add `doctor.el` check for `hlint` executable.