### PR TITLE
Change `magit-blame-addition` to `magit-blame`

### DIFF
--- a/modules/config/default/+bindings.el
+++ b/modules/config/default/+bindings.el
@@ -627,7 +627,7 @@
         :desc "Delete this file"            :n "X" #'doom/delete-this-file)
 
       (:desc "git" :prefix "g"
-        :desc "Magit blame"           :n  "b" #'magit-blame
+        :desc "Magit blame"           :n  "b" #'magit-blame-addition
         :desc "Magit commit"          :n  "c" #'magit-commit
         :desc "Magit clone"           :n  "C" #'+magit/clone
         :desc "Magit dispatch"        :n  "d" #'magit-dispatch-popup


### PR DESCRIPTION
`magit-blame` is deprecated (as of Magit 2.90.0)