### PR TITLE
tools/pdf: recognize modeline and doom-modeline

### DIFF
--- a/modules/tools/pdf/+modeline.el
+++ b/modules/tools/pdf/+modeline.el
@@ -4,16 +4,16 @@
   "Current and total page indicator for PDF documents."
   (format "P %d/%d" (pdf-view-current-page) (pdf-cache-number-of-pages)))
 
-(if (featurep! :ui doom-modeline +new)
+(if (featurep! :ui modeline)
     (def-modeline-format! '+pdf
       '(+mode-line-bar " " +mode-line-buffer-id "  " +pdf-pages)
       '(+mode-line-major-mode +mode-line-vcs))
   (def-modeline! '+pdf
-    '(bar matches " " buffer-info +pdf-pages)
+    '(bar matches " " buffer-info "  " +pdf-pages)
     '(major-mode vcs)))
 
 (defun +pdf|init-modeline ()
-  (funcall (if (featurep! :ui doom-modeline +new)
+  (funcall (if (featurep! :ui modeline)
                #'set-modeline!
              #'doom-set-modeline)
            '+pdf))

--- a/modules/tools/pdf/config.el
+++ b/modules/tools/pdf/config.el
@@ -30,7 +30,7 @@
   ;; Turn off cua so copy works
   (add-hook! 'pdf-view-mode-hook (cua-mode 0))
   ;; Custom modeline that removes useless info and adds page numbers
-  (when (featurep! :ui doom-modeline)
+  (when (or (featurep! :ui doom-modeline) (featurep! :ui modeline))
     (load! "+modeline"))
   ;; Handle PDF-tools related popups better
   (set-popup-rule! "^\\*Outline*" :side 'right :size 40 :select nil)


### PR DESCRIPTION
After the split of `modeline` and `doom-modeline`, the PDF module was not updated to take into account the two modules. This PR fixes this.
