### PR TITLE
Fixed ess main load point

### DIFF
--- a/modules/lang/ess/config.el
+++ b/modules/lang/ess/config.el
@@ -30,6 +30,7 @@
          ("\\.[Jj][Oo][Gg]\\'" . ess-jags-mode)
          ("\\.[Jj][Mm][Dd]\\'" . ess-jags-mode))
   :init
+  (setq ess-smart-S-assign-key nil)
   (unless (featurep! :lang julia)
     (add-to-list 'auto-mode-alist '("\\.jl\\'" . ess-julia-mode)))
   :config
@@ -38,7 +39,6 @@
         ess-expression-offset 2
         ess-nuke-trailing-whitespace-p t
         ess-default-style 'DEFAULT)
-  (ess-toggle-underscore t)
   (set-repl-handler! 'ess-mode #'+ess/r-repl)
   (set-lookup-handlers! 'ess-mode :documentation #'ess-display-help-on-object)
   (define-key! ess-doc-map
@@ -78,8 +78,3 @@
         :n "cm"        #'ess-noweb-mark-chunk
         :n "cp"        #'ess-noweb-previous-chunk
         :n "cn"        #'ess-noweb-next-chunk))
-
-
-;; `ess-smart-equals-mode'
-(add-hook! '(ess-mode-hook inferior-ess-hook)
-  #'ess-smart-equals-mode)

--- a/modules/lang/ess/config.el
+++ b/modules/lang/ess/config.el
@@ -1,6 +1,6 @@
 ;;; lang/ess/config.el -*- lexical-binding: t; -*-
 
-(def-package! ess-site
+(def-package! ess-mode
   :commands (R stata julia SAS)
   :mode (("\\.sp\\'"           . S-mode)
          ("/R/.*\\.q\\'"       . R-mode)

--- a/modules/lang/ess/packages.el
+++ b/modules/lang/ess/packages.el
@@ -2,5 +2,4 @@
 ;;; lang/ess/packages.el
 
 (package! ess)
-(package! ess-smart-equals)
 (package! ess-R-data-view)


### PR DESCRIPTION
The ess loading point has been changed from ess-site to ess-mode as described here: https://github.com/emacs-ess/ESS/pull/404 and here https://github.com/emacs-ess/ESS/issues/589.

Additionally [emacs-smart-equals](https://github.com/genovese/ess-smart-equals) package is broken because ess has made ess-S-assign obsolete and an alternative called ess-assign-list introduced. I have removed the package and disabled the functionality of smart assignment.

I will probably try to create a pull request to fix the emacs-smart-equals package, but it doesn't seem to be active. so no guarantee that it will be accepted.