### PR TITLE
Initialize dashboard later in window-setup-hook

### DIFF
--- a/modules/ui/doom-dashboard/config.el
+++ b/modules/ui/doom-dashboard/config.el
@@ -114,7 +114,7 @@ PLIST can have the following properties:
                               return t)))
         #'+doom-dashboard-initial-buffer))
 
-(add-hook! :append 'window-setup-hook #'+doom-dashboard|init)
+(add-hook 'doom-init-ui-hook #'+doom-dashboard|init)
 
 
 ;;

--- a/modules/ui/doom-dashboard/config.el
+++ b/modules/ui/doom-dashboard/config.el
@@ -114,7 +114,7 @@ PLIST can have the following properties:
                               return t)))
         #'+doom-dashboard-initial-buffer))
 
-(add-hook 'window-setup-hook #'+doom-dashboard|init)
+(add-hook! :append 'window-setup-hook #'+doom-dashboard|init)
 
 
 ;;


### PR DESCRIPTION
Since bb3f027c moved `projectile-mode` into `doom-init-ui-hook`,
projectile was getting initialized after the dashboard.  This means for
non-evil users, the `C-c p p` binding is not shown, because it's not yet
loaded.