### PR TITLE
helm-buffers-list -> helm-mini

### DIFF
--- a/modules/completion/helm/config.el
+++ b/modules/completion/helm/config.el
@@ -51,7 +51,7 @@ be negative.")
     [remap imenu]                     #'helm-semantic-or-imenu
     [remap noop-show-kill-ring]       #'helm-show-kill-ring
     [remap persp-switch-to-buffer]    #'+helm/workspace-mini
-    [remap switch-to-buffer]          #'helm-buffers-list
+    [remap switch-to-buffer]          #'helm-mini
     [remap projectile-find-file]      #'+helm/projectile-find-file
     [remap projectile-recentf]        #'helm-projectile-recentf
     [remap projectile-switch-project] #'helm-projectile-switch-project


### PR DESCRIPTION
helm-mini is a better version of helm-buffers-list: https://github.com/emacs-helm/helm/wiki/Buffers:
> The helm-mini command displays buffers and **recently visited files**. It may be more useful than helm-buffers-list.

> Tip
> Use helm-mini instead of helm-buffers-list.