### PR TITLE
Improved switch-to-buffer-other-window for ivy

### DIFF
--- a/modules/completion/ivy/autoload/ivy.el
+++ b/modules/completion/ivy/autoload/ivy.el
@@ -34,7 +34,9 @@ temporary/special buffers in `font-lock-comment-face'."
 
 If ARG (universal argument), open selection in other-window."
   (interactive "P")
-  (ivy-read "Switch to workspace buffer: "
+  (ivy-read (if arg
+                "Switch to workspace buffer in other window: "
+              "Switch to workspace buffer: ")
             'internal-complete-buffer
             :predicate #'+ivy--is-workspace-or-other-buffer-p
             :action (if arg
@@ -43,6 +45,12 @@ If ARG (universal argument), open selection in other-window."
             :matcher #'ivy--switch-buffer-matcher
             :keymap ivy-switch-buffer-map
             :caller #'+ivy/switch-workspace-buffer))
+
+;;;###autoload
+(defun +ivy/switch-workspace-buffer-other-window (&optional arg)
+  "Switch the other window to a buffer within the current workspace."
+  (interactive)
+  (+ivy/switch-workspace-buffer t))
 
 (defun +ivy--tasks-candidates (tasks)
   "Generate a list of task tags (specified by `+ivy-task-tags') for

--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -76,7 +76,9 @@ immediately runs it on the current candidate (ending the ivy session)."
   :hook (ivy-mode . ivy-rich-mode)
   :config
   ;; Show more buffer information in other switch-buffer commands too
-  (dolist (cmd '(+ivy/switch-workspace-buffer
+  (dolist (cmd '(ivy-switch-buffer-other-window
+                 +ivy/switch-workspace-buffer
+                 +ivy/switch-workspace-buffer-other-window
                  counsel-projectile-switch-to-buffer))
     (ivy-set-display-transformer cmd 'ivy-rich--ivy-switch-buffer-transformer))
   ;; Use `+ivy-rich-buffer-name' to display buffer names

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -34,8 +34,11 @@
    "C-S-r"        #'helm-resume)
  ;; Buffer related bindings
  "C-x b"       #'persp-switch-to-buffer
+ (:when (featurep! :completion ivy)
+   "C-x 4 b"   #'+ivy/switch-workspace-buffer-other-window)
  "C-x C-b"     #'ibuffer-list-buffers
  "C-x B"       #'switch-to-buffer
+ "C-x 4 B"     #'switch-to-buffer-other-window
  "C-x k"       #'doom/kill-this-buffer-in-all-windows
  ;; Popup bindigns
  "C-x p"   #'+popup/other


### PR DESCRIPTION
Added `+ivy/switch-workspace-buffer-other-window` so we have matching behaviour for `C-x b` and `C-x 4 b`.  Ideally this would be a replacement for `persp-switch-to-buffer-other-window`, but that doesn't exist.

Also added `switch-to-buffer-other-window` binding for `C-x 4 B` to mirror `switch-to-buffer` on `C-x B`.

Also added the other-window variants to the ivy-rich enhancement list.