### PR TITLE
Only switch to dashboard when creating a new workspace

### DIFF
--- a/modules/feature/workspaces/autoload/workspaces.el
+++ b/modules/feature/workspaces/autoload/workspaces.el
@@ -507,7 +507,7 @@ This be hooked to `projectile-after-switch-project-hook'."
               (+workspace-message
                (format "Switched to '%s' in new workspace" new-name)
                'success))
-          (with-current-buffer (switch-to-buffer (doom-fallback-buffer))
+          (with-current-buffer (doom-fallback-buffer)
             (setq default-directory +workspaces--project-dir)
             (message "Switched to '%s'" (doom-project-name +workspaces--project-dir)))
           (unless current-prefix-arg

--- a/modules/feature/workspaces/config.el
+++ b/modules/feature/workspaces/config.el
@@ -21,7 +21,7 @@ new project directory.")
 Can be one of the following:
 
 t           Always create a new workspace for the project
-'non-empty  Only create a new workspace if the current one has no buffers
+'non-empty  Only create a new workspace if the current one already has buffers
             associated with it.
 nil         Never create a new workspace on project switch.")
 


### PR DESCRIPTION
The `+workspaces|switch-to-project` routine was unnecessarily switching to dashboard when `+workspaces-on-switch-project-behavior` was `nil` (forcing to re-use the current workspace).