### PR TITLE
Fix write mode fonts and format.el

### DIFF
--- a/core/core-ui.el
+++ b/core/core-ui.el
@@ -351,9 +351,9 @@ frame's window-system, the theme will be reloaded.")
               ((display-graphic-p)
                (setq doom-font (face-attribute 'default :font))))
         (when doom-serif-font
-          (set-face-attribute 'fixed-pitch-serif t :font doom-serif-font))
+          (set-face-attribute 'fixed-pitch-serif nil :font doom-serif-font))
         (when doom-variable-pitch-font
-          (set-face-attribute 'variable-pitch t :font doom-variable-pitch-font))
+          (set-face-attribute 'variable-pitch nil :font doom-variable-pitch-font))
         ;; Fallback to `doom-unicode-font' for Unicode characters
         (when (fontp doom-unicode-font)
           (set-fontset-font t nil doom-unicode-font nil 'append)))

--- a/modules/app/write/autoload.el
+++ b/modules/app/write/autoload.el
@@ -20,3 +20,24 @@
   "Initializes `org-mode' specific settings for `+write-mode'."
   (when (eq major-mode 'org-mode)
     (+org-pretty-mode (if +write-mode +1 -1))))
+
+;;;###autoload
+(defun +write|init-line-numbers ()
+  (display-line-numbers-mode (if +write-mode +1 -1)))
+
+;;;###autoload
+(defun +write|init-mixed-pitch ()
+  (mixed-pitch-mode (if +write-mode +1 -1)))
+
+;;;###autoload
+(defun +write|init-visual-fill-column ()
+  (visual-fill-column-mode (if +write-mode +1 -1)))
+
+;;;###autoload
+(add-hook! '+write-mode-hook
+  #'(flyspell-mode
+     visual-line-mode
+     +write|init-mixed-pitch
+     +write|init-visual-fill-column
+     +write|init-line-numbers
+     +write|init-org-mode))

--- a/modules/app/write/config.el
+++ b/modules/app/write/config.el
@@ -6,24 +6,6 @@
 (defvar +write-line-spacing nil
   "What to set `line-spacing' in `+write-mode'.")
 
-(defun +write|init-line-numbers ()
-  (display-line-numbers-mode (if +write-mode +1 -1)))
-
-(defun +write|init-mixed-pitch ()
-  (mixed-pitch-mode (if +write-mode +1 -1)))
-
-(defun +write|init-visual-fill-column ()
-  (visual-fill-column-mode (if +write-mode +1 -1)))
-
-(add-hook! '+write-mode-hook
-  #'(flyspell-mode
-     visual-line-mode
-     +write|init-mixed-pitch
-     +write|init-visual-fill-column
-     +write|init-line-numbers
-     +write|init-org-mode))
-
-
 ;;
 ;; Packages
 

--- a/modules/editor/format/autoload/format.el
+++ b/modules/editor/format/autoload/format.el
@@ -101,7 +101,7 @@ Stolen shamelessly from go-mode"
 (defun +format*probe (orig-fn)
   "Use `+format-with' instead, if it is set."
   (if +format-with
-      (cons +format-with t)
+      (list +format-with t)
     (funcall orig-fn)))
 
 ;;;###autoload


### PR DESCRIPTION
I set a custom font for variable-pitch and it was not taking effect (it was quite obvious, because I set a serif font, and I got a sans serif one instead).
I also checked with `SPC u C-x =` and looks like the font I set had no effect.

Two reasons:
* the font only got set for new frames, and not for the main emacs frame
* the +write-mode-hook was not actually run, because we assigned to the hook before +write-mode minor mode got defined (and the autoloads only generate autoloads for the mode, not the hooks)

I fixed these, perhaps not in the most elegant way. Feel free to suggest improvements.

Also got a bugfix for format.el, so included it here (wrong type, `cons` expected a list as 2nd argument, but it really wanted to just build a list of 2 elements here).
