### PR TITLE
fix wrong argument order in usage of `alist-get`

### DIFF
--- a/modules/feature/lookup/autoload/lookup.el
+++ b/modules/feature/lookup/autoload/lookup.el
@@ -73,7 +73,7 @@ properties:
                       "Search on: "
                       (mapcar #'car +lookup-provider-url-alist)
                       nil t)))
-          (setf (alist-get +lookup--last-provider key) provider)
+          (setf (alist-get key +lookup--last-provider) provider)
           provider))))
 
 (defun +lookup--symbol-or-region (&optional initial)


### PR DESCRIPTION
In `alist-get`, the argument is passed with wrong order. Just fix it.