### PR TITLE
Add support for the dhall configuration language

### DIFF
--- a/modules/lang/data/config.el
+++ b/modules/lang/data/config.el
@@ -25,6 +25,9 @@
         :desc "Kill fields" :nvm "k" #'csv-kill-fields
         :desc "Transpose fields" :nvm "t" #'csv-transpose))
 
+(def-package! dhall-mode
+  :mode "\\.dhall\\'")
+
 (def-package! graphql-mode
   :mode "\\.gql\\'")
 

--- a/modules/lang/data/packages.el
+++ b/modules/lang/data/packages.el
@@ -8,3 +8,4 @@
 (package! vimrc-mode)
 (package! yaml-mode)
 (package! csv-mode)
+(package! dhall-mode)


### PR DESCRIPTION
This collapses support for the [dhall configuration language](https://github.com/dhall-lang/dhall-lang) under the `data` module.


