### PR TITLE
Add elisp-demos to lang/emacs-lisp module

### DIFF
--- a/modules/lang/emacs-lisp/config.el
+++ b/modules/lang/emacs-lisp/config.el
@@ -122,7 +122,7 @@ This marks a foldable marker for `outline-minor-mode' in elisp buffers.")
 
 
 (def-package! elisp-demos
-  :commands elisp-demos-advice-helpful-update
+  :defer t
   :init
   (advice-add 'helpful-update :after #'elisp-demos-advice-helpful-update))
 

--- a/modules/lang/emacs-lisp/config.el
+++ b/modules/lang/emacs-lisp/config.el
@@ -121,6 +121,12 @@ This marks a foldable marker for `outline-minor-mode' in elisp buffers.")
     (add-hook 'flycheck-mode-hook #'flycheck-cask-setup nil t)))
 
 
+(def-package! elisp-demos
+  :commands elisp-demos-advice-helpful-update
+  :init
+  (advice-add 'helpful-update :after #'elisp-demos-advice-helpful-update))
+
+
 ;;
 ;; Project modes
 

--- a/modules/lang/emacs-lisp/packages.el
+++ b/modules/lang/emacs-lisp/packages.el
@@ -6,6 +6,7 @@
 (package! macrostep)
 (package! overseer)
 (package! elisp-def)
+(package! elisp-demos)
 
 (when (featurep! :tools flycheck)
   (package! flycheck-cask))


### PR DESCRIPTION
This is an extremely useful package which adds little examples to the
help docs for a massive number of elisp functions.

https://github.com/xuchunyang/elisp-demos