### PR TITLE
fix helm execute persistent action

### DIFF
--- a/modules/completion/helm/autoload/posframe.el
+++ b/modules/completion/helm/autoload/posframe.el
@@ -19,6 +19,7 @@ bottom, which is easier on the eyes on big displays."
   "TODO"
   (setq +helm--posframe-last-window (selected-window))
   (require 'posframe)
+  (setq helm--buffer-in-new-frame-p t)
   (posframe-show
    (setq +helm--posframe-buffer buffer)
    :poshandler +helm-posframe-handler


### PR DESCRIPTION
With (helm +childframe) in doom! section, without this patch
execute-persistent-action opens an extra non-child frame. This
doesn't play nicely with my tiling window manager.

This patch is taken from helm-posframe, and seems to fix it.

