### PR TITLE
Improve +fci|disable-when-company-activates

### DIFF
--- a/modules/ui/fci/autoload.el
+++ b/modules/ui/fci/autoload.el
@@ -5,8 +5,7 @@
 ;;;###autoload
 (defun +fci|disable-when-company-activates (&rest ignore)
   "TODO"
-  (setq +fci-last-state fci-mode)
-  (when fci-mode
+  (when (setq +fci-last-state (bound-and-true-p fci-mode))
     (fci-mode -1)))
 
 ;;;###autoload


### PR DESCRIPTION
Hello, and sorry for my poor English...

I think this change avoids the error caused when the variable `fci-mode` is void.

Thanks.