### PR TITLE
Close the ending quote in lispy-mode

### DIFF
--- a/modules/editor/lispy/config.el
+++ b/modules/editor/lispy/config.el
@@ -9,6 +9,7 @@
          (lfe-mode . lispy-mode)
          (clojure-mode . lispy-mode))
   :config
+  (setq lispy-close-quotes-at-end-p t)
   (add-hook 'lispy-mode-hook #'turn-off-smartparens-mode))
 
 (def-package! lispyville


### PR DESCRIPTION
With this setting lispy closes the ending quote which is in alignment
with how Doom treats quotes in other modes.