### PR TITLE
emacs/dired: Ranger package enhancement

### DIFF
--- a/core/packages.el
+++ b/core/packages.el
@@ -8,9 +8,7 @@
   (package! ns-auto-titlebar))
 
 ;; core-ui.el
-(package! all-the-icons
-  :recipe (:fetcher github :repo "ubolonton/all-the-icons.el"
-           :branch "font-lock-fix" :files (:defaults "data")))
+(package! all-the-icons)
 (package! hide-mode-line)
 (package! highlight-indentation)
 (package! highlight-numbers)

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -683,6 +683,9 @@
         (:when (featurep! :ui treemacs)
           :desc "Project sidebar" "p" #'+treemacs/toggle
           :desc "Find file in project sidebar" "P" #'+treemacs/find-file)
+        (:when (featurep! :emacs dired +ranger)
+          :desc "Deer"   "j" #'deer
+          :desc "Ranger" "J" #'ranger)
         (:when (featurep! :emacs imenu)
           :desc "Imenu sidebar" "i" #'imenu-list-smart-toggle)
         (:when (featurep! :emacs term)

--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -99,6 +99,10 @@
   :hook (dired-mode . all-the-icons-dired-mode))
 
 
+(def-package! font-lock+
+  :after all-the-icons-dired)
+
+
 (def-package! dired-x
   :hook (dired-mode . dired-omit-mode)
   :config

--- a/modules/emacs/dired/packages.el
+++ b/modules/emacs/dired/packages.el
@@ -5,4 +5,5 @@
 (when (featurep! +ranger)
   (package! ranger))
 (when (featurep! +icons)
-  (package! all-the-icons-dired))
+  (package! all-the-icons-dired)
+  (package! font-lock+ :recipe (:fetcher github :repo emacsmirror/font-lock-plus)))


### PR DESCRIPTION
I still want to use `font-lock+` in favor of a fork of all-the-icons fix. This time, I hook it after `all-the-icons-dired` since the major issue is `all-the-icons-dired-mode` not showing proper icons.

With `all-the-icons` fix fork, some icons are not showing correctly if we use `swiper` inside deer/ranger.

![image](https://user-images.githubusercontent.com/16655096/51019578-40b92600-1530-11e9-95b0-8ca4876ae41a.png)

While with `font-lock+` enabled, icons are showing properly.
![image](https://user-images.githubusercontent.com/16655096/51019620-66dec600-1530-11e9-9d3d-4eb5f1ca336e.png)
