### PR TITLE
fix treemacs compilation error

### DIFF
--- a/core/core-ui.el
+++ b/core/core-ui.el
@@ -116,7 +116,7 @@ size.")
              all-the-icons-wicon all-the-icons-material all-the-icons-alltheicon)
   :init
   (defun doom*disable-all-the-icons-in-tty (orig-fn &rest args)
-    (when (display-graphic-p)
+    (when (or (display-graphic-p) noninteractive)
       (apply orig-fn args)))
   :config
   ;; all-the-icons doesn't work in the terminal, so we "disable" it.


### PR DESCRIPTION
In toplevel form:
../../../ui/treemacs/config.el:16:1:Error: Custom icon cannot be nil
✕ Failed to compile modules/ui/treemacs/config.el

Might not be the best solution, but it fixes the compile problem.