### PR TITLE
Fix handler calls to reference lisp-mode.

### DIFF
--- a/modules/lang/common-lisp/config.el
+++ b/modules/lang/common-lisp/config.el
@@ -5,8 +5,8 @@
   (setq inferior-lisp-program "sbcl")
 
   (set-popup-rule! "^\\*sly" :quit nil :ttl nil)
-  (set-repl-handler! 'sly-mode #'sly-mrepl)
-  (set-lookup-handlers! 'sly-mode
+  (set-repl-handler! 'lisp-mode #'sly-mrepl)
+  (set-lookup-handlers! 'lisp-mode
     :definition #'sly-edit-definition
     :documentation #'sly-describe-symbol)
 


### PR DESCRIPTION
`set-repl-handler!` helps with opening a repl when a particular mode is
active in a buffer. We want to be able to open a `sly-mrepl` whenever we
are in a lisp buffer, so we should have the repl handler look for
`'lisp-mode` to define opening a sly repl.

I assume the lookup handlers should be making sure we are in a lisp
buffer (similar reasoning to the repl-handler).