### PR TITLE
lang/rust: Added clippy command and :desc descriptions

### DIFF
--- a/modules/lang/rust/config.el
+++ b/modules/lang/rust/config.el
@@ -7,11 +7,12 @@
 
   (map! :map rust-mode-map
         :localleader
-        :prefix "b"
-        :n "b" (λ! (compile "cargo build --color always"))
-        :n "c" (λ! (compile "cargo check --color always"))
-        :n "r" (λ! (compile "cargo run --color always"))
-        :n "t" (λ! (compile "cargo test --color always"))))
+        :desc "cargo" :prefix "b"
+        :desc "build"  :n "b" (λ! (compile "cargo build --color always"))
+        :desc "check"  :n "c" (λ! (compile "cargo check --color always"))
+        :desc "run"    :n "r" (λ! (compile "cargo run --color always"))
+        :desc "clippy" :n "l" (λ! (compile "cargo clippy --color always"))
+        :desc "test"   :n "t" (λ! (compile "cargo test --color always"))))
 
 
 (def-package! racer


### PR DESCRIPTION
Added proper descriptions to cargo's commands instead of 'lambda'
in which-key

Thank you for contributing to Doom!

Before you submit this PR, please make sure your PR is targeted at develop, not
master (unless this is a fix for a critical error). Then replace this message
with a description of your changes.
