### PR TITLE
Improve projectile-git-command

### DIFF
--- a/core/core-projects.el
+++ b/core/core-projects.el
@@ -59,7 +59,7 @@
   ;; fd is a rust program that is significantly faster. It also respects
   ;; .gitignore. This is recommended in the projectile docs
   (when (executable-find "fd")
-    (setq projectile-git-command "fd . --type f -0"
+    (setq projectile-git-command "fd . --type f -0 -H -E .git"
           projectile-generic-command projectile-git-command)))
 
 


### PR DESCRIPTION
When indexing it ignores hidden files, which is especially annoying for dotfiles
where everything starts with a dot. If you just have -H it'll index .git too
though, so we exclude that