### PR TITLE
Mode line is hidden in +write-mode

### DIFF
--- a/modules/app/write/autoload.el
+++ b/modules/app/write/autoload.el
@@ -34,9 +34,14 @@
   (visual-fill-column-mode (if +write-mode +1 -1)))
 
 ;;;###autoload
+(defun +write|init-hide-mode-line ()
+  (hide-mode-line-mode (if +write-mode +1 -1)))
+
+;;;###autoload
 (add-hook! '+write-mode-hook
   #'(flyspell-mode
      visual-line-mode
+     +write|init-hide-mode-line
      +write|init-mixed-pitch
      +write|init-visual-fill-column
      +write|init-line-numbers


### PR DESCRIPTION
The mode line gets hidden when `+write-mode` is activated, as befits a distraction free editing mode.