### PR TITLE
Put company-coq behind conditional

### DIFF
--- a/modules/lang/coq/autoload.el
+++ b/modules/lang/coq/autoload.el
@@ -1,4 +1,5 @@
 ;;; lang/coq/autoload.el -*- lexical-binding: t; -*-
+;;;###if (featurep! :completion company)
 
 ;;;###autoload
 (add-hook 'coq-mode-hook #'company-coq-mode)

--- a/modules/lang/coq/packages.el
+++ b/modules/lang/coq/packages.el
@@ -3,4 +3,5 @@
 
 (package! proof-general :recipe (:fetcher github :repo "ProofGeneral/PG" :files ("*")))
 
-(package! company-coq)
+(when (featurep! :completion company)
+  (package! company-coq))


### PR DESCRIPTION
`company-coq` is now only loaded if company is enabled.
