### PR TITLE
defconst compile time evaluation

### DIFF
--- a/core/core-os.el
+++ b/core/core-os.el
@@ -20,8 +20,8 @@
   (when (featurep 'exec-path-from-shell)
     `(exec-path-from-shell-copy-envs ,@vars)))
 
-(cond (IS-MAC
-       (setq mac-command-modifier 'meta
+(macroexpand (eval-when-compile (cond (IS-MAC
+       `(progn (setq mac-command-modifier 'meta
              mac-option-modifier  'alt
              ;; sane trackpad/mouse scroll settings
              mac-redisplay-dont-reset-vscroll t
@@ -52,15 +52,15 @@
 
        ;; Fix the clipboard in terminal or daemon Emacs (non-GUI)
        (when (or (daemonp) (not (display-graphic-p)))
-         (add-hook 'doom-post-init-hook #'osx-clipboard-mode)))
+         (add-hook 'doom-post-init-hook #'osx-clipboard-mode))))
 
       (IS-LINUX
-       (setq x-gtk-use-system-tooltips nil    ; native tooltips are ugly!
+       `(setq x-gtk-use-system-tooltips nil    ; native tooltips are ugly!
              x-underline-at-descent-line t))  ; draw underline lower
 
       (IS-WINDOWS
-       (setq w32-get-true-file-attributes nil) ; fix file io slowdowns
-       ))
+       `(setq w32-get-true-file-attributes nil) ; fix file io slowdowns
+       ))))
 
 (provide 'core-os)
 ;;; core-os.el ends here

--- a/core/core.el
+++ b/core/core.el
@@ -12,51 +12,60 @@ line or use --debug-init to enable this.")
 
 ;;
 ;; Constants
+(defmacro const! (symbol initvalue &optional docstring)
+  "Define SYMBOL as constant variable initialized to INITVALUE.
+
+Like `defconst', but evaluates INITVALUE at compile time."
+  (declare (debug defconst) (indent defun) (doc-string 3))
+  (if (stringp docstring)
+      `(defconst ,symbol (eval-when-compile ,initvalue) ,docstring)
+    `(defconst ,symbol (eval-when-compile ,initvalue))
+    ))
 
 (defconst doom-version "2.0.9"
   "Current version of DOOM emacs.")
 
-(defconst EMACS26+ (> emacs-major-version 25))
-(defconst EMACS27+ (> emacs-major-version 26))
+(const! EMACS26+ (> emacs-major-version 25))
+(const! EMACS27+ (> emacs-major-version 26))
 
-(defconst IS-MAC     (eq system-type 'darwin))
-(defconst IS-LINUX   (eq system-type 'gnu/linux))
-(defconst IS-WINDOWS (memq system-type '(cygwin windows-nt ms-dos)))
+(const! IS-MAC     (eq system-type 'darwin))
+(const! IS-LINUX   (eq system-type 'gnu/linux))
+(const! IS-WINDOWS (memq system-type '(cygwin windows-nt ms-dos)))
 
 
 ;;
-(defvar doom-emacs-dir user-emacs-directory
+(const! doom-emacs-dir user-emacs-directory
   "The path to this emacs.d directory. Must end in a slash.")
 
-(defvar doom-core-dir (concat doom-emacs-dir "core/")
+(const! doom-core-dir (concat doom-emacs-dir "core/")
   "The root directory of core Doom files.")
 
-(defvar doom-modules-dir (concat doom-emacs-dir "modules/")
+(const! doom-modules-dir (concat doom-emacs-dir "modules/")
   "The root directory for Doom's modules.")
 
-(defvar doom-local-dir (concat doom-emacs-dir ".local/")
+(const! doom-local-dir (concat doom-emacs-dir ".local/")
   "Root directory for local Emacs files. Use this as permanent storage for files
 that are safe to share across systems (if this config is symlinked across
 several computers).")
 
-(defvar doom-etc-dir (concat doom-local-dir "etc/")
+(const! doom-etc-dir (concat doom-local-dir "etc/")
   "Directory for non-volatile storage.
 
 Use this for files that don't change much, like servers binaries, external
 dependencies or long-term shared data.")
 
-(defvar doom-cache-dir (concat doom-local-dir "cache/")
+(const! doom-cache-dir (concat doom-local-dir "cache/")
   "Directory for volatile storage.
 
 Use this for files that change often, like cache files.")
 
-(defvar doom-packages-dir (concat doom-local-dir "packages/")
+(const! doom-packages-dir (concat doom-local-dir "packages/")
   "Where package.el and quelpa plugins (and their caches) are stored.")
 
-(defvar doom-docs-dir (concat doom-emacs-dir "docs/")
+(const! doom-docs-dir (concat doom-emacs-dir "docs/")
   "Where the Doom manual is stored.")
 
-(defvar doom-private-dir
+(const! doom-private-dir
   (eval-when-compile
     (or (getenv "DOOMDIR")
         (let ((xdg-path
@@ -68,10 +77,10 @@ Use this for files that change often, like cache files.")
   "Where your private customizations are placed. Must end in a slash. Respects
 XDG directory conventions if ~/.config/doom exists.")
 
-(defvar doom-autoload-file (concat doom-local-dir "autoloads.el")
+(const! doom-autoload-file (concat doom-local-dir "autoloads.el")
   "Where `doom-reload-doom-autoloads' will generate its core autoloads file.")
 
-(defvar doom-package-autoload-file (concat doom-local-dir "autoloads.pkg.el")
+(const! doom-package-autoload-file (concat doom-local-dir "autoloads.pkg.el")
   "Where `doom-reload-package-autoloads' will generate its package.el autoloads
 file.")
 
@@ -89,10 +98,11 @@ file.")
   "If non-nil, the running version of Emacs is different from the first time
 Doom was setup, which can cause problems.")
 
-(defvar doom-site-load-path load-path
+;; Don't use const! here, this is fairly large
+(defconst doom-site-load-path load-path
   "The starting load-path, before it is altered by `doom-initialize'.")
 
-(defvar doom--last-emacs-file (concat doom-local-dir "emacs-version.el"))
+(const! doom--last-emacs-file (concat doom-local-dir "emacs-version.el"))
 (defvar doom--last-emacs-version nil)
 (defvar doom--refreshed-p nil)
 (defvar doom--stage 'init)

--- a/init.el
+++ b/init.el
@@ -31,11 +31,11 @@
   "The default value to use for `gc-cons-threshold'. If you experience freezing,
 decrease this. If you experience stuttering, increase this.")
 
-(defvar doom-gc-cons-upper-limit 268435456 ; 256mb
+(defconst doom-gc-cons-upper-limit 268435456 ; 256mb
   "The temporary value for `gc-cons-threshold' to defer it.")
 
 
-(defvar doom--file-name-handler-alist file-name-handler-alist)
+(defconst doom--file-name-handler-alist file-name-handler-alist)
 
 (defun doom|restore-startup-optimizations ()
   "Resets garbage collection settings to reasonable defaults (a large
@@ -60,9 +60,8 @@ decrease this. If you experience stuttering, increase this.")
   ;; Not restoring these to their defaults will cause stuttering/freezes.
   (add-hook 'emacs-startup-hook #'doom|restore-startup-optimizations))
 
-
 ;; Ensure Doom is running out of this file's directory
-(setq user-emacs-directory (file-name-directory load-file-name))
+(defconst user-emacs-directory (file-name-directory load-file-name))
 ;; In noninteractive sessions, prioritize non-byte-compiled source files to
 ;; prevent stale, byte-compiled code from running. However, if you're getting
 ;; recursive load errors, it may help to set this to nil.


### PR DESCRIPTION
I was learning more about Emacs by looking at the bytecode it generates for simple constructs, and discovered that `defconst` was not optimized. Here's a macro that can optimize it.
Don't expect visible changes in startup time from this, but it is nice for documentation purposes (and maybe someone else *can* figure how to use this to optimize startup time).

For now I'm quite happy with startup time at 0.784s on Emacs26 (and Emacs27  would further reduce that, but I'll have to wait until it is released, it is not stable yet).