### PR TITLE
turn off fci when window is narrow than fill column

### DIFF
--- a/modules/ui/fci/config.el
+++ b/modules/ui/fci/config.el
@@ -21,6 +21,23 @@ Changes to this variable do not take effect until `fci-mode' is restarted.")
   ;; more important to me, so...
   (add-hook 'org-mode-hook #'turn-off-fci-mode)
 
+  ;; turn off fci if the window is narrow than fill column
+  (defun fci-conditional (window)
+    (let ((fci-enabled (symbol-value 'fci-mode))
+          (fci-column (if fci-rule-column fci-rule-column fill-column)))
+      (with-selected-window window
+        (if (and (eq fci-enabled nil)
+                 (< fci-column
+                    (+ (window-width) (window-hscroll))))
+            (turn-on-fci-mode)
+          (turn-off-fci-mode)))))
+
+  (defun fci-width-workaround (&rest _)
+    (walk-windows #'fci-conditional 'no-minibuf))
+
+  (add-hook 'window-size-change-functions 'fci-width-workaround)
+  (add-hook 'window-configuration-change-hook 'fci-width-workaround)
+
   (defun +fci|set-color ()
     "Automatically change `fci-rule-color' based on `+fci-rule-color-function's
 return value. To disable this, either set `+fci-rule-color-function' to nil or

--- a/modules/ui/fci/config.el
+++ b/modules/ui/fci/config.el
@@ -22,9 +22,9 @@ Changes to this variable do not take effect until `fci-mode' is restarted.")
   (add-hook 'org-mode-hook #'turn-off-fci-mode)
 
   ;; turn off fci if the window is narrow than fill column
-  (defun fci-conditional (window)
+  (defun +fci-toggle-maybe (window)
     (let ((fci-enabled (symbol-value 'fci-mode))
-          (fci-column (if fci-rule-column fci-rule-column fill-column)))
+          (fci-column (or fci-rule-column fill-column)))
       (with-selected-window window
         (if (and (eq fci-enabled nil)
                  (< fci-column
@@ -32,11 +32,11 @@ Changes to this variable do not take effect until `fci-mode' is restarted.")
             (turn-on-fci-mode)
           (turn-off-fci-mode)))))
 
-  (defun fci-width-workaround (&rest _)
-    (walk-windows #'fci-conditional 'no-minibuf))
+  (defun +fci|width-workaround (&rest _)
+    (walk-windows #'+fci-toggle-maybe 'no-minibuf))
 
-  (add-hook 'window-size-change-functions 'fci-width-workaround)
-  (add-hook 'window-configuration-change-hook 'fci-width-workaround)
+  (add-hook 'window-size-change-functions #'+fci|width-workaround)
+  (add-hook 'window-configuration-change-hook #'+fci|width-workaround)
 
   (defun +fci|set-color ()
     "Automatically change `fci-rule-color' based on `+fci-rule-color-function's


### PR DESCRIPTION
without those hook handles:
<img width="440" alt="snipaste_2018-10-22_00-14-25" src="https://user-images.githubusercontent.com/1224321/47269387-7c76cc00-d58f-11e8-9647-3cd63a9d1fdc.png">

with those hook handles:
<img width="328" alt="snipaste_2018-10-22_00-17-51" src="https://user-images.githubusercontent.com/1224321/47269420-f444f680-d58f-11e8-8e0d-9264b4925088.png">