### PR TITLE
Fix flycheck-posframe feature detection

### DIFF
--- a/modules/tools/flycheck/autoload.el
+++ b/modules/tools/flycheck/autoload.el
@@ -10,7 +10,7 @@
 (defun +flycheck*popup-tip-show-popup (orig-fn errors)
   "TODO"
   (if (and EMACS26+
-           (featurep 'flycheck-posframe)
+           (featurep! +childframe)
            (display-graphic-p))
       (flycheck-posframe-show-posframe errors)
     (funcall orig-fn errors)))


### PR DESCRIPTION
The auto-enabling of `flycheck-posframe` was not working due to broken feature check.