### PR TITLE
bindings: correctly detect if syntax-checker is on

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -204,7 +204,7 @@
           "RET"     #'flyspell-correct-word-generic
           [mouse-1] #'flyspell-correct-word-generic))
 
-      (:when (featurep! :completion syntax-checker)
+      (:when (featurep! :feature syntax-checker)
         :m "]e" #'next-error
         :m "[e" #'previous-error
         (:after flycheck


### PR DESCRIPTION
A bug left from legacy code.

syntax-checker is now in "features" and not in "completion".