### PR TITLE
Remove C/C++ tab-always-indent override

### DIFF
--- a/modules/config/default/config.el
+++ b/modules/config/default/config.el
@@ -69,8 +69,7 @@
     (after! cc-mode
       (c-toggle-electric-state -1)
       (c-toggle-auto-newline -1)
-      (setq c-tab-always-indent nil
-            c-electric-flag nil)
+      (setq c-electric-flag nil)
       (dolist (key '("#" "{" "}" "/" "*" ";" "," ":" "(" ")" "\177"))
         (define-key c-mode-base-map key nil)))
 


### PR DESCRIPTION
The default config module sets `c-tab-always-indent` to `nil` when smartparens are enabled, but it's not clear why (it seems to come from the earliest days of this project).  This setting is not consistent with other modes, or with "standard" emacs behaviour.  Note that `tab-always-indent` is set `t` in `core-editor.el`.