### PR TITLE
Bind some rspec functions for ruby and enh-ruby mode

### DIFF
--- a/modules/lang/ruby/config.el
+++ b/modules/lang/ruby/config.el
@@ -141,20 +141,21 @@
           rspec-mode-keymap (make-sparse-keymap)))
   :config
   (map! :localleader
-        :map rspec-mode-map
+        :mode (ruby-mode enh-ruby-mode rspec-mode)
         :prefix "t"
         "r" #'rspec-rerun
         "a" #'rspec-verify-all
-        "s" #'rspec-verify-single
         "v" #'rspec-verify
         "c" #'rspec-verify-continue
-        "e" #'rspec-toggle-example-pendingness
         "f" #'rspec-verify-method
         "l" #'rspec-run-last-failed
         "m" #'rspec-verify-matching
         "t" #'rspec-toggle-spec-and-target-find-example
-        "T" #'rspec-toggle-spec-and-target))
-
+        "T" #'rspec-toggle-spec-and-target
+        :mode rspec-mode
+        :prefix "t"
+        "s" #'rspec-verify-single
+        "e" #'rspec-toggle-example-pendingness))
 
 (def-package! minitest
   :defer t

--- a/modules/lang/ruby/config.el
+++ b/modules/lang/ruby/config.el
@@ -141,10 +141,11 @@
           rspec-mode-keymap (make-sparse-keymap)))
   :config
   (map! :localleader
-        :mode (ruby-mode enh-ruby-mode rspec-mode)
         :prefix "t"
-        "r" #'rspec-rerun
+        :map (rspec-verifiable-mode-map rspec-dired-mode-map)
         "a" #'rspec-verify-all
+        "r" #'rspec-rerun
+        :map rspec-verifiable-mode-map
         "v" #'rspec-verify
         "c" #'rspec-verify-continue
         "f" #'rspec-verify-method
@@ -152,10 +153,12 @@
         "m" #'rspec-verify-matching
         "t" #'rspec-toggle-spec-and-target-find-example
         "T" #'rspec-toggle-spec-and-target
-        :mode rspec-mode
-        :prefix "t"
+        :map rspec-mode-map
         "s" #'rspec-verify-single
-        "e" #'rspec-toggle-example-pendingness))
+        "e" #'rspec-toggle-example-pendingness
+        :map rspec-dired-mode-map
+        "v" #'rspec-dired-verify
+        "s" #'rspec-dired-verify-single))
 
 (def-package! minitest
   :defer t


### PR DESCRIPTION
Some rspec-mode's functions can be used under any Ruby source files. So
adding some localleader bindings for them.

Signed-off-by: Huy Duong <huy.duong@employmenthero.com>

