### PR TITLE
latex: enable flyspell correctly in latex buffers

### DIFF
--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -66,7 +66,7 @@ If no viewers are found, `latex-preview-pane' is used.")
   ;; Enable rainbow mode after applying styles to the buffer
   (add-hook 'TeX-update-style-hook #'rainbow-delimiters-mode)
   (when (featurep! :feature spellcheck)
-    (add-hook 'TeX-mode-local-vars-hook #'flyspell-mode))
+    (add-hook 'latex-mode-local-vars-hook #'flyspell-mode))
   ;; All these excess pairs dramatically slow down typing in latex buffers, so
   ;; we remove them. Let snippets do their job.
   (after! smartparens-latex


### PR DESCRIPTION
The varible `TeX-mode-local-vars-hook` doesn't exist. Instead, we use
`TeX-mode-hook` to enable flyspell. We append to the hook, however, to
enable disabling flyspell with
`(setq-hook! 'TeX-mode-hook +spellcheck-immediately nil)`
