### PR TITLE
Add missing variable name

### DIFF
--- a/modules/lang/ruby/autoload.el
+++ b/modules/lang/ruby/autoload.el
@@ -45,7 +45,7 @@ started it."
             (+ruby-version))))
 
 ;;;###autoload
-(defun +ruby|update-version-in-all-buffers (&rest )
+(defun +ruby|update-version-in-all-buffers (&rest _)
   "Update `+ruby--version' in all `enh-ruby-mode' buffers."
   (dolist (buffer (doom-buffers-in-mode 'enh-ruby-mode))
     (setq +ruby-version-cache (clrhash +ruby-version-cache))


### PR DESCRIPTION
This enables compilation of the Ruby module where previously the
following error would cause a breaking error.

    ../../../lang/ruby/autoload.el:48:45:Error: &rest without variable name
    ✕ Failed to compile modules/lang/ruby/autoload.el
