### PR TITLE
fix: disable verbose message for dired-omit

### DIFF
--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -100,7 +100,9 @@
 
 
 (def-package! dired-x
-  :hook (dired-mode . dired-omit-mode))
+  :hook (dired-mode . dired-omit-mode)
+  :config
+  (setq dired-omit-verbose nil))
 
 
 ;;


### PR DESCRIPTION
To avoid endless spam in \*Messages\*, disable "Omitted 2 lines" every
time a new dired buffer is opened.

![verbose](https://user-images.githubusercontent.com/5365116/50464800-f85e1c00-09f7-11e9-93f7-f381ae4d37ef.gif)
