### PR TITLE
Fix cc fontification for constants with numbers

### DIFF
--- a/modules/lang/cc/autoload.el
+++ b/modules/lang/cc/autoload.el
@@ -143,7 +143,7 @@ simpler."
   "Better fontification for preprocessor constants"
   (when (memq major-mode '(c-mode c++-mode))
     (font-lock-add-keywords
-     nil '(("\\<[A-Z]*_[A-Z_]+\\>" . font-lock-constant-face)
+     nil '(("\\<[A-Z]*_[0-9A-Z_]+\\>" . font-lock-constant-face)
            ("\\<[A-Z]\\{3,\\}\\>"  . font-lock-constant-face))
      t)))
 


### PR DESCRIPTION
The regex wasn't matching numbers; `FOO_BAR` would be pretty, but `FOO_BAR_1` would not.