### PR TITLE
Fix macOS paste shortcut

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -48,7 +48,12 @@
         [remap quit-window] #'kill-this-buffer)
 
       ;; misc
-      :n "C-S-f"  #'toggle-frame-fullscreen)
+      :n "C-S-f"  #'toggle-frame-fullscreen
+
+      ;; Ensure default macOS paste shortcut works everywhere
+      (:when IS-MAC
+        (:map general-override-mode-map
+          :gi "M-v" #'yank)))
 
 
 ;;


### PR DESCRIPTION
In some keymaps (`minibuffer-local-completion-map` and `helm-map` to name few) `M-v` is already mapped to something else