### PR TITLE
Added example of how to activate +ein-hydra

### DIFF
--- a/modules/tools/ein/README.org
+++ b/modules/tools/ein/README.org
@@ -12,6 +12,8 @@
   - [[Interaction with a Jupyter server][Interaction with a Jupyter server]]
 - [[Configuration][Configuration]]
   - [[Setting the default location of your notebooks][Setting the default location of your notebooks]]
+  - [[Using hydra][Using hydra]]
+
 
 * Description
 Adds Jupyter notebook integration into emacs.

--- a/modules/tools/ein/README.org
+++ b/modules/tools/ein/README.org
@@ -61,9 +61,8 @@ simplified and are easily accessible. However, by default, it's not bound to any
 Here's an example of how to bind it:
 
 #+BEGIN_SRC emacs-lisp
-(map!
-  (:map ein:notebook-mode-map
-   :localleader
-   :map ein:notebook-mode-map "," #'+ein-hydra/body))
+(map! :map ein:notebook-mode-map
+      :localleader
+      "," #'+ein-hydra/body)
 #+END_SRC
 

--- a/modules/tools/ein/README.org
+++ b/modules/tools/ein/README.org
@@ -51,3 +51,17 @@ Change ~+ein-notebook-dir~ to tell ein where to find your Jupityr notebooks.
 #+BEGIN_SRC emacs-lisp
 (setq +ein-notebook-dir "~/my-notebooks")
 #+END_SRC
+
+** Using hydra
+This module provides a batteries-included hydra - ~+ein-hydra~ - to make using ein
+easier. Things like navigating between cells, workbook management etc, are greatly
+simplified and are easily accessible. However, by default, it's not bound to any key.
+Here's an example of how to bind it:
+
+#+BEGIN_SRC emacs-lisp
+(map!
+  (:map ein:notebook-mode-map
+   :localleader
+   :map ein:notebook-mode-map "," #'+ein-hydra/body))
+#+END_SRC
+


### PR DESCRIPTION
Small change to README.org with an example of how to bind ein hydra. The code is based on hlissner's suggestion when I asked about this on Discord. Might be useful for other users setting up ein who are not too familiar with hydras (I didn't know you have to append `/body` to hydra definition to actually call it).