### PR TITLE
Add flycheck-credo for lang/elixir

### DIFF
--- a/modules/lang/elixir/config.el
+++ b/modules/lang/elixir/config.el
@@ -38,3 +38,7 @@
   (set-eval-handler! 'elixir-mode #'alchemist-eval-region)
   (set-repl-handler! 'elixir-mode #'alchemist-iex-project-run))
 
+(def-package! flycheck-credo
+  :when (featurep! :feature syntax-checker)
+  :after flycheck
+  :config (flycheck-credo-setup))

--- a/modules/lang/elixir/packages.el
+++ b/modules/lang/elixir/packages.el
@@ -4,3 +4,4 @@
 ;; +elixir.el
 (package! elixir-mode)
 (package! alchemist)
+(package! flycheck-credo)


### PR DESCRIPTION
As discussed in Discord I added the credo flycheck to lang/elixir. It seems reasonably fast and should be safe. It will only run when the Elixir project contains the credo dependency, but this is the expected way of installation for credo anyway. Projects that miss this dependency simply don't get checked by the checker.