### PR TITLE
org: Update revealJS url

### DIFF
--- a/modules/lang/org/+present.el
+++ b/modules/lang/org/+present.el
@@ -13,7 +13,7 @@
 (def-package! ox-reveal
   :defer t
   :config
-  (setq org-reveal-root "http://cdn.jsdelivr.net/reveal.js/3.0.0/"
+  (setq org-reveal-root "https://cdn.jsdelivr.net/npm/reveal.js@3/"
         org-reveal-mathjax t))
 
 


### PR DESCRIPTION
This grabs all minor versions upto 4.xx

If in doubt about the new changes, check [the changelog](https://github.com/hakimel/reveal.js/releases).
