### PR TITLE
Fix some error path and typos spotted by `make compile`

### DIFF
--- a/core/core-lib.el
+++ b/core/core-lib.el
@@ -277,7 +277,7 @@ Body forms can access the hook's arguments through the let-bound variable
     fill-column 80)"
   (declare (indent 1))
   (unless (= 0 (% (length rest) 2))
-    (signal 'wrong-number-of-arguments (listp #'evenp (length rest))))
+    (signal 'wrong-number-of-arguments (list #'evenp (length rest))))
   `(add-hook! :append ,hooks
      ,@(let (forms)
          (while rest

--- a/modules/editor/format/autoload/settings.el
+++ b/modules/editor/format/autoload/settings.el
@@ -77,7 +77,7 @@
 (cl-defun +format--set (name &key function modes unset)
   (declare (indent defun))
   (when (and unset (not (gethash name format-all-format-table)))
-    (error "'%s' formatter does not exist to be unset"))
+    (error "'%s' formatter does not exist to be unset" name))
   (puthash name function format-all-format-table)
   (dolist (mode (doom-enlist modes))
     (cl-destructuring-bind (m &optional probe)

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -391,7 +391,7 @@ conditions where a window's buffer hasn't changed at the time this hook is run."
   ;; Fix variable height org-level-N faces in the eldoc string
   (defun +org*format-outline-path (orig-fn path &optional width prefix separator)
     (let ((result (funcall orig-fn path width prefix separator))
-          (seperator (or separator "/")))
+          (separator (or separator "/")))
       (string-join
        (cl-loop for part
                 in (split-string (substring-no-properties result) separator)


### PR DESCRIPTION
Couple things I noticed when running `make compile`