### PR TITLE
Add LSP for Rust

### DIFF
--- a/modules/lang/rust/packages.el
+++ b/modules/lang/rust/packages.el
@@ -3,8 +3,10 @@
 
 ;; requires rust cargo racer
 
-(package! racer)
 (package! rust-mode)
 
 (when (featurep! :tools flycheck)
   (package! flycheck-rust))
+
+(unless (featurep! +lsp)
+  (package! racer))


### PR DESCRIPTION
In fact, Rust LSP already works :+1: :tada:  , this PR just disable racer when +lsp