### PR TITLE
Add descriptions to rust-mode-map

### DIFF
--- a/modules/lang/rust/config.el
+++ b/modules/lang/rust/config.el
@@ -8,10 +8,10 @@
   (map! :map rust-mode-map
         :localleader
         :prefix "b"
-        :n "b" (λ! (compile "cargo build --color always"))
-        :n "c" (λ! (compile "cargo check --color always"))
-        :n "r" (λ! (compile "cargo run --color always"))
-        :n "t" (λ! (compile "cargo test --color always"))))
+        :desc "cargo build" :n "b" (λ! (compile "cargo build --color always"))
+        :desc "cargo check" :n "c" (λ! (compile "cargo check --color always"))
+        :desc "cargo run" :n "r" (λ! (compile "cargo run --color always"))
+        :desc "cargo test" :n "t" (λ! (compile "cargo test --color always"))))
 
 
 (def-package! racer


### PR DESCRIPTION
Otherwise they all just say `lambda`.
