### PR TITLE
pdf-tools: fixes for the new `modeline` module

### DIFF
--- a/modules/tools/pdf/+modeline.el
+++ b/modules/tools/pdf/+modeline.el
@@ -6,8 +6,8 @@
 
 (if (featurep! :ui modeline)
     (def-modeline-format! '+pdf
-      '(+mode-line-bar " " +mode-line-buffer-id "  " +pdf-pages)
-      '(+mode-line-major-mode +mode-line-vcs))
+      '(+modeline-matches " " +modeline-buffer-id "  " +pdf-pages)
+      '(+modeline-major-mode (vc-mode (" " +modeline-vcs))))
   (def-modeline! '+pdf
     '(bar matches " " buffer-info "  " +pdf-pages)
     '(major-mode vcs)))

--- a/modules/tools/pdf/config.el
+++ b/modules/tools/pdf/config.el
@@ -34,8 +34,7 @@
     (load! "+modeline"))
   ;; Handle PDF-tools related popups better
   (set-popup-rule! "^\\*Outline*" :side 'right :size 40 :select nil)
-  ;; TODO: Add additional important windows that should be handled differently
-  ;; TODO: These two next rules don't work (they should), investigate
+  ;; The next rules are not needed, they are defined in modules/ui/popups/+hacks.el
   ;; (set-popup-rule! "\\*Contents\\*" :side 'right :size 40)
   ;; (set-popup-rule! "* annots\\*$" :side 'left :size 40 :select nil)
   )


### PR DESCRIPTION
When using the new modeline module, pdf tools was not displaying the modeline correctly. This PR fixes it.

Also, remove some TODO comments that have already been addressed.

