### PR TITLE
Use fd for populating projectile cache

### DIFF
--- a/core/core-projects.el
+++ b/core/core-projects.el
@@ -52,7 +52,14 @@
     "Don't traverse the file system if on a remote connection."
     (unless (file-remote-p default-directory)
       (funcall orig-fn file name)))
-  (advice-add #'projectile-locate-dominating-file :around #'doom*projectile-locate-dominating-file))
+  (advice-add #'projectile-locate-dominating-file :around #'doom*projectile-locate-dominating-file)
+
+  ;; If fd exists, use it for git and generic projects
+  ;; fd is a rust program that is significantly faster. It also respects
+  ;; .gitignore. This is recommended in the projectile docs
+  (when (executable-find "fd")
+    (setq projectile-git-command "fd . --type f -0"
+          projectile-generic-command projectile-git-command)))
 
 
 ;;

--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -53,7 +53,7 @@ what features are available.")
   ;; fd is a rust program that is significantly faster. It also respects
   ;; .gitignore. This is recommended in the projectile docs
   (when (executable-find "fd")
-    (setq projectile-git-command "fd . -0"
+    (setq projectile-git-command "fd . --type f -0"
           projectile-generic-command projectile-git-command)))
 
 (def-package! magit-todos

--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -47,7 +47,14 @@ what features are available.")
   ;; Don't replace the leader key
   ;; FIXME remove me when general.el is integrated
   (when doom-leader-key
-    (define-key magit-diff-mode-map (kbd doom-leader-key) nil)))
+    (define-key magit-diff-mode-map (kbd doom-leader-key) nil))
+
+  ;; If fd exists, use it for git and generic projects
+  ;; fd is a rust program that is significantly faster. It also respects
+  ;; .gitignore. This is recommended in the projectile docs
+  (when (executable-find "fd")
+    (setq projectile-git-command "fd . -0"
+          projectile-generic-command projectile-git-command)))
 
 (def-package! magit-todos
   :hook (magit-mode . magit-todos-mode)

--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -47,14 +47,8 @@ what features are available.")
   ;; Don't replace the leader key
   ;; FIXME remove me when general.el is integrated
   (when doom-leader-key
-    (define-key magit-diff-mode-map (kbd doom-leader-key) nil))
+    (define-key magit-diff-mode-map (kbd doom-leader-key) nil)))
 
-  ;; If fd exists, use it for git and generic projects
-  ;; fd is a rust program that is significantly faster. It also respects
-  ;; .gitignore. This is recommended in the projectile docs
-  (when (executable-find "fd")
-    (setq projectile-git-command "fd . --type f -0"
-          projectile-generic-command projectile-git-command)))
 
 (def-package! magit-todos
   :hook (magit-mode . magit-todos-mode)


### PR DESCRIPTION
[fd](https://github.com/sharkdp/fd) is a rust program **significantly faster** than find and git ls-files that **respects .gitignore**.

This change is also recommended in the [projectile docs](https://projectile.readthedocs.io/en/latest/configuration/), or a screenshot: ![screenshot](https://i.imgur.com/oCmBGb5.png)