### PR TITLE
ui/vc-gutter: switch git-gutter order

### DIFF
--- a/modules/ui/vc-gutter/config.el
+++ b/modules/ui/vc-gutter/config.el
@@ -25,9 +25,9 @@ to the right fringe.")
   (defun +version-control|git-gutter-maybe ()
     "Enable `git-gutter-mode' in non-remote buffers."
     (when (and buffer-file-name
-               (vc-backend buffer-file-name)
                (or +vc-gutter-in-remote-files
-                   (not (file-remote-p buffer-file-name))))
+                   (not (file-remote-p buffer-file-name)))
+               (vc-backend buffer-file-name))
       (if (display-graphic-p)
           (progn
             (require 'git-gutter-fringe)


### PR DESCRIPTION
This change checks whether a file is remote before checking whether it's a version controlled repo, rather than the other way around. Gives a slight speed improvement to Tramp.

Also thank you for making doom-emacs such a wonderful coding experience!  I really appreciate all the works that goes into maintaining such a project. I know many people (myself included) that have a much better time using doom-emacs than vim. Continue the good work!