### PR TITLE
Fix Clojure mode lookup handlers

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -18,8 +18,8 @@
     (set-repl-handler! 'clojure-mode #'+clojure/repl)
     (set-eval-handler! 'clojure-mode #'cider-eval-region)
     (set-lookup-handlers! 'clojure-mode
-      :definition #'cider-browse-ns-find-at-point
-      :documentation #'cider-browse-ns-doc-at-point)
+      :definition #'cider-find-dwim
+      :documentation #'cider-doc)
     (add-hook 'cider-mode-hook #'eldoc-mode)
     :config
     (setq nrepl-hide-special-buffers t
@@ -104,6 +104,9 @@
 
   (def-package! clj-refactor
     :hook (clojure-mode . clj-refactor-mode)
+    :init
+    (set-lookup-handlers! 'clojure-mode
+      :references #'cljr-find-usages)
     :config
     (map! :map clj-refactor-map
           :localleader


### PR DESCRIPTION
Both `cider-browse-ns-find-at-point` and `cider-browse-ns-doc-at-point` are functions that meant to be used inside of the Cider's [namespace browser](https://docs.cider.mx/en/latest/miscellaneous_features/#browsing-namespaces) and not in the regular source files, so I switched lookup handlers to use functions which actually work in source files. 

I've also added references lookup handler based on `clj-refactor` as Cider itself [doesn't support it (yet)](https://github.com/clojure-emacs/cider/issues/1840).