### PR TITLE
Fix doom-leader-alt-key binding for +emacs-bindings

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -14,6 +14,7 @@
 ;; Prefix key to invoke doom related commands
 (setq doom-leader-alt-key "C-c")
 (setq doom-localleader-alt-key "C-c l")
+(global-set-key (kbd doom-leader-alt-key) 'doom/leader)
 
 (map!
  ;; Text scaling


### PR DESCRIPTION
Since a4c0bc27 it's no longer possible to just `(setq doom-leader-alt-key ...)` from a module or even `$DOOMDIR/init.el`.  This is a workaround so non-vimmers aren't stuck with `M-SPC` in the interim.