### PR TITLE
Allow `deadgreap` folding in normal mode

### DIFF
--- a/modules/feature/evil/autoload/folds.el
+++ b/modules/feature/evil/autoload/folds.el
@@ -164,6 +164,8 @@ Otherwise, jump to the matching delimiter with `evilmi-jump-items'."
     (call-interactively
      (cond ((derived-mode-p 'magit-mode)
             #'magit-section-toggle)
+           ((derived-mode-p 'deadgrep-mode)
+            #'deadgrep-toggle-file-results)
            ((+evil-from-eol (invisible-p (point)))
             #'+evil/fold-toggle)
            (#'evilmi-jump-items)))))


### PR DESCRIPTION
`TAB` doesn't work in normal mode for `deadgreap` to hide results on per-file basis. This PR fixes that by explicitly distinguishing the `deadgrep` mode.
