### PR TITLE
irc: remap tracking-next-buffer to +irc/tracking-next-buffer

### DIFF
--- a/modules/app/irc/config.el
+++ b/modules/app/irc/config.el
@@ -143,6 +143,7 @@ playback.")
     (interactive)
     (when (derived-mode-p 'circe-mode)
       (tracking-next-buffer)))
+  (global-set-key [remap tracking-next-buffer] #'+irc/tracking-next-buffer)
 
   (after! solaire-mode
     ;; distinguish chat/channel buffers from server buffers.


### PR DESCRIPTION
This prevents default keybindings from using `tracking-next-buffer' so that a user doesn't accidentally end up in a weird mixed workspace.