### PR TITLE
Fix autoloading helpful for doom/describe-symbol

### DIFF
--- a/core/core-editor.el
+++ b/core/core-editor.el
@@ -271,7 +271,7 @@ savehist file."
 
 ;; `helpful' --- a better *help* buffer
 (def-package! helpful
-  :defer t
+  :commands helpful--read-symbol
   :init
   (define-key!
     [remap describe-function] #'helpful-callable


### PR DESCRIPTION
We use `helpful--read-symbol` which isn't already autoloaded.