### PR TITLE
Fixes java-mode project package function

### DIFF
--- a/modules/feature/file-templates/templates/java-mode/.yas-setup.el
+++ b/modules/feature/file-templates/templates/java-mode/.yas-setup.el
@@ -1,7 +1,8 @@
 (defun yas-java-project-package ()
   (if (eq major-mode 'java-mode)
-    (s-chop-suffix "." (s-replace "/" "." (f-dirname (f-relative (buffer-file-name)
-                                                                 (concat (narf/project-root) "/src/")))))
+    (s-chop-prefixes '("main.java." "test.java.")
+                     (s-chop-suffix "." (s-replace "/" "." (f-dirname (f-relative (buffer-file-name)
+                                                                 (concat (doom-project-root) "/src/"))))))
     ""))
 
 (defun yas-java-class-name ()


### PR DESCRIPTION
This change fixes the el yas-java-project-package function.

- Use doom-project-dir instead of undefined narf function.
- Add support for maven/gradle main/java and test/java prefix paths.

I am not an expert elisper, please let me know if you need anything changed.

Thanks,

Aaron