### PR TITLE
doctor: Fix error with markdown

### DIFF
--- a/modules/lang/markdown/doctor.el
+++ b/modules/lang/markdown/doctor.el
@@ -3,4 +3,4 @@
 
 (when (featurep! +pandoc)
   (unless (executable-find "pandoc")
-    (warn! "Couldn't find pandoc, markdown-mode may have issues"))
+    (warn! "Couldn't find pandoc, markdown-mode may have issues")))


### PR DESCRIPTION
Really minor change.

Fixes the obvious:

```bash
 ./bin/doom doc         
Doom Doctor
Emacs v26.1
Doom v2.0.9 (c8de34fb)
shell: /bin/zsh
Compiled with:
  XPM JPEG TIFF GIF PNG RSVG IMAGEMAGICK SOUND GPM DBUS GSETTINGS NOTIFY ACL
  GNUTLS LIBXML2 FREETYPE M17N_FLT LIBOTF XFT ZLIB TOOLKIT_SCROLL_BARS GTK3 X11
  MODULES THREADS LIBSYSTEMD LCMS2
uname -a:
  Linux myarchbox 4.16.16-1-ck-haswell #1 SMP PREEMPT Sat Jun 16 08:24:52 EDT 2018
  x86_64 GNU/Linux

Checking your OS...
Checking your fonts...
Checking gnutls/openssl...
Testing your root certificates...
Checking for GNU/BSD tar...
Checking your enabled modules...
  > (:lang markdown) Syntax error: (end-of-file
    /home/haozeke/.emacs.d/modules/lang/markdown/doctor.el)


There is 1 error!
```