### PR TITLE
magit: only implement leader key logic when doom-leader-key is non-nil

### DIFF
--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -47,8 +47,8 @@ available.")
 
   ;; Don't replace the leader key
   ;; FIXME remove me when general.el is integrated
-  (define-key magit-diff-mode-map (kbd doom-leader-key) nil))
-
+  (when doom-leader-key
+    (define-key magit-diff-mode-map (kbd doom-leader-key) nil)))
 
 (def-package! magit-todos
   :hook (magit-mode . magit-todos-mode)


### PR DESCRIPTION
As someone that doesn't use evil, it seems this call needs to be guarded.