### PR TITLE
DONE: add coq module

### DIFF
--- a/modules/lang/coq/README.org
+++ b/modules/lang/coq/README.org
@@ -1,13 +1,3 @@
 #+TITLE: :lang coq
 
 This module adds [[https://coq.inria.fr][coq]] support, powered by [[https://proofgeneral.github.io][Proof General]], with code completion via [[https://github.com/cpitclaudel/company-coq][company-coq]].
-
-* Install
-Unfortunately, Proof General needs to be installed manually.
-
-#+BEGIN_SRC sh
-git clone https://github.com/ProofGeneral/PG $PG-LOC && cd $PG-LOC
-make
-#+END_SRC
-
-Manually set the variable ~+coq-pg-loc~ to the value of $PG-LOC in your doom config.

--- a/modules/lang/coq/README.org
+++ b/modules/lang/coq/README.org
@@ -1,0 +1,13 @@
+#+TITLE: :lang coq
+
+This module adds [[https://coq.inria.fr][coq]] support, powered by [[https://proofgeneral.github.io][Proof General]], with code completion via [[https://github.com/cpitclaudel/company-coq][company-coq]].
+
+* Install
+Unfortunately, Proof General needs to be installed manually.
+
+#+BEGIN_SRC sh
+git clone https://github.com/ProofGeneral/PG $PG-LOC && cd $PG-LOC
+make
+#+END_SRC
+
+Manually set the variable ~+coq-pg-loc~ to the value of $PG-LOC in your doom config.

--- a/modules/lang/coq/autoload.el
+++ b/modules/lang/coq/autoload.el
@@ -1,0 +1,4 @@
+;;; lang/coq/autoload.el -*- lexical-binding: t; -*-
+
+;;;###autoload
+(add-hook 'coq-mode-hook #'company-coq-mode)

--- a/modules/lang/coq/config.el
+++ b/modules/lang/coq/config.el
@@ -1,0 +1,9 @@
+;;; lang/coq/config.el -*- lexical-binding: t; -*-
+
+(defvar +coq-pg-loc "/home/patrl/GitHub/PG/generic")
+
+(def-package! proof-site
+  :load-path +coq-pg-loc
+  :defer t
+  :mode ("\\.v\\'" . coq-mode)
+  :hook (coq-mode . company-coq-mode))

--- a/modules/lang/coq/config.el
+++ b/modules/lang/coq/config.el
@@ -1,8 +1,5 @@
 ;;; lang/coq/config.el -*- lexical-binding: t; -*-
 
-;; set this to the absolute path of the folder containing proof-site.el, e.g. /home/$USER/GitHub/PG/generic
-(defvar +coq-pg-loc nil)
-
 (def-package! proof-site
   :load-path +coq-pg-loc
   :defer t

--- a/modules/lang/coq/config.el
+++ b/modules/lang/coq/config.el
@@ -1,6 +1,7 @@
 ;;; lang/coq/config.el -*- lexical-binding: t; -*-
 
-(defvar +coq-pg-loc "/home/patrl/GitHub/PG/generic")
+;; set this to the absolute path of the folder containing proof-site.el, e.g. /home/$USER/GitHub/PG/generic
+(defvar +coq-pg-loc nil)
 
 (def-package! proof-site
   :load-path +coq-pg-loc

--- a/modules/lang/coq/config.el
+++ b/modules/lang/coq/config.el
@@ -1,5 +1,0 @@
-;;; lang/coq/config.el -*- lexical-binding: t; -*-
-
-(def-package! proof-site
-  :mode ("\\.v\\'" . coq-mode)
-  :hook (coq-mode . company-coq-mode))

--- a/modules/lang/coq/config.el
+++ b/modules/lang/coq/config.el
@@ -1,7 +1,5 @@
 ;;; lang/coq/config.el -*- lexical-binding: t; -*-
 
 (def-package! proof-site
-  :load-path +coq-pg-loc
-  :defer t
   :mode ("\\.v\\'" . coq-mode)
   :hook (coq-mode . company-coq-mode))

--- a/modules/lang/coq/packages.el
+++ b/modules/lang/coq/packages.el
@@ -1,0 +1,4 @@
+;; -*- no-byte-compile: t; -*-
+;;; lang/coq/packages.el
+
+(package! company-coq)

--- a/modules/lang/coq/packages.el
+++ b/modules/lang/coq/packages.el
@@ -1,4 +1,6 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; lang/coq/packages.el
 
+(package! proof-general :recipe (:fetcher github :repo "ProofGeneral/PG" :files ("*")))
+
 (package! company-coq)


### PR DESCRIPTION
Adds basic support for the coq proof assistant via proof general (sadly, not packaged on elpa/melpa) and company-coq.
