### PR TITLE
Maximize window vertically/horizontally

### DIFF
--- a/core/autoload/ui.el
+++ b/core/autoload/ui.el
@@ -103,7 +103,7 @@ See `display-line-numbers' for what these values mean."
     (save-buffers-kill-emacs)))
 
 ;;;###autoload
-(defun doom/window-zoom ()
+(defun doom/window-maximize-buffer ()
   "Close other windows to focus on this one. Activate again to undo this. If the
 window changes before then, the undo expires.
 
@@ -119,7 +119,7 @@ Alternatively, use `doom/window-enlargen'."
 ;;;###autoload
 (defun doom/window-enlargen ()
   "Enlargen the current window to focus on this one. Does not close other
-windows (unlike `doom/window-zoom') Activate again to undo."
+windows (unlike `doom/window-maximize-buffer') Activate again to undo."
   (interactive)
   (setq doom--window-enlargened
         (if (and doom--window-enlargened
@@ -142,6 +142,24 @@ windows (unlike `doom/window-zoom') Activate again to undo."
                 (maximize-window))
             (maximize-window))
           t)))
+
+;;;###autoload
+(defun doom/window-maximize-horizontally ()
+  "Delete all windows to the left and right of the current window."
+  (interactive)
+  (require 'windmove)
+  (save-excursion
+    (while (ignore-errors (windmove-left)) (delete-window))
+    (while (ignore-errors (windmove-right)) (delete-window))))
+
+;;;###autoload
+(defun doom/window-maximize-vertically ()
+  "Delete all windows above and below the current window."
+  (interactive)
+  (require 'windmove)
+  (save-excursion
+    (while (ignore-errors (windmove-up)) (delete-window))
+    (while (ignore-errors (windmove-down)) (delete-window))))
 
 ;;;###autoload
 (defun doom/reload-font ()

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -95,11 +95,14 @@
         "L"       #'+evil/window-move-right
         "C-S-w"   #'ace-swap-window
         ;; Window undo/redo
+        (:prefix "m"
+            "m"   #'doom/window-maximize-buffer
+            "v"   #'doom/window-maximize-vertically
+            "s"   #'doom/window-maximize-horizontally)
         "u"       #'winner-undo
         "C-u"     #'winner-undo
         "C-r"     #'winner-redo
         "o"       #'doom/window-enlargen
-        "O"       #'doom/window-zoom
         ;; Delete window
         "c"       #'+workspace/close-window-or-workspace
         "C-C"     #'ace-delete-window)

--- a/modules/lang/org/autoload/org-present.el
+++ b/modules/lang/org/autoload/org-present.el
@@ -44,7 +44,7 @@
 ;;;###autoload
 (defun +org-present|init-org-tree-window ()
   "Set up the org window for presentation."
-  (doom/window-zoom)
+  (doom/window-maximize-buffer)
   (let ((cwm-use-vertical-padding t)
         (cwm-frame-internal-border 110)
         (cwm-left-fringe-ratio -10)


### PR DESCRIPTION
The default behavior for the windows key bindings is to *enlargen* instead of replacing all windows in the given direction. For me it sounds more sensible to do replacement but if you don't agree it's fine with me. I can keep this functionality in my private separate configuration.

I copied the maximize functions from Spacemacs. Apparently, they were copied from a blog post that no longer exists.

The second commit just adds the missing register key mapping for helm.