### PR TITLE
Fix race condition in popup load

### DIFF
--- a/modules/ui/popup/autoload/settings.el
+++ b/modules/ui/popup/autoload/settings.el
@@ -1,5 +1,6 @@
 ;;; ui/popup/autoload/settings.el -*- lexical-binding: t; -*-
 
+;;;###autoload
 (defvar +popup--display-buffer-alist nil)
 
 ;;;###autoload


### PR DESCRIPTION
When compiling everything I got this on Emacs startup:
```
Debugger entered--Lisp error: (void-variable +popup--display-buffer-alist)
  (setq +popup--old-display-buffer-alist display-buffer-alist display-buffer-alist +popup--display-buffer-alist window--sides-inhibit-check t)
  (cond (+popup-mode (add-hook 'doom-escape-hook (function +popup|close-on-escape) t) (add-hook 'doom-cleanup-hook (function +popup|cleanup-rules)) (setq +popup--old-display-buffer-alist display-buffer-alist display-buffer-alist +popup--display-buffer-alist window--sides-inhibit-check t) (let ((--dolist-tail-- +popup-window-parameters)) (while --dolist-tail-- (let ((prop (car --dolist-tail--))) (setq window-persistent-parameters (cons (cons prop 'writable) window-persistent-parameters)) (setq --dolist-tail-- (cdr --dolist-tail--)))))) (t (remove-hook 'doom-escape-hook (function +popup|close-on-escape)) (remove-hook 'doom-cleanup-hook (function +popup|cleanup-rules)) (setq display-buffer-alist +popup--old-display-buffer-alist window--sides-inhibit-check nil) (+popup|cleanup-rules) (let ((--dolist-tail-- +popup-window-parameters)) (while --dolist-tail-- (let ((prop (car --dolist-tail--))) (delq (assq prop window-persistent-parameters) window-persistent-parameters) (setq --dolist-tail-- (cdr --dolist-tail--)))))))
  (let ((last-message (current-message))) (setq-default +popup-mode (if (eq arg 'toggle) (not (default-value '+popup-mode)) (> (prefix-numeric-value arg) 0))) (cond (+popup-mode (add-hook 'doom-escape-hook (function +popup|close-on-escape) t) (add-hook 'doom-cleanup-hook (function +popup|cleanup-rules)) (setq +popup--old-display-buffer-alist display-buffer-alist display-buffer-alist +popup--display-buffer-alist window--sides-inhibit-check t) (let ((--dolist-tail-- +popup-window-parameters)) (while --dolist-tail-- (let ((prop (car --dolist-tail--))) (setq window-persistent-parameters (cons (cons prop 'writable) window-persistent-parameters)) (setq --dolist-tail-- (cdr --dolist-tail--)))))) (t (remove-hook 'doom-escape-hook (function +popup|close-on-escape)) (remove-hook 'doom-cleanup-hook (function +popup|cleanup-rules)) (setq display-buffer-alist +popup--old-display-buffer-alist window--sides-inhibit-check nil) (+popup|cleanup-rules) (let ((--dolist-tail-- +popup-window-parameters)) (while --dolist-tail-- (let ((prop (car --dolist-tail--))) (delq (assq prop window-persistent-parameters) window-persistent-parameters) (setq --dolist-tail-- (cdr --dolist-tail--))))))) (run-hooks '+popup-mode-hook (if (default-value '+popup-mode) '+popup-mode-on-hook '+popup-mode-off-hook)) (if (called-interactively-p 'any) (progn (customize-mark-as-set '+popup-mode) (if (and (current-message) (not (equal last-message (current-message)))) nil (let ((local "")) (message "+Popup mode %sabled%s" (if (default-value '+popup-mode) "en" "dis") local))))))
  +popup-mode()
  doom-try-run-hook(+popup-mode)
  run-hook-wrapped(doom-try-run-hook +popup-mode)
  doom|init-ui()
  run-hooks(emacs-startup-hook term-setup-hook)
  #f(compiled-function () #<bytecode 0x46c615>)()
  normal-top-level()
```

Signed-off-by: Edwin Török <edwin@etorok.net>

Thank you for contributing to Doom!

Before you submit this PR, please make sure your PR is targeted at develop, not
master (unless this is a fix for a critical error). Then replace this message
with a description of your changes.
