### PR TITLE
Company-coq tweaks

### DIFF
--- a/modules/lang/coq/autoload.el
+++ b/modules/lang/coq/autoload.el
@@ -1,5 +1,4 @@
 ;;; lang/coq/autoload.el -*- lexical-binding: t; -*-
-;;;###if (featurep! :completion company)
 
 ;;;###autoload
 (add-hook 'coq-mode-hook #'company-coq-mode)

--- a/modules/lang/coq/config.el
+++ b/modules/lang/coq/config.el
@@ -1,7 +1,7 @@
 ;;; lang/coq/config.el -*- lexical-binding: t; -*-
 
-(after! coq
-  (setq proof-electric-terminator-enable t))
+;; `coq'
+(setq proof-electric-terminator-enable t)
 
 (after! company-coq
   (set-lookup-handlers! 'company-coq-mode

--- a/modules/lang/coq/config.el
+++ b/modules/lang/coq/config.el
@@ -1,0 +1,5 @@
+;;; lang/coq/config.el -*- lexical-binding: t; -*-
+
+(after! company-coq
+  (when (not (featurep! :completion company))
+    (setq company-coq-disabled-features '(company company-defaults))))

--- a/modules/lang/coq/config.el
+++ b/modules/lang/coq/config.el
@@ -3,7 +3,7 @@
 (after! company-coq
   (set-lookup-handlers! 'company-coq-mode
     :definition #'company-coq-jump-to-definition
-    :references #'company-coq-occur
+    :references #'company-coq-grep-symbol
     :documentation #'company-coq-doc)
   (when (not (featurep! :completion company))
     (setq company-coq-disabled-features '(company company-defaults))))

--- a/modules/lang/coq/config.el
+++ b/modules/lang/coq/config.el
@@ -8,5 +8,5 @@
     :definition #'company-coq-jump-to-definition
     :references #'company-coq-grep-symbol
     :documentation #'company-coq-doc)
-  (when (not (featurep! :completion company))
+  (unless (featurep! :completion company)
     (setq company-coq-disabled-features '(company company-defaults))))

--- a/modules/lang/coq/config.el
+++ b/modules/lang/coq/config.el
@@ -1,5 +1,9 @@
 ;;; lang/coq/config.el -*- lexical-binding: t; -*-
 
 (after! company-coq
+  (set-lookup-handlers! 'company-coq-mode
+    :definition #'company-coq-jump-to-definition
+    :references #'company-coq-occur
+    :documentation #'company-coq-doc)
   (when (not (featurep! :completion company))
     (setq company-coq-disabled-features '(company company-defaults))))

--- a/modules/lang/coq/config.el
+++ b/modules/lang/coq/config.el
@@ -1,5 +1,8 @@
 ;;; lang/coq/config.el -*- lexical-binding: t; -*-
 
+(after! coq
+  (setq proof-electric-terminator-enable t))
+
 (after! company-coq
   (set-lookup-handlers! 'company-coq-mode
     :definition #'company-coq-jump-to-definition

--- a/modules/lang/coq/packages.el
+++ b/modules/lang/coq/packages.el
@@ -3,5 +3,4 @@
 
 (package! proof-general :recipe (:fetcher github :repo "ProofGeneral/PG" :files ("*")))
 
-(when (featurep! :completion company)
-  (package! company-coq))
+(package! company-coq)


### PR DESCRIPTION
`company-coq` does more than just provide company completion.

- define lookup handlers based on `company-coq` functions.
- disable company features if company is disabled.

