### PR TITLE
fix wrong url of dotfiles repository

### DIFF
--- a/modules/app/email/README.org
+++ b/modules/app/email/README.org
@@ -36,7 +36,7 @@ sudo pacman --noconfirm --needed -S offlineimap mu
 * Dependencies
 You need to do the following:
 
-1. Write a ~\~/.offlineimaprc~. Mine can be found [[https://github.com/hlissner/dotfiles/tree/master/shell/+mu][in my dotfiles repository]]. It is configured to download mail to ~\~/.mail~. I use [[https://www.passwordstore.org/][unix pass]] to securely store my login credentials.
+1. Write a ~\~/.offlineimaprc~. Mine can be found [[https://github.com/hlissner/dotfiles/tree/master/shell/mu][in my dotfiles repository]]. It is configured to download mail to ~\~/.mail~. I use [[https://www.passwordstore.org/][unix pass]] to securely store my login credentials.
 2. Download your email: ~offlineimap -o~ (may take a while)
 3. Index it with mu: ~mu index --maildir ~/.mail~
 


### PR DESCRIPTION
Thank you for contributing to Doom!

Before you submit this PR, please make sure your PR is targeted at develop, not
master (unless this is a fix for a critical error). Then replace this message
with a description of your changes.

the dotfiles repository url is wrong. it gives a 404 error. 