### PR TITLE
fix `+macos/open-in-default-project` under `ranger-mode`

### DIFF
--- a/modules/tools/macos/autoload.el
+++ b/modules/tools/macos/autoload.el
@@ -7,7 +7,7 @@
   (let* ((path (expand-file-name
                 (replace-regexp-in-string
                  "'" "\\'"
-                 (or path (if (eq major-mode 'dired-mode)
+                 (or path (if (derived-mode-p 'dired-mode)
                               (dired-get-file-for-visit)
                             (buffer-file-name)))
                  nil t)))


### PR DESCRIPTION
A quick fix for invoking `+macos/open-in-default-project` under `ranger-mode`