### PR TITLE
Markdown tweaks

### DIFF
--- a/modules/lang/markdown/config.el
+++ b/modules/lang/markdown/config.el
@@ -14,7 +14,8 @@
         markdown-fontify-code-blocks-natively t
         markdown-hide-urls nil ; trigger with `markdown-toggle-url-hiding'
         markdown-enable-math ; syntax highlighting for latex fragments
-        markdown-gfm-uppercase-checkbox t ) ; compatibility with org-mode
+        markdown-gfm-uppercase-checkbox t ; for compat with org-mode
+        markdown-header-scaling t) ; fontify section headers
 
   :config
   (defun +markdown|set-fill-column-and-line-spacing ()

--- a/modules/lang/markdown/config.el
+++ b/modules/lang/markdown/config.el
@@ -12,7 +12,9 @@
         markdown-make-gfm-checkboxes-buttons t
         markdown-gfm-additional-languages '("sh")
         markdown-fontify-code-blocks-natively t
-        markdown-hide-urls nil) ; trigger with `markdown-toggle-url-hiding'
+        markdown-hide-urls nil ; trigger with `markdown-toggle-url-hiding'
+        markdown-enable-math ; syntax highlighting for latex fragments
+        markdown-gfm-uppercase-checkbox t ) ; compatibility with org-mode
 
   :config
   (defun +markdown|set-fill-column-and-line-spacing ()

--- a/modules/lang/markdown/config.el
+++ b/modules/lang/markdown/config.el
@@ -14,8 +14,7 @@
         markdown-fontify-code-blocks-natively t
         markdown-hide-urls nil ; trigger with `markdown-toggle-url-hiding'
         markdown-enable-math t ; syntax highlighting for latex fragments
-        markdown-gfm-uppercase-checkbox t ; for compat with org-mode
-        markdown-header-scaling t) ; fontify section headers
+        markdown-gfm-uppercase-checkbox t) ; for compat with org-mode
 
   :config
   (defun +markdown|set-fill-column-and-line-spacing ()

--- a/modules/lang/markdown/config.el
+++ b/modules/lang/markdown/config.el
@@ -13,7 +13,7 @@
         markdown-gfm-additional-languages '("sh")
         markdown-fontify-code-blocks-natively t
         markdown-hide-urls nil ; trigger with `markdown-toggle-url-hiding'
-        markdown-enable-math t; syntax highlighting for latex fragments
+        markdown-enable-math t ; syntax highlighting for latex fragments
         markdown-gfm-uppercase-checkbox t ; for compat with org-mode
         markdown-header-scaling t) ; fontify section headers
 

--- a/modules/lang/markdown/config.el
+++ b/modules/lang/markdown/config.el
@@ -13,7 +13,7 @@
         markdown-gfm-additional-languages '("sh")
         markdown-fontify-code-blocks-natively t
         markdown-hide-urls nil ; trigger with `markdown-toggle-url-hiding'
-        markdown-enable-math ; syntax highlighting for latex fragments
+        markdown-enable-math t; syntax highlighting for latex fragments
         markdown-gfm-uppercase-checkbox t ; for compat with org-mode
         markdown-header-scaling t) ; fontify section headers
 


### PR DESCRIPTION
Enables:
 - syntax highlighting of latex math fragments
 - org-mode compatible checkboxes