### PR TITLE
Fix running make from inside doom

### DIFF
--- a/bin/doom
+++ b/bin/doom
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-":"; EMACS=${EMACS:-emacs} # -*-emacs-lisp-*-
+":"; [[ $EMACS = *"term"* ]] && EMACS=emacs || EMACS=${EMACS:-emacs} # -*-emacs-lisp-*-
 ":"; command -v $EMACS >/dev/null || { >&2 echo "Emacs isn't installed"; exit 1; }
 ":"; VERSION=$($EMACS --version | head -n1)
 ":"; [[ $VERSION == *\ 2[0-2].[0-1].[0-9] ]] && { echo "You're running $VERSION"; echo "That version is too old to run Doom. Check your PATH"; echo; exit 2; }


### PR DESCRIPTION
The `term.el` package defines an environment variable `EMACS` inside its shell process, containing the Emacs and term.el version, in a string that looks like this: `26.1 (term:0.96)`. This interferes with the `bin/doom` command, which expects that environment variable to be a path to an Emacs binary. Trying to run make inside a doom terminal thus gives you this error:

```
Emacs isn't installed
make: *** [Makefile:5: all] Error 1
```

This simple fix just checks if `$EMACS` looks like a term version string, and ignores it if so.
