### PR TITLE
Load electric ident

### DIFF
--- a/modules/lang/haskell/config.el
+++ b/modules/lang/haskell/config.el
@@ -3,6 +3,9 @@
 (cond ((featurep! +intero) (load! "+intero"))
       ((featurep! +dante)  (load! "+dante")))
 
+(when (featurep! :emacs electric)
+  (add-hook 'haskell-mode-hook 'electric-indent-mode))
+
 ;;
 ;; Common plugins
 ;;

--- a/modules/lang/haskell/config.el
+++ b/modules/lang/haskell/config.el
@@ -3,8 +3,6 @@
 (cond ((featurep! +intero) (load! "+intero"))
       ((featurep! +dante)  (load! "+dante")))
 
-(when (featurep! :emacs electric)
-  (add-hook 'haskell-mode-hook 'electric-indent-local-mode))
 
 ;;
 ;; Common plugins
@@ -14,6 +12,7 @@
   :hook (haskell-mode . hindent-mode))
 
 (after! haskell-mode
+  (setq haskell-indentation-electric-flag t)
   (set-repl-handler! 'haskell-mode #'switch-to-haskell)
   (add-to-list 'completion-ignored-extensions ".hi"))
 

--- a/modules/lang/haskell/config.el
+++ b/modules/lang/haskell/config.el
@@ -4,7 +4,7 @@
       ((featurep! +dante)  (load! "+dante")))
 
 (when (featurep! :emacs electric)
-  (add-hook 'haskell-mode-hook 'electric-indent-mode))
+  (add-hook 'haskell-mode-hook 'electric-indent-local-mode))
 
 ;;
 ;; Common plugins


### PR DESCRIPTION
Since `haskell-indentation-mode` (the default in `haskell-mode`) supports `electric-indent-mode`, load it if `electric` is enabled
