### PR TITLE
Intero hlint

### DIFF
--- a/modules/lang/haskell/+intero.el
+++ b/modules/lang/haskell/+intero.el
@@ -13,4 +13,7 @@ This is necessary because `intero-mode' doesn't do its own error checks."
         (message "Couldn't find stack. Refusing to enable intero-mode."))))
   (add-hook 'haskell-mode-hook #'+haskell|init-intero)
   :config
-  (set-lookup-handlers! 'intero-mode :definition #'intero-goto-definition))
+  (set-lookup-handlers! 'intero-mode :definition #'intero-goto-definition)
+  (when (featurep! :feature syntax-checker)
+    (add-hook! 'intero-mode
+      (flycheck-add-next-checker 'intero '(warning . haskell-hlint)))))

--- a/modules/lang/haskell/doctor.el
+++ b/modules/lang/haskell/doctor.el
@@ -3,9 +3,7 @@
 
 (when (featurep! +dante)
   (unless (executable-find "cabal")
-    (warn! "Couldn't find cabal, haskell-mode may have issues"))
-  (unless (executable-find "hlint")
-    (warn! "Couldn't find hlint. Flycheck may have issues in haskell-mode")))
+    (warn! "Couldn't find cabal, haskell-mode may have issues")))
 
 (when (featurep! +intero)
   (unless (executable-find "stack")
@@ -13,4 +11,9 @@
 
 (unless (executable-find "hindent")
   (warn! "Couldn't find hindent. hindent-mode won't work"))
+
+(when (or (featurep! +dante) (featurep! +intero))
+  (unless (executable-find "hlint")
+    (warn! "Couldn't find hlint. Flycheck may have issues in haskell-mode")))
+
 


### PR DESCRIPTION
Adds the `hlint` checker for `intero` users. Note that this used to be the default in `intero`: https://github.com/commercialhaskell/intero/commit/06527fc4c9a5239e7921845f9c7cd4d2783eb030

Note this adds some redundancy, since the `hlint` checker is declared in two places. 

Since `intero` is broken on NixOS, this needs testing!
