### PR TITLE
lang/ocaml: drop bad imenu initialization

### DIFF
--- a/modules/lang/ocaml/config.el
+++ b/modules/lang/ocaml/config.el
@@ -59,7 +59,6 @@
 
   (def-package! merlin-iedit
     :when (featurep! :editor multiple-cursors)
-    :hook (merlin-mode . merlin-use-merlin-imenu)
     :config
     (map! :map tuareg-mode-map
           :v "R" #'merlin-iedit-occurrences))


### PR DESCRIPTION
A copy+paste error slipped  through in my previous PR, this would cause problems due to `merlin-imenu` not being available at the time `merlin-iedit` is initialized.