### PR TITLE
update README for go

### DIFF
--- a/modules/lang/go/README.org
+++ b/modules/lang/go/README.org
@@ -51,7 +51,7 @@ This module requires a valid ~GOPATH~, and the following Go packages:
 export GOPATH=~/work/go
 
 go get -u github.com/motemen/gore
-go get -u github.com/nsf/gocode
+go get -u github.com/mdempsky/gocode
 go get -u golang.org/x/tools/cmd/godoc
 go get -u golang.org/x/tools/cmd/goimports
 go get -u golang.org/x/tools/cmd/gorename


### PR DESCRIPTION
According to README in [nsf/gocode](https://github.com/nsf/gocode)

> VERY IMPORTANT: this project is not maintained anymore, look for alternatives or forks if you need Go autocompletion tool
> IMPORTANT: consider switching to https://github.com/mdempsky/gocode if you have problems starting with Go version 1.10, due to changes in binary packages architecture (introduction of package cache) I'm not going to adjust gocode for it for quite some time. There is a higher chance that fork under the given link will have some solution to the problem sooner or later.

It is better to use [github.com/mdempsky/gocode](https://github.com/mdempsky/gocode) now.