### PR TITLE
Double quote doom binary location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DOOM = bin/doom
+DOOM = "bin/doom"
 MODULES = $(patsubst modules/%/, %, $(sort $(dir $(wildcard modules/*/ modules/*/*/))))
 
 all:


### PR DESCRIPTION
This allows 'make quickstart' to work on Windows when using GNU make (appreciate Windows isn't officially supported)
