### PR TITLE
minor haskell tweaks

### DIFF
--- a/modules/lang/haskell/config.el
+++ b/modules/lang/haskell/config.el
@@ -11,8 +11,11 @@
   :hook (haskell-mode . hindent-mode))
 
 (after! haskell-mode
+  (setq haskell-process-suggest-remove-import-lines t ;; warnings for redundant imports etc.
+        haskell-process-auto-import-loaded-modules t ;; auto import modules
+        haskell-process-show-overlays nil) ;;flycheck makes this unnecessary
   (add-hook 'haskell-mode-hook 'subword-mode) ;; improves text navigation with camelCase:
-  (add-hook 'haskell-mode-hook 'haskell-collapse-mode) ;; support collapsing haskell code blocks.
+  (add-hook 'haskell-mode-hook #'haskell-collapse-mode) ;; support collapsing haskell code blocks.
   (add-hook 'haskell-mode-hook #'interactive-haskell-mode)
   (set-lookup-handlers! 'haskell-mode :definition #'haskell-mode-jump-to-def-or-tag)
   (set-file-template! 'haskell-mode :trigger #'haskell-auto-insert-module-template :project t)
@@ -27,6 +30,6 @@
         :n "c" #'haskell-cabal-visit-file
         :n "p" #'hindent-reformat-buffer
         :v "p" #'hindent-reformat-region
-        :n "h" #'haskell-hide-toggle
-        :n "H" #'haskell-hide-toggle-all))
+        :v "h" #'haskell-hide-toggle
+        :nv "H" #'haskell-hide-toggle-all))
 

--- a/modules/lang/haskell/config.el
+++ b/modules/lang/haskell/config.el
@@ -13,8 +13,8 @@
 (after! haskell-mode
   (setq haskell-process-suggest-remove-import-lines t ;; warnings for redundant imports etc.
         haskell-process-auto-import-loaded-modules t) ;; auto import modules
-  (when! (featurep! :feature syntax-checker)
-         (setq haskell-process-show-overlays nil)) ;;flycheck makes this unnecessary
+  (when (featurep! :feature syntax-checker)
+    (setq haskell-process-show-overlays nil)) ;;flycheck makes this unnecessary
   (add-hook 'haskell-mode-hook 'subword-mode) ;; improves text navigation with camelCase:
   (add-hook 'haskell-mode-hook #'haskell-collapse-mode) ;; support collapsing haskell code blocks.
   (add-hook 'haskell-mode-hook #'interactive-haskell-mode)

--- a/modules/lang/haskell/config.el
+++ b/modules/lang/haskell/config.el
@@ -11,6 +11,7 @@
   :hook (haskell-mode . hindent-mode))
 
 (after! haskell-mode
+  (add-hook 'haskell-mode-hook 'subword-mode)
   (add-hook 'haskell-mode-hook #'interactive-haskell-mode)
   (set-lookup-handlers! 'haskell-mode :definition #'haskell-mode-jump-to-def-or-tag)
   (set-file-template! 'haskell-mode :trigger #'haskell-auto-insert-module-template :project t)

--- a/modules/lang/haskell/config.el
+++ b/modules/lang/haskell/config.el
@@ -12,8 +12,9 @@
 
 (after! haskell-mode
   (setq haskell-process-suggest-remove-import-lines t ;; warnings for redundant imports etc.
-        haskell-process-auto-import-loaded-modules t ;; auto import modules
-        haskell-process-show-overlays nil) ;;flycheck makes this unnecessary
+        haskell-process-auto-import-loaded-modules t) ;; auto import modules
+  (when! (featurep! :feature syntax-checker)
+         (setq haskell-process-show-overlays nil)) ;;flycheck makes this unnecessary
   (add-hook 'haskell-mode-hook 'subword-mode) ;; improves text navigation with camelCase:
   (add-hook 'haskell-mode-hook #'haskell-collapse-mode) ;; support collapsing haskell code blocks.
   (add-hook 'haskell-mode-hook #'interactive-haskell-mode)

--- a/modules/lang/haskell/config.el
+++ b/modules/lang/haskell/config.el
@@ -11,7 +11,8 @@
   :hook (haskell-mode . hindent-mode))
 
 (after! haskell-mode
-  (add-hook 'haskell-mode-hook 'subword-mode)
+  (add-hook 'haskell-mode-hook 'subword-mode) ;; improves text navigation with camelCase:
+  (add-hook 'haskell-mode-hook 'haskell-collapse-mode) ;; support collapsing haskell code blocks.
   (add-hook 'haskell-mode-hook #'interactive-haskell-mode)
   (set-lookup-handlers! 'haskell-mode :definition #'haskell-mode-jump-to-def-or-tag)
   (set-file-template! 'haskell-mode :trigger #'haskell-auto-insert-module-template :project t)
@@ -25,5 +26,7 @@
         :n "b" #'haskell-process-cabal-build
         :n "c" #'haskell-cabal-visit-file
         :n "p" #'hindent-reformat-buffer
-        :v "p" #'hindent-reformat-region))
+        :v "p" #'hindent-reformat-region
+        :n "h" #'haskell-hide-toggle
+        :n "H" #'haskell-hide-toggle-all))
 

--- a/modules/lang/haskell/config.el
+++ b/modules/lang/haskell/config.el
@@ -11,13 +11,14 @@
   :hook (haskell-mode . hindent-mode))
 
 (after! haskell-mode
-  (setq haskell-process-suggest-remove-import-lines t ;; warnings for redundant imports etc.
-        haskell-process-auto-import-loaded-modules t) ;; auto import modules
+  (setq haskell-process-suggest-remove-import-lines t  ; warnings for redundant imports etc
+        haskell-process-auto-import-loaded-modules t)
   (when (featurep! :feature syntax-checker)
-    (setq haskell-process-show-overlays nil)) ;;flycheck makes this unnecessary
-  (add-hook 'haskell-mode-hook 'subword-mode) ;; improves text navigation with camelCase:
-  (add-hook 'haskell-mode-hook #'haskell-collapse-mode) ;; support collapsing haskell code blocks.
-  (add-hook 'haskell-mode-hook #'interactive-haskell-mode)
+    (setq haskell-process-show-overlays nil))  ; flycheck makes this unnecessary
+  (add-hook! 'haskell-mode-hook 
+    #'(subword-mode           ; improves text navigation with camelCase
+       haskell-collapse-mode  ; support folding haskell code blocks
+       interactive-haskell-mode))
   (set-lookup-handlers! 'haskell-mode :definition #'haskell-mode-jump-to-def-or-tag)
   (set-file-template! 'haskell-mode :trigger #'haskell-auto-insert-module-template :project t)
   (set-repl-handler! '(haskell-mode haskell-cabal-mode literate-haskell-mode) #'+haskell-repl-buffer)


### PR DESCRIPTION
- [x] add a hook for `subword-mode` to make navigating with camelCase a breeze, since camelCase is a convention for functions and variables in haskell.
- [x] add support for code-block collapsing via `haskell-collapse-mode` (built into `haskell-mode`)
- [x] enable some benign and useful features [as recommended in the haskell-mode manual](http://haskell.github.io/haskell-mode/manual/latest/Interactive-Haskell.html#Interactive-Haskell).
- [x] allow flycheck to handle error popups if `:feature syntax-checker` is enabled.