### PR TITLE
Updated documentation to use better gocode fork (supports Go 1.11+)

### DIFF
--- a/modules/lang/go/README.org
+++ b/modules/lang/go/README.org
@@ -51,7 +51,7 @@ This module requires a valid ~GOPATH~, and the following Go packages:
 export GOPATH=~/work/go
 
 go get -u github.com/motemen/gore
-go get -u github.com/nsf/gocode
+go get -u github.com/stamblerre/gocode
 go get -u golang.org/x/tools/cmd/godoc
 go get -u golang.org/x/tools/cmd/goimports
 go get -u golang.org/x/tools/cmd/gorename


### PR DESCRIPTION
Updated the documentation to install the recommended gocode package.

nsf/gocode is obsolete since it does not support Go 1.10+.

This fork is the currently recommended one as seen here: https://github.com/golang/go/issues/24661
