### PR TITLE
Improvements to apropos and describe-symbol

### DIFF
--- a/core/autoload/help.el
+++ b/core/autoload/help.el
@@ -297,6 +297,21 @@ If prefix arg is prsent, refresh the cache."
             (delete-char -1)))))))
 
 ;;;###autoload
+(defun doom/describe-symbol (symbol)
+  "Show help for SYMBOL, a variable, function or macro."
+  (interactive
+   (list (helpful--read-symbol "Symbol: " #'helpful--bound-p)))
+  (let* ((sym (intern-soft symbol))
+         (bound (boundp sym))
+         (fbound (fboundp sym)))
+    (cond ((and sym bound (not fbound))
+           (helpful-variable sym))
+          ((and sym fbound (not bound))
+           (helpful-callable sym))
+          ((apropos (format "^%s\$" symbol)))
+          ((apropos (format "%s" symbol))))))
+
+;;;###autoload
 (defun doom/what-face (arg &optional pos)
   "Shows all faces and overlay faces at point.
 

--- a/core/core-editor.el
+++ b/core/core-editor.el
@@ -271,11 +271,7 @@ savehist file."
 
 ;; `helpful' --- a better *help* buffer
 (def-package! helpful
-  :commands (helpful-callable
-             helpful-command
-             helpful-variable
-             helpful-key
-             helpful--read-symbol)
+  :defer t
   :init
   (define-key!
     [remap describe-function] #'helpful-callable

--- a/core/core-editor.el
+++ b/core/core-editor.el
@@ -271,13 +271,31 @@ savehist file."
 
 ;; `helpful' --- a better *help* buffer
 (def-package! helpful
-  :defer t
+  :commands (helpful-callable
+             helpful-command
+             helpful-variable
+             helpful-key
+             helpful--read-symbol)
   :init
   (define-key!
     [remap describe-function] #'helpful-callable
     [remap describe-command]  #'helpful-command
     [remap describe-variable] #'helpful-variable
-    [remap describe-key]      #'helpful-key))
+    [remap describe-key]      #'helpful-key
+    [remap describe-symbol]   #'doom/describe-symbol)
+
+  (after! apropos
+    ;; patch apropos buttons to call helpful instead of help
+    (dolist (fun-bt '(apropos-function apropos-macro apropos-command))
+      (button-type-put
+       fun-bt 'action
+       (lambda (button)
+         (helpful-callable (button-get button 'apropos-symbol)))))
+    (dolist (var-bt '(apropos-variable apropos-user-option))
+      (button-type-put
+       var-bt 'action
+       (lambda (button)
+         (helpful-variable (button-get button 'apropos-symbol)))))))
 
 
 (def-package! ws-butler

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -320,6 +320,11 @@
       (:after helpful-mode
         :map helpful-mode-map
         "o" #'ace-link-help)
+      (:after apropos
+        :map apropos-mode-map
+        "o" #'ace-link-help
+        "n" #'forward-button
+        "p" #'backward-button)
       (:after info
         :map Info-mode-map
         "o" #'ace-link-info)

--- a/modules/lang/emacs-lisp/autoload.el
+++ b/modules/lang/emacs-lisp/autoload.el
@@ -126,9 +126,8 @@ library/userland functions"
 
 ;;;###autoload
 (defun +emacs-lisp-lookup-documentation (thing)
-  "Lookup THING with `helpful-symbol' if it's a symbol, apropos otherwise."
-  (cond ((not thing)
-         (call-interactively #'helpful-symbol))
-        ((if-let* ((sym (intern-soft thing))) (helpful-symbol sym)))
-        ((apropos (format "^%s" thing)))
-        ((apropos thing))))
+  "Lookup THING with `helpful-variable' if it's a variable, `helpful-callable'
+if it's callable, `apropos' otherwise."
+  (if (not thing)
+      (call-interactively #'doom/describe-symbol)
+    (doom/describe-symbol thing)))

--- a/modules/lang/emacs-lisp/autoload.el
+++ b/modules/lang/emacs-lisp/autoload.el
@@ -128,6 +128,6 @@ library/userland functions"
 (defun +emacs-lisp-lookup-documentation (thing)
   "Lookup THING with `helpful-variable' if it's a variable, `helpful-callable'
 if it's callable, `apropos' otherwise."
-  (if (not thing)
-      (call-interactively #'doom/describe-symbol)
-    (doom/describe-symbol thing)))
+  (if thing
+      (doom/describe-symbol thing)
+    (call-interactively #'doom/describe-symbol)))


### PR DESCRIPTION
Patch the apropos button types so they call helpful instead of the
built-in describe functions.  Also add some bindings to apropos-mode-map
so it behaves like other help modes.

Add `doom/describe-symbol` function, which shows documentation for
callable and variable symbols.  If a symbol is both a variable and a
callable, it dispatches to apropos.  This gives a better workflow than
`helpful-symbol`, which annoyingly prompts the user.

Remap `describe-symbol` to `doom/describe-symbol`, and update
`+emacs-lisp-lookup-documentation` to call it also.