### PR TITLE
Deactivate expansion of abbreviations (ProofGeneral/Coq)

### DIFF
--- a/modules/lang/coq/README.org
+++ b/modules/lang/coq/README.org
@@ -1,3 +1,6 @@
 #+TITLE: :lang coq
 
-This module adds [[https://coq.inria.fr][coq]] support, powered by [[https://proofgeneral.github.io][Proof General]], with code completion via [[https://github.com/cpitclaudel/company-coq][company-coq]].
+This module adds [[https://coq.inria.fr][coq]] support, powered by [[https://proofgeneral.github.io][Proof General]].
+
++ Code completion ([[https://github.com/cpitclaudel/company-coq][company-coq]])
++ [[https://github.com/hlissner/emacs-snippets/tree/master/coq-mode][Snippets]]

--- a/modules/lang/coq/config.el
+++ b/modules/lang/coq/config.el
@@ -3,6 +3,8 @@
 ;; `coq'
 (setq proof-electric-terminator-enable t)
 
+(setq coq-mode-abbrev-table '())
+
 (after! company-coq
   (set-lookup-handlers! 'company-coq-mode
     :definition #'company-coq-jump-to-definition


### PR DESCRIPTION
This line deactivates the expansion of abbreviations since it is hard to work with Coq in evil mode when this is active. For example, if my cursor is next to the letter L and I hit escape, it gets expanded to: `
Lemma # : #.
  Proof.
     #
  Qed.
`
That makes it hard to work with ProofGeneral.
The solution I found is from a [ProofGeneral Github issue](https://github.com/ProofGeneral/PG/issues/174). I was not sure where to add the line. Apparently it has to be before loading evil-mode.

Let me know if you want me to add it in a different place or just close the PR if you don't want to have this at all.

Thank you for your work. I really enjoy using emacs using doom.
