### PR TITLE
Configurable sync backends for NotMuch

### DIFF
--- a/modules/app/notmuch/autoload.el
+++ b/modules/app/notmuch/autoload.el
@@ -35,7 +35,15 @@
   (interactive)
   (start-process-shell-command
    "notmuch update" nil
-   "cd ~/.mail/account.gmail && /usr/local/bin/gmi push && /usr/local/bin/gmi pull && /usr/local/bin/notmuch new && /usr/local/bin/afew -a -t"))
+   (pcase +notmuch-sync-backend
+     (`gmi
+      (concat "cd " +notmuch-mail-folder " && gmi push && gmi pull && notmuch new && afew -a -t"))
+     (`mbsync
+      "mbsync -a && notmuch new && afew -a -t")
+     (`mbsync-xdg
+      "mbsync -c \"$XDG_CONFIG_HOME\"/isync/mbsyncrc -a && notmuch new && afew -a -t")
+     (`offlineimap
+      "offlineimap && notmuch new && afew -a -t"))))
 
 ;;;###autoload
 (defun +notmuch/search-delete ()

--- a/modules/app/notmuch/config.el
+++ b/modules/app/notmuch/config.el
@@ -2,6 +2,12 @@
 
 ;; FIXME This module is a WIP!
 
+(defvar +notmuch-sync-backend 'gmi
+  "Which backend to use. Can be either gmi, mbsync, offlineimap or nil (manual).")
+
+(defvar +notmuch-mail-folder "~/.mail/account.gmail"
+  "Where your email folder is located (for use with gmailieer).")
+
 (after! notmuch
   (set-company-backend! 'notmuch-message-mode
     '(notmuch-company (company-ispell :with company-yasnippet)))


### PR DESCRIPTION
This is a simple fix to allow users to be able to specify the sync backend they
wish to use for NotMuch.