### PR TITLE
mu4e-confirm-quit should be nil instead of t

### DIFF
--- a/modules/app/email/config.el
+++ b/modules/app/email/config.el
@@ -50,7 +50,7 @@
               ((featurep! :completion helm) #'completing-read)
               (t #'ido-completing-read))
         ;; no need to ask
-        mu4e-confirm-quit t
+        mu4e-confirm-quit nil
         ;; remove 'lists' column
         mu4e-headers-fields
         '((:account . 12)


### PR DESCRIPTION
I believe the `mu4e-confirm-quit` is meant to be nil according to the comment
above. Feel free to close if this was intended.