### PR TITLE
proof-general now on melpa

### DIFF
--- a/modules/lang/coq/packages.el
+++ b/modules/lang/coq/packages.el
@@ -1,6 +1,6 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; lang/coq/packages.el
 
-(package! proof-general :recipe (:fetcher github :repo "ProofGeneral/PG" :files ("*")))
+(package! proof-general)
 
 (package! company-coq)


### PR DESCRIPTION
Proof-general no longer has to be loaded via quelpa's git fetcher.

https://melpa.org/#/proof-general