### PR TITLE
Add haskell +lsp

### DIFF
--- a/modules/lang/haskell/+lsp.el
+++ b/modules/lang/haskell/+lsp.el
@@ -1,0 +1,8 @@
+;;; lang/haskell/+lsp.el -*- lexical-binding: t; -*-
+
+(def-package! lsp-haskell
+  :after haskell-mode
+  :init (add-hook 'haskell-mode-hook #'lsp)
+  :config
+  ;; Does some strange indentation if it pastes in the snippet
+  (setq company-lsp-enable-snippet nil))

--- a/modules/lang/haskell/+lsp.el
+++ b/modules/lang/haskell/+lsp.el
@@ -2,7 +2,7 @@
 
 (def-package! lsp-haskell
   :after haskell-mode
-  :init (add-hook 'haskell-mode-hook #'lsp)
+  :init (add-hook 'haskell-mode-hook #'+lsp|init)
   :config
   ;; Does some strange indentation if it pastes in the snippet
   (setq company-lsp-enable-snippet nil))

--- a/modules/lang/haskell/+lsp.el
+++ b/modules/lang/haskell/+lsp.el
@@ -5,4 +5,4 @@
   :init (add-hook 'haskell-mode-hook #'+lsp|init)
   :config
   ;; Does some strange indentation if it pastes in the snippet
-  (setq company-lsp-enable-snippet nil))
+  (setq yas-indent-line 'fixed))

--- a/modules/lang/haskell/+lsp.el
+++ b/modules/lang/haskell/+lsp.el
@@ -5,4 +5,4 @@
   :init (add-hook 'haskell-mode-hook #'+lsp|init)
   :config
   ;; Does some strange indentation if it pastes in the snippet
-  (setq yas-indent-line 'fixed))
+  (setq-hook! 'haskell-mode-hook yas-indent-line 'fixed))

--- a/modules/lang/haskell/config.el
+++ b/modules/lang/haskell/config.el
@@ -1,7 +1,8 @@
 ;;; lang/haskell/config.el -*- lexical-binding: t; -*-
 
 (cond ((featurep! +intero) (load! "+intero"))
-      ((featurep! +dante)  (load! "+dante")))
+      ((featurep! +dante)  (load! "+dante"))
+      ((featurep! +lsp)    (load! "+lsp")))
 
 ;;
 ;; Common packages

--- a/modules/lang/haskell/packages.el
+++ b/modules/lang/haskell/packages.el
@@ -7,4 +7,6 @@
        (package! dante)
        (package! attrap))
       ((featurep! +intero)
-       (package! intero)))
+       (package! intero))
+      ((featurep! +lsp)
+       (package! lsp-haskell)))


### PR DESCRIPTION
A few things are left wanting in this mode which has been mentioned on discord.
One of the glaring things is that when company-lsp has snippets, the line is
incorrectly indented when chosing a completion, and you have to unindent the
line. 

The other glaring issue is eldoc only shows what the function will return,
which would be bearable if company worked with snippets!

Some more digging re: eldoc should get you looking at `lsp-eldoc-render-all` and `lsp-markup-display-all`

[The lsp server is hie](https://github.com/haskell/haskell-ide-engine/)