### PR TITLE
bindings: default set of bindings for emacs users

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -26,8 +26,13 @@
  ;; Editor related bindings
  "C-a"            #'doom/backward-to-bol-or-indent
  [remap newline]  #'newline-and-indent
- "C-j"           #'+default/newline
- "C-S-s"          #'swiper
+ "C-j"            #'+default/newline
+ (:when (featurep! :completion ivy)
+   "C-S-s"        #'swiper
+   "C-S-r"        #'ivy-resume)
+ (:when (featurep! :completion helm)
+   "C-S-s"        #'swiper-helm
+   "C-S-r"        #'helm-resume)
  ;; Buffer related bindings
  "C-x b"       #'persp-switch-to-buffer
  "C-x C-b"     #'ibuffer-list-buffers

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -13,6 +13,7 @@
 
 ;; Prefix key to invoke doom related commands
 (setq doom-leader-alt-key "C-c")
+(setq doom-localleader-alt-key "C-c l")
 
 (map!
  ;; Text scaling

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -17,9 +17,12 @@
 
 (map!
  ;; Text scaling
- "C-+" (λ! (text-scale-set 0))
- "C-=" #'text-scale-increase
- "C--" #'text-scale-decrease
+ "<C-mouse-4>" #'text-scale-increase
+ "<C-mouse-5>" #'text-scale-decrease
+ "<C-down-mouse-2>" (λ! (text-scale-set 0))
+ "M-+" (λ! (text-scale-set 0))
+ "M-=" #'text-scale-increase
+ "M--" #'text-scale-decrease
  ;; Editor related bindings
  "C-a"            #'doom/backward-to-bol-or-indent
  [remap newline]  #'newline-and-indent

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -174,7 +174,7 @@
      (:prefix ("I" . "irc")
        :desc "Open irc app" "i"      #'=irc
        :desc "Quit irc" "q"          #'+irc/quit
-       :desc "Reconnect all" "r"     #'circle-reconnect-all
+       :desc "Reconnect all" "r"     #'circe-reconnect-all
        :desc "Send message" "s"      #'+irc/send-message
        (:when (featurep! :completion ivy)
          :desc "Jump to channel" "j" #'irc/ivy-jump-to-channel)))

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -147,7 +147,31 @@
        :desc "Edit line starts"   "a"         #'mc/edit-beginnings-of-lines
        :desc "Mark tag"           "s"         #'mc/mark-sgml-tag-pair
        :desc "Mark in defun"      "d"         #'mc/mark-all-like-this-in-defun
-       :desc "Add cursor w/mouse" "<mouse-1>" #'mc/add-cursor-on-click)))
+       :desc "Add cursor w/mouse" "<mouse-1>" #'mc/add-cursor-on-click))
+
+   ;; APPs
+
+   ;; Email
+   (:when (featurep! :app email)
+     (:prefix ("M" . "email")
+       :desc "Open email app" "m" #'=email
+       :desc "Compose email" "c"  #'+email/compose))
+   ;; IRC
+   (:when (featurep! :app irc)
+     (:prefix ("I" . "irc")
+       :desc "Open irc app" "i"      #'=irc
+       :desc "Quit irc" "q"          #'+irc/quit
+       :desc "Reconnect all" "r"     #'circle-reconnect-all
+       :desc "Send message" "s"      #'+irc/send-message
+       (when (featurep! :completion ivy)
+         :desc "Jump to channel" "j" #'irc/ivy-jump-to-channel)))
+   ;; Twitter
+   (:when (featurep! :app twitter)
+     (:prefix ("T" . "twitter")
+       :desc "Open twitter app" "t" #'=twitter
+       :desc "Quit twitter" "q"     #'+twitter/quit
+       :desc "Rerender twits" "r"   #'+twitter/rerender-all
+       :desc "Ace link" "l"         #'+twitter/ace-link)))
 
  ;; Plugins
 

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -181,6 +181,7 @@
  (:when (featurep! :ui treemacs)
    "<f9>" #'+treemacs)
  "C-="  #'er/expand-region
+ "C--"  #'er/contract-region
  ;; smartparens
  (:after smartparens
    (:map smartparens-mode-map

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -176,7 +176,10 @@
  ;; Plugins
 
  ;; misc plugins
- "<f9>" #'+neotree/open
+ (:when (featurep! :ui neotree)
+   "<f9>" #'+neotree/open)
+ (:when (featurep! :ui treemacs)
+   "<f9>" #'+treemacs)
  "C-="  #'er/expand-region
  ;; smartparens
  (:after smartparens

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -122,6 +122,7 @@
      :desc "Redo window config"           "U" #'winner-redo
      :desc "Switch to left workspace"     "p" #'+workspace/switch-left
      :desc "Switch to right workspace"    "n" #'+workspace/switch-right
+     :desc "Switch to"                    "w" #'+workspace/switch-to
      :desc "Switch to workspace 1"        "1" (λ! (+workspace/switch-to 0))
      :desc "Switch to workspace 2"        "2" (λ! (+workspace/switch-to 1))
      :desc "Switch to workspace 3"        "3" (λ! (+workspace/switch-to 2))

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -1,3 +1,258 @@
 ;;; config/default/+emacs-bindings.el -*- lexical-binding: t; -*-
 
-;; TODO
+;; Sensible deafult key bindings for non-evil users
+
+;; persp-mode and projectile in different prefixes
+(setq persp-keymap-prefix (kbd "C-c e"))
+(after! projectile
+  (define-key projectile-mode-map (kbd "C-c p") 'projectile-command-map))
+
+(which-key-add-key-based-replacements "C-c !"   "checking")
+(which-key-add-key-based-replacements "C-c e"   "perspective")
+(which-key-add-key-based-replacements "C-c p"   "projectile")
+
+;; Prefix key to invoke doom related commands
+(setq doom-leader-alt-key "C-c")
+
+(map!
+ ;; Text scaling
+ "C-+" (λ! (text-scale-set 0))
+ "C-=" #'text-scale-increase
+ "C--" #'text-scale-decrease
+ ;; Editor related bindings
+ "C-a"            #'doom/backward-to-bol-or-indent
+ [remap newline]  #'newline-and-indent
+ "C-j"           #'+default/newline
+ "C-S-s"          #'swiper
+ ;; Buffer related bindings
+ "C-x b"       #'persp-switch-to-buffer
+ "C-x C-b"     #'ibuffer-list-buffers
+ "C-x B"       #'switch-to-buffer
+ "C-x k"       #'doom/kill-this-buffer-in-all-windows
+ ;; Popup bindigns
+ "C-x p"   #'+popup/other
+ "C-`"     #'+popup/toggle
+ "C-~"     #'+popup/raise
+ ;; Doom emacs bindings
+ (:leader
+   (:prefix ("d" . "doom")
+     :desc "Dashboard"                 "d" #'+doom-dashboard/open
+     :desc "Recent files"              "f" #'recentf-open-files
+     (:when (featurep! :ui neotree)
+       :desc "Open neotree"            "n" #'+neotree/open
+       :desc "File in neotree"         "N" #'neotree/find-this-file)
+     (:when (featurep! :ui treemacs)
+       :desc "Toggle treemacs"         "n" #'+treemacs/toggle
+       :desc "File in treemacs"        "N" #'+treemacs/find-file)
+     :desc "Popup other"               "o" #'+popup/other
+     :desc "Popup toggle"              "t" #'+popup/toggle
+     :desc "Popup close"               "c" #'+popup/close
+     :desc "Popup close all"           "C" #'+popup/close-all
+     :desc "Popup raise"               "r" #'+popup/raise
+     :desc "Popup restore"             "R" #'+popup/restore
+     :desc "Scratch buffer"            "s" #'doom/open-scratch-buffer
+     :desc "Switch to scratch buffer"  "S" #'doom/switch-to-scratch-buffer
+     :desc "Sudo this file"            "u" #'doom/sudo-this-file
+     :desc "Sudo find file"            "U" #'doom/sudo-find-file
+     :desc "Eshell popup"              "e" #'+eshell/open-popup
+     :desc "Eshell open"               "E" #'+eshell/open
+     :desc "Reload Private Config"     "R" #'doom/reload)
+   ;; Org related bindings
+   "o" nil ; we need to unbind it first as Org claims this
+   (:prefix ("o". "org")
+     :desc "Do what I mean"          "o"     #'+org/dwim-at-point
+     :desc "Sync org caldav"         "s"     #'org-caldav-sync
+     (:prefix ("a" . "org agenda")
+       :desc "Agenda"                  "a"   #'org-agenda
+       :desc "Todo list"               "t"   #'org-todo-list
+       :desc "Tags view"               "m"   #'org-tags-view
+       :desc "View search"             "v"   #'org-search-view)
+     :desc "Capture"                 "c"     #'org-capture
+     :desc "Goto capture"            "C"     (λ! (require 'org-capture) (call-interactively #'org-capture-goto-target))
+     :desc "Switch org buffers"      "b"     #'org-switchb
+     (:prefix ("e" . "org export")
+       :desc "Export beamer to latex"  "l b" #'org-beamer-export-to-latex
+       :desc "Export beamer as latex"  "l B" #'org-beamer-export-as-latex
+       :desc "Export beamer as pdf"    "l P" #'org-beamer-export-to-pdf)
+     :desc "Link store"              "l"     #'org-store-link)
+   ;; Snippets
+   "&" nil ; yasnippet creates this prefix, we use a different one
+   (:prefix ("s" . "snippets")
+     :desc "New snippet"           "n" #'yas-new-snippet
+     :desc "Insert snippet"        "i" #'yas-insert-snippet
+     :desc "Find global snippet"   "/" #'yas-visit-snippet-file
+     :desc "Reload snippets"       "r" #'yas-reload-all
+     :desc "Create Temp Template"  "c" #'aya-create
+     :desc "Use Temp Template"     "e" #'aya-expand)
+   ;; Version control bindings
+   (:prefix ("v" . "versioning")
+     :desc "Browse issues tracker" "i" #'+vc/git-browse-issues
+     :desc "Browse remote"         "o" #'+vc/git-browse
+     :desc "Diff current file"     "d" #'magit-diff-buffer-file
+     :desc "Git revert hunk"       "r" #'git-gutter:revert-hunk
+     :desc "Git stage file"        "S" #'magit-stage-file
+     :desc "Git stage hunk"        "s" #'git-gutter:stage-hunk
+     :desc "Git time machine"      "t" #'git-timemachine-toggle
+     :desc "Git unstage file"      "U" #'magit-unstage-file
+     :desc "Initialize repo"       "I" #'magit-init
+     :desc "List repositories"     "L" #'magit-list-repositories
+     :desc "Magit blame"           "b" #'magit-blame-addition
+     :desc "Magit buffer log"      "l" #'magit-log-buffer-file
+     :desc "Magit commit"          "c" #'magit-commit-create
+     :desc "Magit status"          "g" #'magit-status
+     :desc "Next hunk"             "]" #'git-gutter:next-hunk
+     :desc "Previous hunk"         "[" #'git-gutter:previous-hunk)
+   ;; Worspace and window management bindings
+   (:prefix ("w". "workspaces")
+     :desc "Autosave session"             "a" #'+workspace/save-session
+     :desc "Display workspaces"           "d" #'+workspace/display
+     :desc "Rename workspace"             "r" #'+workspace/rename
+     :desc "Create workspace"             "c" #'+workspace/new
+     :desc "Delete workspace"             "k" #'+workspace/delete
+     :desc "Save session"                 "s" (λ! (let ((current-prefix-arg '(4))) (call-interactively #'+workspace/save-session)))
+     :desc "Save workspace"               "S" #'+workspace/save
+     :desc "Load session"                 "l" #'+workspace/load-session
+     :desc "Load last autosaved session"  "L" #'+workspace/load-last-session
+     :desc "Kill other buffers"           "o" #'doom/kill-other-buffers
+     :desc "Undo window config"           "u" #'winner-undo
+     :desc "Redo window config"           "U" #'winner-redo
+     :desc "Switch to left workspace"     "p" #'+workspace/switch-left
+     :desc "Switch to right workspace"    "n" #'+workspace/switch-right
+     :desc "Switch to workspace 1"        "1" (λ! (+workspace/switch-to 0))
+     :desc "Switch to workspace 2"        "2" (λ! (+workspace/switch-to 1))
+     :desc "Switch to workspace 3"        "3" (λ! (+workspace/switch-to 2))
+     :desc "Switch to workspace 4"        "4" (λ! (+workspace/switch-to 3))
+     :desc "Switch to workspace 5"        "5" (λ! (+workspace/switch-to 4))
+     :desc "Switch to workspace 6"        "6" (λ! (+workspace/switch-to 5))
+     :desc "Switch to workspace 7"        "7" (λ! (+workspace/switch-to 6))
+     :desc "Switch to workspace 8"        "8" (λ! (+workspace/switch-to 7))
+     :desc "Switch to workspace 9"        "9" (λ! (+workspace/switch-to 8))
+     :desc "Switch to last workspace"     "0" #'+workspace/switch-to-last)
+   ;; Multiple Cursors
+   (:when (featurep! :editor multiple-cursors)
+     (:prefix ("m" . "multiple cursors")
+       :desc "Edit lines"         "l"         #'mc/edit-lines
+       :desc "Mark next"          "n"         #'mc/mark-next-like-this
+       :desc "Unmark next"        "N"         #'mc/unmark-next-like-this
+       :desc "Mark previous"      "p"         #'mc/mark-previous-like-this
+       :desc "Unmark previous"    "P"         #'mc/unmark-previous-like-this
+       :desc "Mark all"           "t"         #'mc/mark-all-like-this
+       :desc "Mark all DWIM"      "m"         #'mc/mark-all-like-this-dwim
+       :desc "Edit line endings"  "e"         #'mc/edit-ends-of-lines
+       :desc "Edit line starts"   "a"         #'mc/edit-beginnings-of-lines
+       :desc "Mark tag"           "s"         #'mc/mark-sgml-tag-pair
+       :desc "Mark in defun"      "d"         #'mc/mark-all-like-this-in-defun
+       :desc "Add cursor w/mouse" "<mouse-1>" #'mc/add-cursor-on-click)))
+
+ ;; Plugins
+
+ ;; misc plugins
+ "<f9>" #'+neotree/open
+ "C-="  #'er/expand-region
+ ;; smartparens
+ (:after smartparens
+   (:map smartparens-mode-map
+     "C-M-a"     #'sp-beginning-of-sexp
+     "C-M-e"     #'sp-end-of-sexp
+     "C-M-f"     #'sp-forward-sexp
+     "C-M-b"     #'sp-backward-sexp
+     "C-M-d"     #'sp-splice-sexp
+     "C-M-k"     #'sp-kill-sexp
+     "C-M-t"     #'sp-transpose-sexp
+     "C-<right>" #'sp-forward-slurp-sexp
+     "M-<right>" #'sp-forward-barf-sexp
+     "C-<left>"  #'sp-backward-slurp-sexp
+     "M-<left>"  #'sp-backward-barf-sexp))
+ ;; company mode
+ "C-;" #'+company/complete
+ ;; Counsel
+ (:when (featurep! :completion ivy)
+   (:after counsel
+     (:map counsel-ag-map
+       [backtab]  #'+ivy/wgrep-occur      ; search/replace on results
+       "C-SPC"    #'ivy-call-and-recenter ; preview
+       "M-RET"    (+ivy-do-action! #'+ivy-git-grep-other-window-action))
+     "C-h b" #'counsel-descbinds
+     "C-M-y" #'counsel-yank-pop
+     "C-h F" #'counsel-faces
+     "C-h p" #'counsel-package
+     "C-h a" #'counsel-apropos
+     "C-h V" #'counsel-set-variable
+     "C-'"   #'counsel-imenu))
+ ;; repl toggle
+ "C-c C-z" #'+eval/open-repl
+ ;; company mode
+ (:after company
+   (:map company-active-map
+     "C-o"        #'company-search-kill-others
+     "C-n"        #'company-select-next
+     "C-p"        #'company-select-previous
+     "C-h"        #'company-quickhelp-manual-begin
+     "C-S-h"      #'company-show-doc-buffer
+     "C-s"        #'company-search-candidates
+     "M-s"        #'company-filter-candidates
+     "<C-tab>"    #'company-complete-common-or-cycle
+     [tab]        #'company-complete-common-or-cycle
+     [backtab]    #'company-select-previous
+     "C-RET"      #'counsel-company)
+   (:map company-search-map
+     "C-n"        #'company-search-repeat-forward
+     "C-p"        #'company-search-repeat-backward
+     "C-s"        (λ! (company-search-abort) (company-filter-candidates))))
+ ;; neotree bindings
+ (:after neotree
+   :map neotree-mode-map
+   "q"       #'neotree-hide
+   [return]  #'neotree-enter
+   "RET"     #'neotree-enter
+   "SPC"     #'neotree-quick-look
+   "v"       #'neotree-enter-vertical-split
+   "s"       #'neotree-enter-horizontal-split
+   "c"       #'neotree-create-node
+   "D"       #'neotree-delete-node
+   "g"       #'neotree-refresh
+   "r"       #'neotree-rename-node
+   "R"       #'neotree-refresh
+   "h"       #'+neotree/collapse-or-up
+   "l"       #'+neotree/expand-or-open
+   "n"       #'neotree-next-line
+   "p"       #'neotree-previous-line
+   "N"       #'neotree-select-next-sibling-node
+   "P"       #'neotree-select-previous-sibling-node)
+ ;; help and info
+ (:after help-mode
+   (:map help-mode-map
+     "o" #'ace-link-help
+     ">" #'help-go-forward
+     "<" #'help-go-back))
+ (:after helpful-mode
+   (:map helpful-mode-map
+     "o" #'ace-link-help))
+ (:after info
+   (:map Info-mode-map
+     "o" #'ace-link-info))
+ ;; yasnippet
+ (:after yasnippet
+   ;; keymap while editing an inserted snippet
+   (:map yas-keymap
+     "C-e"           #'snippets/goto-end-of-field
+     "C-a"           #'snippets/goto-start-of-field
+     "<S-tab>"       #'yas-prev-field
+     "<M-backspace>" #'+snippets/delete-to-start-of-field
+     [backspace]     #'+snippets/delete-backward-char
+     [delete]        #'+snippets/delete-forward-char-or-field))
+ ;; flycheck
+ (:after flycheck
+   (:map flycheck-error-list-mode-map
+     "C-n" #'flycheck-error-list-next-error
+     "C-p" #'flycheck-error-list-previous-error
+     "RET" #'flycheck-error-list-goto-error))
+ ;; ivy
+ (:after ivy
+   (:map ivy-minibuffer-map
+     "TAB" #'ivy-alt-done
+     "C-g" #'keyboard-escape-quit))
+ ;; ein notebokks
+ (:after ein:notebook-multilang
+   (:map ein:notebook-multilang-mode-map
+     "C-c h" #'+ein/hydra/body)))

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -176,7 +176,7 @@
        :desc "Quit irc" "q"          #'+irc/quit
        :desc "Reconnect all" "r"     #'circle-reconnect-all
        :desc "Send message" "s"      #'+irc/send-message
-       (when (featurep! :completion ivy)
+       (:when (featurep! :completion ivy)
          :desc "Jump to channel" "j" #'irc/ivy-jump-to-channel)))
    ;; Twitter
    (:when (featurep! :app twitter)

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -84,6 +84,14 @@
        :desc "Export beamer as latex"  "l B" #'org-beamer-export-as-latex
        :desc "Export beamer as pdf"    "l P" #'org-beamer-export-to-pdf)
      :desc "Link store"              "l"     #'org-store-link)
+   ;; Quit/Restart
+   (:prefix ("q" . "quit/restart")
+     :desc "Quit Emacs"                   "q" #'kill-emacs
+     :desc "Save and quit Emacs"          "Q" #'save-buffers-kill-terminal
+     (:when (featurep! :feature workspaces)
+       :desc "Quit Emacs & forget session"  "X" #'+workspace/kill-session-and-quit
+       :desc "Restart & restore Emacs"      "r" #'+workspace/restart-emacs-then-restore)
+     :desc "Restart Emacs"                "R" #'restart-emacs)
    ;; Snippets
    "&" nil ; yasnippet creates this prefix, we use a different one
    (:prefix ("s" . "snippets")

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -18,6 +18,17 @@
   (global-set-key (kbd "M-`") #'other-frame))
 
 ;;
+;; Minibuffer keybindings
+
+;; CUA keys in minibuffer
+(define-key! :keymaps +default-minibuffer-maps
+  [escape] #'abort-recursive-edit
+  "C-v"    #'yank
+  "C-z"    (λ! (ignore-errors (call-interactively #'undo)))
+  "C-a"    #'move-beginning-of-line
+  "C-b"    #'backward-word)
+
+;;
 ;; Global keybindings
 
 (define-key!

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -12,11 +12,6 @@
             doom-leader-key doom-localleader-key
             doom-leader-alt-key doom-localleader-alt-key))
 
-;; OS specific fixes
-(when IS-MAC
-  ;; Fix frame-switching key on MacOS
-  (global-set-key (kbd "M-`") #'other-frame))
-
 ;;
 ;; Minibuffer keybindings
 

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -53,12 +53,6 @@
   ;; textmate-esque deletion
   [M-backspace] #'doom/backward-kill-to-bol-and-indent)
 
-;; Smarter C-a/C-e for both Emacs and Evil. C-a will jump to indentation.
-;; Pressing it again will send you to the true bol. Same goes for C-e, except
-;; it will ignore comments+trailing whitespace before jumping to eol.
-(map! :gi "C-a" #'doom/backward-to-bol-or-indent
-      :gi "C-e" #'doom/forward-to-last-non-comment-or-eol)
-
 (map! (:map override
         ;; A little sandbox to run code in
         "A-;" #'eval-expression

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -12,9 +12,46 @@
             doom-leader-key doom-localleader-key
             doom-leader-alt-key doom-localleader-alt-key))
 
+;; OS specific fixes
+(when IS-MAC
+  ;; Fix frame-switching key on MacOS
+  (global-set-key (kbd "M-`") #'other-frame))
 
 ;;
 ;; Global keybindings
+
+(define-key!
+  ;; Buffer-local font scaling
+  "M-+" (λ! (text-scale-set 0))
+  "M-=" #'text-scale-increase
+  "M--" #'text-scale-decrease
+  ;; Simple window/frame navigation/manipulation
+  "M-w" #'delete-window
+  "M-W" #'delete-frame
+  "M-n" #'+default/new-buffer
+  "M-N" #'make-frame
+  ;; Restore OS undo, save, copy, & paste keys (without cua-mode, because
+  ;; it imposes some other functionality and overhead we don't need)
+  "M-z" #'undo
+  "M-s" #'save-buffer
+  "M-c" (if (featurep 'evil) 'evil-yank 'copy-region-as-kill)
+  "M-v" #'yank
+  ;; Textmate-esque bindings
+  "M-a" #'mark-whole-buffer
+  "M-b" #'+default/compile
+  "M-f" #'swiper
+  "M-q" (if (daemonp) #'delete-frame #'evil-quit-all)
+  ;; textmate-esque newline insertion
+  [M-return]    #'evil-open-below
+  [M-S-return]  #'evil-open-above
+  ;; textmate-esque deletion
+  [M-backspace] #'doom/backward-kill-to-bol-and-indent)
+
+;; Smarter C-a/C-e for both Emacs and Evil. C-a will jump to indentation.
+;; Pressing it again will send you to the true bol. Same goes for C-e, except
+;; it will ignore comments+trailing whitespace before jumping to eol.
+(map! :gi "C-a" #'doom/backward-to-bol-or-indent
+      :gi "C-e" #'doom/forward-to-last-non-comment-or-eol)
 
 (map! (:map override
         ;; A little sandbox to run code in

--- a/modules/config/default/config.el
+++ b/modules/config/default/config.el
@@ -114,15 +114,9 @@
   (define-key input-decode-map (kbd "TAB") [tab]))
 (add-hook 'tty-setup-hook #'+default|setup-input-decode-map)
 
-;; Restore CUA keys in minibuffer
+;; A Doom convention where C-s on popups and interactive searches will invoke
+;; ivy/helm for their superior filtering.
 (define-key! :keymaps +default-minibuffer-maps
-  [escape] #'abort-recursive-edit
-  "C-v"    #'yank
-  "C-z"    (λ! (ignore-errors (call-interactively #'undo)))
-  "C-a"    #'move-beginning-of-line
-  "C-b"    #'backward-word
-  ;; A Doom convention where C-s on popups and interactive searches will invoke
-  ;; ivy/helm for their superior filtering.
   "C-s"    (if (featurep! :completion ivy)
                #'counsel-minibuffer-history
              #'helm-minibuffer-history))

--- a/modules/config/default/config.el
+++ b/modules/config/default/config.el
@@ -141,6 +141,12 @@
     "M-x"  #'execute-extended-command
     "A-x"  #'execute-extended-command)
 
+  ;; Smarter C-a/C-e for both Emacs and Evil. C-a will jump to indentation.
+  ;; Pressing it again will send you to the true bol. Same goes for C-e, except
+  ;; it will ignore comments+trailing whitespace before jumping to eol.
+  (map! :gi "C-a" #'doom/backward-to-bol-or-indent
+        :gi "C-e" #'doom/forward-to-last-non-comment-or-eol)
+
   (if (featurep 'evil)
       (load! "+evil-bindings")
     (load! "+emacs-bindings")))

--- a/modules/config/default/config.el
+++ b/modules/config/default/config.el
@@ -128,7 +128,9 @@
 ;; OS specific fixes
 (when IS-MAC
   ;; Fix MacOS shift+tab
-  (define-key input-decode-map [S-iso-lefttab] [backtab]))
+  (define-key input-decode-map [S-iso-lefttab] [backtab])
+  ;; Fix frame-switching key on MacOS
+  (global-set-key (kbd "M-`") #'other-frame))
 
 ;;
 ;; Doom's keybinding scheme

--- a/modules/config/default/config.el
+++ b/modules/config/default/config.el
@@ -134,10 +134,7 @@
 ;; OS specific fixes
 (when IS-MAC
   ;; Fix MacOS shift+tab
-  (define-key input-decode-map [S-iso-lefttab] [backtab])
-  ;; Fix frame-switching key on MacOS
-  (global-set-key (kbd "M-`") #'other-frame))
-
+  (define-key input-decode-map [S-iso-lefttab] [backtab]))
 
 ;;
 ;; Doom's keybinding scheme
@@ -147,39 +144,6 @@
   (define-key! 'override
     "M-x"  #'execute-extended-command
     "A-x"  #'execute-extended-command)
-
-  (define-key!
-    ;; Buffer-local font scaling
-    "M-+" (λ! (text-scale-set 0))
-    "M-=" #'text-scale-increase
-    "M--" #'text-scale-decrease
-    ;; Simple window/frame navigation/manipulation
-    "M-w" #'delete-window
-    "M-W" #'delete-frame
-    "M-n" #'+default/new-buffer
-    "M-N" #'make-frame
-    ;; Restore OS undo, save, copy, & paste keys (without cua-mode, because
-    ;; it imposes some other functionality and overhead we don't need)
-    "M-z" #'undo
-    "M-s" #'save-buffer
-    "M-c" (if (featurep 'evil) 'evil-yank 'copy-region-as-kill)
-    "M-v" #'yank
-    ;; Textmate-esque bindings
-    "M-a" #'mark-whole-buffer
-    "M-b" #'+default/compile
-    "M-f" #'swiper
-    "M-q" (if (daemonp) #'delete-frame #'evil-quit-all)
-    ;; textmate-esque newline insertion
-    [M-return]    #'evil-open-below
-    [M-S-return]  #'evil-open-above
-    ;; textmate-esque deletion
-    [M-backspace] #'doom/backward-kill-to-bol-and-indent)
-
-  ;; Smarter C-a/C-e for both Emacs and Evil. C-a will jump to indentation.
-  ;; Pressing it again will send you to the true bol. Same goes for C-e, except
-  ;; it will ignore comments+trailing whitespace before jumping to eol.
-  (map! :gi "C-a" #'doom/backward-to-bol-or-indent
-        :gi "C-e" #'doom/forward-to-last-non-comment-or-eol)
 
   (if (featurep 'evil)
       (load! "+evil-bindings")


### PR DESCRIPTION
With the `default` module and the `+bindings` flag enabled, non-evil users will have a default set of bindings suitable for Doom emacs.