### PR TITLE
lang/haskell: only require intero when flag is set

### DIFF
--- a/modules/lang/haskell/packages.el
+++ b/modules/lang/haskell/packages.el
@@ -6,5 +6,5 @@
 (cond ((featurep! +dante)
        (package! dante)
        (package! attrap))
-      ((package! intero)))
-
+      ((featurep! +intero)
+       (package! intero)))


### PR DESCRIPTION
Looks like a leftover from https://github.com/hlissner/doom-emacs/issues/158
