### PR TITLE
Fix an issue where doom-leader-alt-key and doom-localleader-alt-key does not work in emacs mode

### DIFF
--- a/core/core-keybinds.el
+++ b/core/core-keybinds.el
@@ -77,14 +77,14 @@ If any hook returns non-nil, all hooks after it are ignored.")
 (after! evil
   (defmacro define-leader-key! (&rest args)
     `(general-define-key
-      :states '(normal visual motion insert)
+      :states '(normal visual motion insert emacs)
       :keymaps 'doom-leader-map
       :prefix doom-leader-key
       :non-normal-prefix doom-leader-alt-key
       ,@args))
 
   (general-create-definer define-localleader-key!
-    :states '(normal visual motion insert)
+    :states '(normal visual motion insert emacs)
     :major-modes t
     :wk-full-keys nil
     :prefix doom-localleader-key


### PR DESCRIPTION
Fixes #1071.

Also `general-non-normal-states` has the value `(insert emacs hybrid iedit-insert)`. I'm not sure if I should bother with `hybrid` and `iedit-insert` modes.
