### PR TITLE
Cut: lang/clojure: unneeded + subjective parts

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -5,14 +5,7 @@
 
 
 (def-package! clj-refactor
-  :after clojure-mode
-  :config
-  ;; setup some extra namespace auto completion for great awesome
-  (dolist (ns '(("re-frame" . "re-frame.core")
-                ("reagent"  . "reagent.core")
-                ("str"      . "clojure.string")))
-    (map-put cljr-magic-require-namespaces (car ns) (cdr ns))))
-
+  :after clojure-mode)
 
 (def-package! cider
   ;; NOTE: if you don't have an org directory set (the dir doesn't exist), cider
@@ -23,13 +16,7 @@
   (setq nrepl-hide-special-buffers t
         cider-stacktrace-default-filters '(tooling dup)
         cider-prompt-save-file-on-load nil
-        cider-repl-use-clojure-font-lock t
-        ;; Setup cider for clojurescript / figwheel dev.
-        cider-cljs-lein-repl
-        "(do (require 'figwheel-sidecar.repl-api)
-         (figwheel-sidecar.repl-api/start-figwheel!)
-         (figwheel-sidecar.repl-api/cljs-repl))")
-
+        cider-repl-use-clojure-font-lock t)
   (set-popup-rule! "^\\*cider-repl" :quit nil :select nil)
   (set-repl-handler! 'clojure-mode #'+clojure/repl)
   (set-eval-handler! 'clojure-mode #'cider-eval-region)


### PR DESCRIPTION
str => clojure.string is already defined in `cljr-magic-require-namespaces'
re-frame + reagent is subjective (for personal configuration IMO)

fighweel aspect is now handled upstream by giving a prompt
see: `cider-cljs-repl-types'