### PR TITLE
:lang agda (done)

### DIFF
--- a/modules/lang/agda/README.org
+++ b/modules/lang/agda/README.org
@@ -1,0 +1,9 @@
+#+TITLE: :lang agda
+
+This module adds support for the [[http://wiki.portal.chalmers.se/agda/pmwiki.php][agda]] programming language.
+
+Emacs support is included in the agda release (you can find installation
+instructions [[https://agda.readthedocs.io/en/latest/getting-started/installation.html][here]]). This module attempts to find the location of ~agda2.el~ via
+the ~agda-mode locate~ command that comes with the agda release. Users can set
+this manually by setting the ~+agda2-dir~ variable. 
+

--- a/modules/lang/agda/config.el
+++ b/modules/lang/agda/config.el
@@ -1,7 +1,7 @@
 ;;; lang/agda/config.el -*- lexical-binding: t; -*-
 
 (defvar +agda-dir
-  (when (executable-find "adga-mode")
+  (when (executable-find "agda-mode")
     (file-name-directory (shell-command-to-string "agda-mode locate")))
   "TODO")
 

--- a/modules/lang/agda/config.el
+++ b/modules/lang/agda/config.el
@@ -2,10 +2,18 @@
 
 (defvar +agda-dir
   (when (executable-find "agda-mode")
-    (file-name-directory (shell-command-to-string "agda-mode locate")))
-  "TODO")
+    (file-name-directory (shell-command-to-string "agda-mode locate"))))
 
+(def-package! agda-input
+  :load-path +agda-dir)
 
-(def-package! agda2
-  :load-path +agda-dir
-  :defer t)
+(def-package! agda2-mode
+  :mode "\\.agda\\'"
+  :after agda-input
+  :config
+  (map! :map agda2-mode-map
+                :localleader
+                :n "l" #'agda2-load
+                :n "d" #'agda2-infer-type-maybe-toplevel
+                :n "o" #'agda2-module-contents-maybe-toplevel
+                :n "n" #'agda2-compute-normalised-maybe-toplevel))

--- a/modules/lang/agda/config.el
+++ b/modules/lang/agda/config.el
@@ -11,8 +11,7 @@
   :mode "\\.agda\\'"
   :after agda-input
   :init
-  ;; fix syntax highlighting
-  ;; (taken from https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Blang/agda/packages.el)
+  ;; make syntax-highlighting more consistent with other major modes
    (progn
         (mapc
          (lambda (x) (add-to-list 'face-remapping-alist x))
@@ -32,7 +31,14 @@
            (agda2-highlight-primitive-face               . font-lock-type-face)
            (agda2-highlight-macro-face                   . font-lock-function-name-face)
            (agda2-highlight-record-face                  . font-lock-type-face)
-           (agda2-highlight-error-face                   . font-lock-warning-face))))
+           (agda2-highlight-error-face                   . font-lock-warning-face)
+           (agda2-highlight-dotted-face                  . font-lock-variable-name-face)
+           (agda2-highlight-unsolved-meta-face           . font-lock-warning-face)
+           (agda2-highlight-unsolved-constraint-face     . font-lock-warning-face)
+           (agda2-highlight-termination-problem-face     . font-lock-warning-face)
+           (agda2-highlight-positivity-problem-face      . font-lock-warning-face)
+           (agda2-highlight-incomplete-pattern-face      . font-lock-warning-face)
+           (agda2-highlight-typechecks-face              . font-lock-warning-face))))
   :config
   (map! :map agda2-mode-map
                 :localleader

--- a/modules/lang/agda/config.el
+++ b/modules/lang/agda/config.el
@@ -41,9 +41,27 @@
            (agda2-highlight-typechecks-face              . font-lock-warning-face))))
   :config
   (map! :map agda2-mode-map
-                :localleader
-                :n "l" #'agda2-load
-                :n "d" #'agda2-infer-type-maybe-toplevel
-                :n "o" #'agda2-module-contents-maybe-toplevel
-                :n "n" #'agda2-compute-normalised-maybe-toplevel))
-  ;; TODO finish keybindings
+        :localleader
+        :n "?"  #'agda2-show-goals
+        :n "."  #'agda2-goal-and-context-and-inferred
+        :n ","   #'agda2-goal-and-context
+        :n "="   #'agda2-show-constraints
+        :n "SPC" #'agda2-give
+        :n "a"   #'agda2-auto
+        :n "c"   #'agda2-make-case
+        :n "d"   #'agda2-infer-type-maybe-toplevel
+        :n "e"   #'agda2-show-context
+        :n "gG"  #'agda2-go-back
+        :n "h"   #'agda2-helper-function-type
+        :n "l"   #'agda2-load
+        :n "n"  #'agda2-compute-normalised-maybe-toplevel
+        :n "p"  #'agda2-module-contents-maybe-toplevel
+        :n "r"  #'agda2-refine
+        :n "s"  #'agda2-solveAll
+        :n "t"  #'agda2-goal-type
+        :n "w"  #'agda2-why-in-scope-maybe-toplevel
+        :n "xc" #'agda2-compile
+        :n "xd" #'agda2-remove-annotations
+        :n "xh" #'agda2-display-implicit-arguments
+        :n "xq" #'agda2-quit
+        :n "xr" #'agda2-restart))

--- a/modules/lang/agda/config.el
+++ b/modules/lang/agda/config.el
@@ -4,41 +4,12 @@
   (when (executable-find "agda-mode")
     (file-name-directory (shell-command-to-string "agda-mode locate"))))
 
-(def-package! agda-input
+(def-package! agda2
+  :when +agda-dir
   :load-path +agda-dir)
 
 (def-package! agda2-mode
-  :mode "\\.agda\\'"
-  :after agda-input
-  :init
-  ;; make syntax-highlighting more consistent with other major modes
-   (progn
-        (mapc
-         (lambda (x) (add-to-list 'face-remapping-alist x))
-         '((agda2-highlight-keyword-face                 . font-lock-keyword-face)
-           (agda2-highlight-string-face                  . font-lock-string-face)
-           (agda2-highlight-number-face                  . font-lock-string-face)
-           (agda2-highlight-symbol-face                  . font-lock-variable-name-face)
-           (agda2-highlight-primitive-type-face          . font-lock-type-face)
-           (agda2-highlight-bound-variable-face          . font-lock-variable-name-face)
-           (agda2-highlight-inductive-constructor-face   . font-lock-type-face)
-           (agda2-highlight-coinductive-constructor-face . font-lock-type-face)
-           (agda2-highlight-datatype-face                . font-lock-type-face)
-           (agda2-highlight-field-face                   . font-lock-type-face)
-           (agda2-highlight-function-face                . font-lock-function-name-face)
-           (agda2-highlight-module-face                  . font-lock-variable-name-face)
-           (agda2-highlight-postulate-face               . font-lock-type-face)
-           (agda2-highlight-primitive-face               . font-lock-type-face)
-           (agda2-highlight-macro-face                   . font-lock-function-name-face)
-           (agda2-highlight-record-face                  . font-lock-type-face)
-           (agda2-highlight-error-face                   . font-lock-warning-face)
-           (agda2-highlight-dotted-face                  . font-lock-variable-name-face)
-           (agda2-highlight-unsolved-meta-face           . font-lock-warning-face)
-           (agda2-highlight-unsolved-constraint-face     . font-lock-warning-face)
-           (agda2-highlight-termination-problem-face     . font-lock-warning-face)
-           (agda2-highlight-positivity-problem-face      . font-lock-warning-face)
-           (agda2-highlight-incomplete-pattern-face      . font-lock-warning-face)
-           (agda2-highlight-typechecks-face              . font-lock-warning-face))))
+  :defer t
   :config
   (map! :map agda2-mode-map
         :localleader

--- a/modules/lang/agda/config.el
+++ b/modules/lang/agda/config.el
@@ -1,0 +1,7 @@
+;;; lang/agda/config.el -*- lexical-binding: t; -*-
+
+(defvar +agda-dir (string-remove-suffix "/agda2.el" (shell-command-to-string "agda-mode locate")))
+
+(def-package! agda2
+  :load-path +agda-dir)
+

--- a/modules/lang/agda/config.el
+++ b/modules/lang/agda/config.el
@@ -1,7 +1,11 @@
 ;;; lang/agda/config.el -*- lexical-binding: t; -*-
 
-(defvar +agda-dir (string-remove-suffix "/agda2.el" (shell-command-to-string "agda-mode locate")))
+(defvar +agda-dir
+  (when (executable-find "adga-mode")
+    (file-name-directory (shell-command-to-string "agda-mode locate")))
+  "TODO")
+
 
 (def-package! agda2
-  :load-path +agda-dir)
-
+  :load-path +agda-dir
+  :defer t)

--- a/modules/lang/agda/config.el
+++ b/modules/lang/agda/config.el
@@ -10,6 +10,21 @@
 (def-package! agda2-mode
   :mode "\\.agda\\'"
   :after agda-input
+  :init
+  ;; fix syntax highlighting
+  ;; (taken from https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Blang/agda/packages.el)
+   (progn
+        (mapc
+         (lambda (x) (add-to-list 'face-remapping-alist x))
+         '((agda2-highlight-datatype-face              . font-lock-type-face)
+           (agda2-highlight-function-face              . font-lock-type-face)
+           (agda2-highlight-inductive-constructor-face . font-lock-function-name-face)
+           (agda2-highlight-keyword-face               . font-lock-keyword-face)
+           (agda2-highlight-module-face                . font-lock-constant-face)
+           (agda2-highlight-number-face                . nil)
+           (agda2-highlight-postulate-face             . font-lock-type-face)
+           (agda2-highlight-primitive-type-face        . font-lock-type-face)
+           (agda2-highlight-record-face                . font-lock-type-face))))
   :config
   (map! :map agda2-mode-map
                 :localleader
@@ -17,3 +32,4 @@
                 :n "d" #'agda2-infer-type-maybe-toplevel
                 :n "o" #'agda2-module-contents-maybe-toplevel
                 :n "n" #'agda2-compute-normalised-maybe-toplevel))
+  ;; TODO finish keybindings

--- a/modules/lang/agda/config.el
+++ b/modules/lang/agda/config.el
@@ -16,15 +16,23 @@
    (progn
         (mapc
          (lambda (x) (add-to-list 'face-remapping-alist x))
-         '((agda2-highlight-datatype-face              . font-lock-type-face)
-           (agda2-highlight-function-face              . font-lock-type-face)
-           (agda2-highlight-inductive-constructor-face . font-lock-function-name-face)
-           (agda2-highlight-keyword-face               . font-lock-keyword-face)
-           (agda2-highlight-module-face                . font-lock-constant-face)
-           (agda2-highlight-number-face                . nil)
-           (agda2-highlight-postulate-face             . font-lock-type-face)
-           (agda2-highlight-primitive-type-face        . font-lock-type-face)
-           (agda2-highlight-record-face                . font-lock-type-face))))
+         '((agda2-highlight-keyword-face                 . font-lock-keyword-face)
+           (agda2-highlight-string-face                  . font-lock-string-face)
+           (agda2-highlight-number-face                  . font-lock-string-face)
+           (agda2-highlight-symbol-face                  . font-lock-variable-name-face)
+           (agda2-highlight-primitive-type-face          . font-lock-type-face)
+           (agda2-highlight-bound-variable-face          . font-lock-variable-name-face)
+           (agda2-highlight-inductive-constructor-face   . font-lock-type-face)
+           (agda2-highlight-coinductive-constructor-face . font-lock-type-face)
+           (agda2-highlight-datatype-face                . font-lock-type-face)
+           (agda2-highlight-field-face                   . font-lock-type-face)
+           (agda2-highlight-function-face                . font-lock-function-name-face)
+           (agda2-highlight-module-face                  . font-lock-variable-name-face)
+           (agda2-highlight-postulate-face               . font-lock-type-face)
+           (agda2-highlight-primitive-face               . font-lock-type-face)
+           (agda2-highlight-macro-face                   . font-lock-function-name-face)
+           (agda2-highlight-record-face                  . font-lock-type-face)
+           (agda2-highlight-error-face                   . font-lock-warning-face))))
   :config
   (map! :map agda2-mode-map
                 :localleader

--- a/modules/lang/agda/doctor.el
+++ b/modules/lang/agda/doctor.el
@@ -1,0 +1,5 @@
+;; -*- lexical-binding: t; no-byte-compile: t; -*-
+;;; lang/agda/doctor.el
+
+(unless (executable-find "agda-mode")
+  (warn! "Couldn't find agda-mode. Agda support won't work"))


### PR DESCRIPTION
This PR adds basic support for the agda language. Since `agda2-mode` isn't packaged on (m)elpa, but instead accompanies each agda release, this module automatically finds the location of the emacs support files via the built-in `agda-mode locate` command. If the user doesn't have agda installed, this naturally won't work.

A couple of modifications are made to upstream `agda-mode`:
- local leader keybindings
- colorscheme agnostic syntax highlighting, mostly based on haskell and idris