### PR TITLE
Load .elc even for themes

### DIFF
--- a/core/core-ui.el
+++ b/core/core-ui.el
@@ -448,6 +448,16 @@ instead). Meant for `kill-buffer-query-functions'."
     (powerline-reset)))
 (advice-add #'load-theme :around #'doom*disable-old-themes-first)
 
+(defun doom*prefer-compiled-theme (orig-fn &rest args)
+  "Make `load-theme' prioritize the byte-compiled theme (if it exists) for a
+moderate boost in startup (or theme switch) time."
+  (cl-letf* ((old-locate-file (symbol-function 'locate-file))
+             ((symbol-function 'locate-file)
+              (lambda (filename path &optional _suffixes predicate)
+                (funcall old-locate-file filename path '("c" "") predicate))))
+    (apply orig-fn args)))
+(advice-add #'load-theme :around #'doom*prefer-compiled-theme)
+
 (defun doom|disable-whitespace-mode-in-childframes (frame)
   (when (frame-parameter frame 'parent-frame)
     (with-selected-frame frame


### PR DESCRIPTION
Even when an `.elc` is preset `load-theme` would attempt to load the `.el` first,
to give the opportunity to inspect the theme.
However we are loading themes automatically from (M)ELPA, and loading a
theme package is no more dangerous than loading a regular package.

So override the search order for themes and atttempt to load the `.elc`
first.
This looks a bit ugly, but improves startup time by ~25ms with the default theme.
