### PR TITLE
Fix loading of multiple-cursors configuration

### DIFF
--- a/modules/editor/multiple-cursors/config.el
+++ b/modules/editor/multiple-cursors/config.el
@@ -56,7 +56,7 @@
                                :evil-mc t))
 
 
-(after! multiple-cursors
+(after! multiple-cursors-core
   (setq mc/list-file (concat doom-etc-dir "mc-lists.el"))
 
   ;; TODO multiple-cursors config for Emacs users?


### PR DESCRIPTION
The package is split in a way that `multiple-cursors.el` is normally not
required when autoloading from commands; `multiple-cursors-core.el` is
always loaded.

Unfortunately the `mc/list-file` location is still not being set
properly, a fix has been submitted: magnars/multiple-cursors.el#355