### PR TITLE
DONE: improve nix module

### DIFF
--- a/modules/lang/nix/config.el
+++ b/modules/lang/nix/config.el
@@ -1,16 +1,8 @@
-;;; config.el --- description -*- lexical-binding: t; -*-
-
-(def-package! nix-update
-  :commands (nix-update-fetch))
-
-(def-package! nix-repl
-  :commands (nix-repl-show))
-
-(def-package! helm-nixos-options
-  :when (featurep! :completion helm)
-  :commands (helm-nixos-options))
+;;; lang/nix/config.el -*- lexical-binding: t; -*-
 
 (after! nix-mode
+  (set-company-backend! 'nix-mode 'company-nixos-options)
+        
   (map! :map nix-mode-map
         :localleader
         :n "f" #'nix-update-fetch
@@ -18,12 +10,12 @@
         :n "r" #'nix-repl-show
         :n "s" #'nix-shell
         :n "b" #'nix-build
-        :n "u" #'nix-unpack)
+        :n "u" #'nix-unpack
+        (:when (featurep! :completion helm)
+          :n "o" #'helm-nixos-options)))
 
-  (when (featurep! :completion helm)
-    (map! :map nix-mode-map
-          :localleader
-          :n "o" #'helm-nixos-options))
+(def-package! nix-update
+  :commands (nix-update-fetch))
 
-  (when (featurep! :completion company)
-    (set-company-backend! 'nix-mode 'company-nixos-options)))
+(def-package! nix-repl
+  :commands (nix-repl-show))

--- a/modules/lang/nix/config.el
+++ b/modules/lang/nix/config.el
@@ -1,21 +1,16 @@
 ;;; config.el --- description -*- lexical-binding: t; -*-
 
-(def-package! company-nixos-options
-  :when (featurep! :completion company)
-  :after nix-mode
-  :config
-  (set-company-backend! 'nix-mode 'company-nixos-options))
-
 (def-package! nix-update
-  :after nix-mode
   :commands (nix-update-fetch))
 
 (def-package! nix-repl
-  :after nix-mode
   :commands (nix-repl-show))
 
-(def-package! nix-mode
-  :config
+(def-package! helm-nixos-options
+  :when (featurep! :completion helm)
+  :commands (helm-nixos-options))
+
+(after! nix-mode
   (map! :map nix-mode-map
         :localleader
         :n "f" #'nix-update-fetch
@@ -23,4 +18,12 @@
         :n "r" #'nix-repl-show
         :n "s" #'nix-shell
         :n "b" #'nix-build
-        :n "u" #'nix-unpack))
+        :n "u" #'nix-unpack)
+
+  (when (featurep! :completion helm)
+    (map! :map nix-mode-map
+          :localleader
+          :n "o" #'helm-nixos-options))
+
+  (when (featurep! :completion company)
+    (set-company-backend! 'nix-mode 'company-nixos-options)))

--- a/modules/lang/nix/config.el
+++ b/modules/lang/nix/config.el
@@ -5,3 +5,7 @@
   :after nix-mode
   :config
   (set-company-backend! 'nix-mode 'company-nixos-options))
+
+(def-package! nix-update
+  :after nix-mode
+  :commands (nix-update-fetch))

--- a/modules/lang/nix/config.el
+++ b/modules/lang/nix/config.el
@@ -1,0 +1,7 @@
+;;; config.el --- description -*- lexical-binding: t; -*-
+
+(def-package! company-nixos-options
+  :when (featurep! :completion company)
+  :after nix-mode
+  :config
+  (set-company-backend! 'nix-mode 'company-nixos-options))

--- a/modules/lang/nix/config.el
+++ b/modules/lang/nix/config.el
@@ -9,3 +9,7 @@
 (def-package! nix-update
   :after nix-mode
   :commands (nix-update-fetch))
+
+(def-package! nix-repl
+  :after nix-mode
+  :commands (nix-repl-show))

--- a/modules/lang/nix/config.el
+++ b/modules/lang/nix/config.el
@@ -13,3 +13,14 @@
 (def-package! nix-repl
   :after nix-mode
   :commands (nix-repl-show))
+
+(def-package! nix-mode
+  :config
+  (map! :map nix-mode-map
+        :localleader
+        :n "f" #'nix-update-fetch
+        :n "p" #'nix-format-buffer
+        :n "r" #'nix-repl-show
+        :n "s" #'nix-shell
+        :n "b" #'nix-build
+        :n "u" #'nix-unpack))

--- a/modules/lang/nix/doctor.el
+++ b/modules/lang/nix/doctor.el
@@ -1,6 +1,9 @@
 ;; -*- lexical-binding: t; no-byte-compile: t; -*-
 ;;; lang/nix/doctor.el
 
+(unless (executable-find "nix")
+  (warn! "Couldn't find the nix package manager. nix-mode won't work."))
+
 (unless (executable-find "nixfmt")
-  (warn! "Couldn't find nixfmt. nix-format-buffer won't work"))
+  (warn! "Couldn't find nixfmt. nix-format-buffer won't work."))
 

--- a/modules/lang/nix/doctor.el
+++ b/modules/lang/nix/doctor.el
@@ -1,0 +1,6 @@
+;; -*- lexical-binding: t; no-byte-compile: t; -*-
+;;; lang/nix/doctor.el
+
+(unless (executable-find "nixfmt")
+  (warn! "Couldn't find nixfmt. nix-format-buffer won't work"))
+

--- a/modules/lang/nix/packages.el
+++ b/modules/lang/nix/packages.el
@@ -2,7 +2,7 @@
 ;;; lang/nix/packages.el
 
 (package! nix-mode)
-(package! nix-update :recipe (:fetcher github :repo "jwiegley/nix-update-el"))
+(package! nix-update)
 
 (when (featurep! :completion company)
   (package! company-nixos-options))

--- a/modules/lang/nix/packages.el
+++ b/modules/lang/nix/packages.el
@@ -2,3 +2,6 @@
 ;;; lang/nix/packages.el
 
 (package! nix-mode)
+
+(when (featurep! :completion company)
+  (package! company-nixos-options))

--- a/modules/lang/nix/packages.el
+++ b/modules/lang/nix/packages.el
@@ -2,6 +2,7 @@
 ;;; lang/nix/packages.el
 
 (package! nix-mode)
+(package! nix-update :recipe (:fetcher github :repo "jwiegley/nix-update-el"))
 
 (when (featurep! :completion company)
   (package! company-nixos-options))

--- a/modules/lang/nix/packages.el
+++ b/modules/lang/nix/packages.el
@@ -2,7 +2,11 @@
 ;;; lang/nix/packages.el
 
 (package! nix-mode)
+
 (package! nix-update)
 
 (when (featurep! :completion company)
   (package! company-nixos-options))
+
+(when (featurep! :completion helm)
+  (package! helm-nixos-options))


### PR DESCRIPTION
- [x] Add company completion of NixOS options for `nix-mode`.
- [x] Add support for @jwiegley's `nix-update`
- [x] Make `nix-repl` available
- [x] Add major mode bindings
- [x] Add doctor check for `nix` and `nixfmt` executables

For future investigation:
  - [nix-company.el](https://github.com/NixOS/nix-mode/blob/master/nix-company.el) seems to be broken.
 - [nix-buffer](https://github.com/shlevy/nix-buffer) looks interesting but probably shouldn't be lazily loaded, due to its nature.
