### PR TITLE
Capture template tweaks

### DIFF
--- a/modules/lang/org/+capture.el
+++ b/modules/lang/org/+capture.el
@@ -31,23 +31,23 @@ It is used in Doom's default `org-capture-templates'.")
 (defvar org-capture-templates
   '(("t" "Personal todo" entry
      (file+headline +org-capture-todo-file "Inbox")
-     "* [ ] %?\n%i" :prepend t :kill-buffer t)
+     "* [ ] %?\n%i\n%a" :prepend t :kill-buffer t)
     ("n" "Personal notes" entry
      (file+headline +org-capture-notes-file "Inbox")
-     "* %u %?\n%i" :prepend t :kill-buffer t)
+     "* %u %?\n%i\n%a" :prepend t :kill-buffer t)
 
     ;; Will use {project-root}/{todo,notes,changelog}.org, unless a
     ;; {todo,notes,changelog}.org file is found in a parent directory.
     ("p" "Templates for projects")
     ("pt" "Project todo" entry  ; {project-root}/todo.org
      (file+headline +org-capture-project-todo-file "Inbox")
-     "* [ ] %?\n%i" :prepend t :kill-buffer t)
+     "* [ ] %?\n%i\n%a" :prepend t :kill-buffer t)
     ("pn" "Project notes" entry  ; {project-root}/notes.org
      (file+headline +org-capture-project-notes-file "Inbox")
-     "* [ ] %?\n%i" :prepend t :kill-buffer t)
+     "* [ ] %?\n%i\n%a" :prepend t :kill-buffer t)
     ("pc" "Project changelog" entry  ; {project-root}/changelog.org
      (file+headline +org-capture-project-notes-file "Unreleased")
-     "* [ ] %?\n%i" :prepend t :kill-buffer t)))
+     "* [ ] %?\n%i\n%a" :prepend t :kill-buffer t)))
 
 
 (defvar org-default-notes-file nil)  ; defined in org.el

--- a/modules/lang/org/+capture.el
+++ b/modules/lang/org/+capture.el
@@ -31,7 +31,7 @@ It is used in Doom's default `org-capture-templates'.")
 (defvar org-capture-templates
   '(("t" "Personal todo" entry
      (file+headline +org-capture-todo-file "Inbox")
-     "* [] %?\n%i\n%a" :prepend t :kill-buffer t)
+     "* [ ] %?\n%i\n%a" :prepend t :kill-buffer t)
     ("n" "Personal notes" entry
      (file+headline +org-capture-notes-file "Inbox")
      "* %u %?\n%i\n%a" :prepend t :kill-buffer t)

--- a/modules/lang/org/+capture.el
+++ b/modules/lang/org/+capture.el
@@ -31,7 +31,7 @@ It is used in Doom's default `org-capture-templates'.")
 (defvar org-capture-templates
   '(("t" "Personal todo" entry
      (file+headline +org-capture-todo-file "Inbox")
-     "* TODO %?\n%i\n%a" :prepend t :kill-buffer t)
+     "* [] %?\n%i\n%a" :prepend t :kill-buffer t)
     ("n" "Personal notes" entry
      (file+headline +org-capture-notes-file "Inbox")
      "* %u %?\n%i\n%a" :prepend t :kill-buffer t)

--- a/modules/lang/org/+capture.el
+++ b/modules/lang/org/+capture.el
@@ -31,7 +31,7 @@ It is used in Doom's default `org-capture-templates'.")
 (defvar org-capture-templates
   '(("t" "Personal todo" entry
      (file+headline +org-capture-todo-file "Inbox")
-     "* [ ] %?\n%i\n%a" :prepend t :kill-buffer t)
+     "* TODO %?\n%i\n%a" :prepend t :kill-buffer t)
     ("n" "Personal notes" entry
      (file+headline +org-capture-notes-file "Inbox")
      "* %u %?\n%i\n%a" :prepend t :kill-buffer t)
@@ -41,13 +41,13 @@ It is used in Doom's default `org-capture-templates'.")
     ("p" "Templates for projects")
     ("pt" "Project todo" entry  ; {project-root}/todo.org
      (file+headline +org-capture-project-todo-file "Inbox")
-     "* [ ] %?\n%i\n%a" :prepend t :kill-buffer t)
+     "* TODO %?\n%i\n%a" :prepend t :kill-buffer t)
     ("pn" "Project notes" entry  ; {project-root}/notes.org
      (file+headline +org-capture-project-notes-file "Inbox")
-     "* [ ] %?\n%i\n%a" :prepend t :kill-buffer t)
+     "* TODO %?\n%i\n%a" :prepend t :kill-buffer t)
     ("pc" "Project changelog" entry  ; {project-root}/changelog.org
      (file+headline +org-capture-project-notes-file "Unreleased")
-     "* [ ] %?\n%i\n%a" :prepend t :kill-buffer t)))
+     "* TODO %?\n%i\n%a" :prepend t :kill-buffer t)))
 
 
 (defvar org-default-notes-file nil)  ; defined in org.el


### PR DESCRIPTION
- The built-in capture templates now add a link to the file from which capture was initiated - this integrates well with a capture-based workflow, and also means that the built-in templates play nicely with, e.g., `org-mu4e-store-and-capture`.
- Checkboxes have been changed to TODOs - other components of doom, e.g., `magit-todos` assume TODOs and don't recognize checkboxes. In any case, in org-mode checkboxes are standardly used for subtasks.