### PR TITLE
Fix advice for `undo-tree-make-history-save-file-name'

### DIFF
--- a/core/core-editor.el
+++ b/core/core-editor.el
@@ -221,10 +221,11 @@ savehist file."
         `(("." . ,(concat doom-cache-dir "undo-tree-hist/"))))
   (global-undo-tree-mode +1)
 
-  ;; compress undo with xz
-  (advice-add #'undo-tree-make-history-save-file-name :filter-return
-              (cond ((executable-find "zstd") (lambda (file) (concat file ".zst")))
-                    ((executable-find "gzip") (lambda (file) (concat file ".gz")))))
+  ;; optionally compress undo with xz/gzip
+  (when (or (executable-find "zstd") (executable-find "gzip"))
+    (advice-add #'undo-tree-make-history-save-file-name :filter-return
+                (cond ((executable-find "zstd") (concat file ".zst"))
+                      ((executable-find "gzip") (concat file ".gz")))))
 
   (advice-add #'undo-tree-load-history :around #'doom*shut-up)
 


### PR DESCRIPTION
`:filter-return' expects a function to be given. If neither "zstd" nor "gzip" are found on the executable path, then it gets given nil instead, which results in sadness when trying to save files.

This is just the quick-and-dirty fix I made locally to fix the problem of not having either xz or gzip in the path (Windows problem).