### PR TITLE
Fix disable ivy fuzzy search in counsel-grep and swiper

### DIFF
--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -216,7 +216,8 @@ immediately runs it on the current candidate (ending the ivy session)."
         '((counsel-ag . ivy--regex-plus)
           (counsel-rg . ivy--regex-plus)
           (counsel-pt . ivy--regex-plus)
-          (counsel-grep-or-swiper . ivy--regex-plus)
+          (counsel-grep . ivy--regex-plus)
+          (swiper . ivy--regex-plus)
           (t . ivy--regex-fuzzy))
         ivy-initial-inputs-alist nil))
 


### PR DESCRIPTION
As the title said. The previous code does not work.