### PR TITLE
Use configured variables for rtags binary names

### DIFF
--- a/modules/lang/cc/autoload.el
+++ b/modules/lang/cc/autoload.el
@@ -106,7 +106,7 @@ simpler."
   ;; first rtag
   (when (and (featurep 'rtags)
              rtags-enabled
-             (executable-find "rc"))
+             (executable-find rtags-rc-binary-name))
     (with-temp-buffer
       (message "Reloaded compile commands for rtags daemon")
       (rtags-call-rc :silent t "-J" (or (doom-project-root) default-directory))))

--- a/modules/lang/cc/config.el
+++ b/modules/lang/cc/config.el
@@ -191,6 +191,7 @@ compilation database is present in the project.")
   (defun +cc|init-rtags ()
     "Start an rtags server in c-mode and c++-mode buffers."
     (when (and (memq major-mode '(c-mode c++-mode))
+               (require 'rtags nil t)
                (rtags-executable-find rtags-rdm-binary-name))
       (rtags-start-process-unless-running)))
   (add-hook 'c-mode-common-hook #'+cc|init-rtags)

--- a/modules/lang/cc/config.el
+++ b/modules/lang/cc/config.el
@@ -191,7 +191,7 @@ compilation database is present in the project.")
   (defun +cc|init-rtags ()
     "Start an rtags server in c-mode and c++-mode buffers."
     (when (and (memq major-mode '(c-mode c++-mode))
-               (rtags-executable-find "rdm"))
+               (rtags-executable-find rtags-rdm-binary-name))
       (rtags-start-process-unless-running)))
   (add-hook 'c-mode-common-hook #'+cc|init-rtags)
   :config

--- a/modules/lang/cc/doctor.el
+++ b/modules/lang/cc/doctor.el
@@ -1,10 +1,11 @@
 ;; -*- lexical-binding: t; no-byte-compile: t; -*-
 ;;; lang/cc/doctor.el
 
-;; rtags
-(let ((bins (cl-remove-if #'executable-find '("rdm" "rc"))))
-  (when (/= (length bins) 0)
-    (warn! "Couldn't find the rtag client and/or server programs %s. Disabling rtags support" bins)))
+(when (require 'rtags nil t)
+  ;; rtags
+  (let ((bins (cl-remove-if #'executable-find `(,rtags-rdm-binary-name ,rtags-rc-binary-name))))
+    (when (/= (length bins) 0)
+      (warn! "Couldn't find the rtag client and/or server programs %s. Disabling rtags support" bins))))
 
 ;; irony server
 (when (require 'irony nil t)


### PR DESCRIPTION
`rtags` supports custom binary names.