### PR TITLE
Fix org-pdfview initialising too early

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -83,6 +83,7 @@
     :config (evil-org-agenda-set-keys)))
 
 (def-package! org-pdfview
+  :after org
   :when (featurep! :tools pdf)
   :commands (org-pdfview-open)
   :init


### PR DESCRIPTION
Fixes startup error when org and pdf modules enabled:

Error in a Doom module: modules/lang/org/config.el, (void-variable org-file-apps)