### PR TITLE
Bind C-l to ivy-done in counsel-ag-map

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -302,6 +302,7 @@
         (:after counsel
           :map counsel-ag-map
           "C-SPC"    #'ivy-call-and-recenter ; preview
+          "C-l"      #'ivy-done
           [backtab]  #'+ivy/wgrep-occur      ; search/replace on results
           [C-return] (+ivy-do-action! #'+ivy-git-grep-other-window-action))
         (:after swiper


### PR DESCRIPTION
to make it more consistent with `ivy-minibuffer-map` rather than it being bound to `ivy-call-and-recenter` which is already mapped by `C-SPC`
