### PR TITLE
Improved repl handling for haskell module

### DIFF
--- a/modules/lang/haskell/config.el
+++ b/modules/lang/haskell/config.el
@@ -3,14 +3,19 @@
 (cond ((featurep! +intero) (load! "+intero"))
       ((featurep! +dante)  (load! "+dante")))
 
+(add-hook 'haskell-mode-hook 'haskell-auto-insert-module-template)
+
+(add-hook 'haskell-mode-hook 'interactive-haskell-mode)
+
+(after! haskell-mode
+  (set-repl-handler! 'haskell-mode #'haskell-interactive-bring)
+  (set-repl-handler! 'haskell-cabal-mode #'haskell-interactive-bring)
+  (set-repl-handler! 'literate-haskell-mode #'haskell-interactive-bring)
+  (add-to-list 'completion-ignored-extensions ".hi"))
+
 ;;
 ;; Common plugins
 ;;
 
 (def-package! hindent
   :hook (haskell-mode . hindent-mode))
-
-(after! haskell-mode
-  (set-repl-handler! 'haskell-mode #'switch-to-haskell)
-  (add-to-list 'completion-ignored-extensions ".hi"))
-


### PR DESCRIPTION
The haskell repl is now handled by `interactive-haskell-mode`, which supports a distinct haskell process per cabal project. Repl-handling is also set up for `.cabal` and `.lhs` (literate haskell) files.

`.hs` files also now have a module declaration inserted automatically (just like, e.g., `.el` files).

Still to do:
- [ ] disable for intero users