### PR TITLE
Add descriptions for clojure-mode map

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -43,14 +43,12 @@
           cider-repl-wrap-history nil
           cider-stacktrace-default-filters '(tooling dup))
 
-    ;; TODO: Add mode-local labels when general support is in.
     (map! (:localleader
             (:map clojure-mode-map
               "'"  #'cider-jack-in
-              "\"" #'cider-jack-in-clojurescript)
-            (:map cider-mode-map
-              ;; eval
-              (:prefix "e"
+              "\"" #'cider-jack-in-clojurescript
+
+              (:prefix ("e" . "eval")
                 "d" #'cider-eval-defun-at-point
                 "D" #'cider-insert-defun-in-repl
                 "e" #'cider-eval-last-sexp
@@ -58,32 +56,26 @@
                 "r" #'cider-eval-region
                 "R" #'cider-insert-region-in-repl
                 "u" #'cider-undef)
-              ;; go/jump
-              (:prefix "g"
+              (:prefix ("g" . "go/jump")
                 "b" #'cider-pop-back
                 "g" #'cider-find-var
                 "n" #'cider-find-ns)
-              ;; help
-              (:prefix "h"
+              (:prefix ("h" . "help")
                 "n" #'cider-find-ns
                 "a" #'cider-apropos
                 "d" #'cider-doc
                 "g" #'cider-grimoire-web
                 "j" #'cider-javadoc)
-              ;; inspect
-              (:prefix "i"
+              (:prefix ("i" . "inspect")
                 "i" #'cider-inspect
                 "r" #'cider-inspect-last-result)
-              ;; macro
-              (:prefix "m"
+              (:prefix ("m" . "macro")
                 "e" #'cider-macroexpand-1
                 "E" #'cider-macroexpand-al)
-              ;; namespace
-              (:prefix "n"
+              (:prefix ("n" . "namespace")
                 "n" #'cider-browse-ns
                 "N" #'cider-browse-ns-all)
-              ;; repl
-              (:prefix "r"
+              (:prefix ("r" . "repl")
                 "n" #'cider-repl-set-ns
                 "q" #'cider-quit
                 "r" #'cider-refresh
@@ -105,9 +97,9 @@
   (def-package! clj-refactor
     :hook (clojure-mode . clj-refactor-mode)
     :config
-    (map! :map clj-refactor-map
+    (map! :map clojure-mode-map
           :localleader
-          "R" #'hydra-cljr-help-menu/body))
+          :desc "refactor" "R" #'hydra-cljr-help-menu/body))
 
   (def-package! flycheck-joker
     :when (featurep! :feature syntax-checker)


### PR DESCRIPTION
For some reason descriptions are not shown for minor mode maps (such as `cider-mode-map` and `clj-refactor-map` in Clojure package), so for now I've switched all mappings to major `clojure-mode-map`. I'm not sure if it's a right way to do it and what could be broken due to this switch, but so far I haven't encountered any problems with it.

I'm not really a Emacs expert, but initial investigation shows the following: 

`map!` macroexpands to the expression containing `:major-modes t` option:

```
ELISP> (macroexpand '(map! (:localleader (:map cider-mode-map (:prefix ("h" . "help") "d" #'cider-find-doc)))))
(general-define-key :keymaps
                    '(cider-mode-map)
                    :infix "h" ""
                    (list :ignore t :which-key "help")
                    "d" #'cider-find-doc :states
                    '(normal visual motion insert)
                    :major-modes t :wk-full-keys nil :prefix doom-localleader-key :non-normal-prefix doom-localleader-alt-key)
```

According to the `general.el` documentation `:major-modes t ` option does the following

> The :which-key keyword can be used with the :major-modes keyword (locally or globally) which can be compared to using which-key-add-major-mode-key-based-replacements. :major-modes can have the following values (see the examples below):
> t - the major mode will be obtained from all keymaps by removing “-map”

Clearly in case with minor mode maps it's not really correct because it's equivalent to `:major-modes '(cider-mode)` and `cider-mode` is not a major mode. 

I'm not sure how exactly `:major-modes` option affect behavior of the `general.el` but manual experimentation shows that descriptions still don't show up if `:major-modes` are ommited completely from the `general-define-key` call and show up if I explicitly pass `:major-modes '(clojure-mode)`. 

I didn't get if it's currently possible to adjust `:major-modes` option generated by `map!` so switched to using the major mode map as a workaround/hack.