### PR TITLE
Emacs27+: reduce number of GCs on startup from 4 to 1

### DIFF
--- a/early-init.el
+++ b/early-init.el
@@ -3,6 +3,12 @@
 ;; Emacs HEAD (27+) introduces early-init.el, which is run before init.el,
 ;; before package and UI initialization happens.
 
+
+(defconst doom-gc-cons-upper-limit 268435456 ; 256mb
+          "The temporary value for `gc-cons-threshold' to defer it.")
+;; This reduces gcs-done from 4 to 1 on startup
+(setq gc-cons-threshold doom-gc-cons-upper-limit)
+
 ;; Package initialize occurs automatically, before `user-init-file' is
 ;; loaded, but after `early-init-file'. Doom handles package
 ;; initialization, so we must prevent Emacs from doing it early!

--- a/early-init.el
+++ b/early-init.el
@@ -3,11 +3,8 @@
 ;; Emacs HEAD (27+) introduces early-init.el, which is run before init.el,
 ;; before package and UI initialization happens.
 
-
-(defconst doom-gc-cons-upper-limit 268435456 ; 256mb
-          "The temporary value for `gc-cons-threshold' to defer it.")
-;; This reduces gcs-done from 4 to 1 on startup
-(setq gc-cons-threshold doom-gc-cons-upper-limit)
+;; Defer garbage collection further back in the startup process
+(setq gc-cons-threshold 268435456)
 
 ;; Package initialize occurs automatically, before `user-init-file' is
 ;; loaded, but after `early-init-file'. Doom handles package


### PR DESCRIPTION
describe-variables `gcs-done`, it used to be 4, now it is 1.

Unfortunately `emacs-snapshot` segfaults when compiling doom twice, so I'm  back to Emacs26.
