### PR TITLE
Change .gitignore to exclude "modules/private" when attached as symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .local/
 var/
-modules/private/
+modules/private
 .yas-compiled-snippets.el
 
 # folders created by Cask


### PR DESCRIPTION
Change .gitignore to exclude "modules/private" when attached as symlink.