### PR TITLE
Open org links with `pdf-view-mode` (with `:tools pdf`)

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -52,6 +52,12 @@
     :after org-agenda
     :config (evil-org-agenda-set-keys)))
 
+(def-package! org-pdfview
+  :when (featurep! :tools pdf)
+  :config
+  (delete '("\\.pdf\\'" . default) org-file-apps)
+  (add-to-list 'org-file-apps '("\\.pdf\\'" . (lambda (file link) (org-pdfview-open link)))) ;; org links to pdf files are opened in pdf-view-mode
+  (add-to-list 'org-file-apps '("\\.pdf::\\([[:digit:]]+\\)\\'" . (lambda (file link) (org-pdfview-open link))))) ;; support for links to specific pages
 
 ;;
 ;; Bootstrap

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -54,10 +54,15 @@
 
 (def-package! org-pdfview
   :when (featurep! :tools pdf)
-  :config
-  (delete '("\\.pdf\\'" . default) org-file-apps)
-  (add-to-list 'org-file-apps '("\\.pdf\\'" . (lambda (file link) (org-pdfview-open link)))) ;; org links to pdf files are opened in pdf-view-mode
-  (add-to-list 'org-file-apps '("\\.pdf::\\([[:digit:]]+\\)\\'" . (lambda (file link) (org-pdfview-open link))))) ;; support for links to specific pages
+  :commands (org-pdfview-open)
+  :init
+  (after! org
+    (delete '("\\.pdf\\'" . default) org-file-apps)
+    ;; org links to pdf files are opened in pdf-view-mode
+    (add-to-list 'org-file-apps '("\\.pdf\\'" . (lambda (_file link) (org-pdfview-open link)))) 
+    ;; support for links to specific pages
+    (add-to-list 'org-file-apps '("\\.pdf::\\([[:digit:]]+\\)\\'" . (lambda (_file link) (org-pdfview-open link)))))) 
+
 
 ;;
 ;; Bootstrap

--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -11,6 +11,9 @@
 (when (featurep! :feature evil)
   (package! evil-org))
 
+(when (featurep! :tools pdf)
+  (package! org-pdfview))
+
 (when (featurep! +attach)
   (package! org-download))
 


### PR DESCRIPTION
When `:tools pdf` is enabled, org links to pdf files should be opened in `pdf-view-mode`. Additional support is added for links to a specific *page* in the pdf.