### PR TITLE
Enable magit by default

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -70,7 +70,7 @@
        ;;gist              ; interacting with github gists
        ;;macos             ; MacOS-specific commands
        ;;make              ; run make tasks from Emacs
-       ;;magit             ; a git porcelain for Emacs
+       magit             ; a git porcelain for Emacs
        ;;password-store    ; password manager for nerds
        ;;pdf               ; pdf enhancements
        ;;prodigy           ; FIXME managing external services & code builders


### PR DESCRIPTION
makes sense as almost a staple of emacs it should be on by default. not
to mention the vcs module is enabled by default too!
