### PR TITLE
Fix ace-link-help binding in helpful-mode

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -317,7 +317,7 @@
         "o" #'ace-link-help
         ">" #'help-go-forward
         "<" #'help-go-back)
-      (:after helpful-mode
+      (:after helpful
         :map helpful-mode-map
         "o" #'ace-link-help)
       (:after info


### PR DESCRIPTION
This was simply hooked to `helpful-mode.el` instead of `helpful.el`.