### PR TITLE
set nix-indent-function to #'nix-indent-line

### DIFF
--- a/modules/lang/nix/config.el
+++ b/modules/lang/nix/config.el
@@ -5,6 +5,8 @@
   :config
   (set-company-backend! 'nix-mode 'company-nixos-options)
 
+  (setq nix-indent-function #'nix-indent-line)
+
   (map! :localleader
         :map nix-mode-map
         "f" #'nix-update-fetch


### PR DESCRIPTION
otherwise when you indent (=) it'll indent everything to the very left and the
file will be flat!