### PR TITLE
Add transient quit evil-bindings

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -445,11 +445,14 @@
 
 ;;; :tools
 (map! (:when (featurep! :tools magit)
-        :after evil-magit
-        ;; fix conflicts with private bindings
-        :map (magit-status-mode-map magit-revision-mode-map)
-        "C-j" nil
-        "C-k" nil)
+        (:after evil-magit
+          ;; fix conflicts with private bindings
+          :map (magit-status-mode-map magit-revision-mode-map)
+          "C-j" nil
+          "C-k" nil)
+        (:map transient-map
+          [escape] #'transient-quit-one
+          "q"      #'transient-quit-one))
 
       (:when (featurep! :tools gist)
         :after gist


### PR DESCRIPTION
this adds back the dismiss behavior of "magit popups" that was lost from the
magit-popup -> transient update
