### PR TITLE
Factor out hindent

### DIFF
--- a/modules/lang/haskell/+hindent.el
+++ b/modules/lang/haskell/+hindent.el
@@ -1,6 +1,0 @@
-;;; +hindent.el --- description -*- lexical-binding: t; -*-
-;;;###if (featurep! +hindent)
-
-(def-package! hindent
-  :hook (haskell-mode . hindent-mode))
-

--- a/modules/lang/haskell/+hindent.el
+++ b/modules/lang/haskell/+hindent.el
@@ -1,0 +1,6 @@
+;;; +hindent.el --- description -*- lexical-binding: t; -*-
+;;;###if (featurep! +hindent)
+
+(def-package! hindent
+  :hook (haskell-mode . hindent-mode))
+

--- a/modules/lang/haskell/+intero.el
+++ b/modules/lang/haskell/+intero.el
@@ -14,7 +14,3 @@ This is necessary because `intero-mode' doesn't do its own error checks."
   (add-hook 'haskell-mode-hook #'+haskell|init-intero)
   :config
   (set-lookup-handlers! 'intero-mode :definition #'intero-goto-definition))
-
-
-(def-package! hindent
-  :hook (haskell-mode . hindent-mode))

--- a/modules/lang/haskell/config.el
+++ b/modules/lang/haskell/config.el
@@ -3,6 +3,8 @@
 (cond ((featurep! +intero) (load! "+intero"))
       ((featurep! +dante)  (load! "+dante")))
 
+(when (featurep! +hindent) (load! "+hindent"))
+
 
 ;;
 ;; Common plugins

--- a/modules/lang/haskell/config.el
+++ b/modules/lang/haskell/config.el
@@ -3,12 +3,12 @@
 (cond ((featurep! +intero) (load! "+intero"))
       ((featurep! +dante)  (load! "+dante")))
 
-(when (featurep! +hindent) (load! "+hindent"))
-
-
 ;;
 ;; Common plugins
 ;;
+
+(def-package! hindent
+  :hook (haskell-mode . hindent-mode))
 
 (after! haskell-mode
   (set-repl-handler! 'haskell-mode #'switch-to-haskell)

--- a/modules/lang/haskell/doctor.el
+++ b/modules/lang/haskell/doctor.el
@@ -11,7 +11,6 @@
   (unless (executable-find "stack")
     (warn! "Couldn't find stack. Intero will not work.")))
 
-(when (featurep! +hindent)
-  (unless (executable-find "hindent")
-    (warn! "Couldn't find hindent. hindent-mode won't work.")))
+(unless (executable-find "hindent")
+  (warn! "Couldn't find hindent. hindent-mode won't work."))
 

--- a/modules/lang/haskell/doctor.el
+++ b/modules/lang/haskell/doctor.el
@@ -3,11 +3,15 @@
 
 (when (featurep! +dante)
   (unless (executable-find "cabal")
-    (warn! "Couldn't find cabal, haskell-mode may have issues"))
+    (warn! "Couldn't find cabal, haskell-mode may have issues."))
   (unless (executable-find "hlint")
-    (warn! "Couldn't find hlint. Flycheck may have issues in haskell-mode/")))
+    (warn! "Couldn't find hlint. Flycheck may have issues in haskell-mode.")))
 
 (when (featurep! +intero)
   (unless (executable-find "stack")
-    (warn! "Couldn't find stack. Intero will not work")))
+    (warn! "Couldn't find stack. Intero will not work.")))
+
+(when (featurep! +hindent)
+  (unless (executable-find "hindent")
+    (warn! "Couldn't find hindent. hindent-mode won't work.")))
 

--- a/modules/lang/haskell/packages.el
+++ b/modules/lang/haskell/packages.el
@@ -6,7 +6,8 @@
 ;;
 (cond ((featurep! +dante)
        (package! dante))
-      (t
-       (package! intero)
-       (package! hindent)))
+      (t (package! intero)))
+
+(when (featurep! +hindent)
+      (package! hindent))
 

--- a/modules/lang/haskell/packages.el
+++ b/modules/lang/haskell/packages.el
@@ -8,6 +8,5 @@
        (package! dante))
       (t (package! intero)))
 
-(when (featurep! +hindent)
-      (package! hindent))
+(package! hindent)
 


### PR DESCRIPTION
`hindent` was previously only loaded as part of the `+intero` feature. It's now factored out as part of `config.el` with a `doom doc` check for the `hindent` executable.