### PR TITLE
ivy-rich: add all-the-icon if it exists

### DIFF
--- a/modules/completion/ivy/autoload/ivy.el
+++ b/modules/completion/ivy/autoload/ivy.el
@@ -14,15 +14,20 @@
 Displays buffers in other projects in `font-lock-doc-face', and
 temporary/special buffers in `font-lock-comment-face'."
   (with-current-buffer (get-buffer candidate)
-    (propertize candidate
-     'face (cond ((string-match-p "^ *\\*" candidate)
-                  'font-lock-comment-face)
-                 ((not buffer-file-name) nil)
-                 ((not (file-in-directory-p
-                        buffer-file-name
-                        (or (doom-project-root)
-                            default-directory)))
-                  'font-lock-doc-face)))))
+	(let ((icon (all-the-icons-icon-for-mode major-mode)))
+      (concat (if (symbolp icon)
+	              (all-the-icons-icon-for-mode 'fundamental-mode)
+	            icon)
+              " "
+              (propertize candidate
+                          'face (cond ((string-match-p "^ *\\*" candidate)
+                                       'font-lock-comment-face)
+                                      ((not buffer-file-name) nil)
+                                      ((not (file-in-directory-p
+                                             buffer-file-name
+                                             (or (doom-project-root)
+                                                 default-directory)))
+                                       'font-lock-doc-face)))))))
 
 
 ;;


### PR DESCRIPTION
Most of this diff is just re-indentation, only the first few lines are new.