### PR TITLE
Initialize dashboard later on doom-init-ui-hook

### DIFF
--- a/modules/ui/doom-dashboard/config.el
+++ b/modules/ui/doom-dashboard/config.el
@@ -114,7 +114,7 @@ PLIST can have the following properties:
                               return t)))
         #'+doom-dashboard-initial-buffer))
 
-(add-hook 'doom-init-ui-hook #'+doom-dashboard|init)
+(add-hook 'doom-init-ui-hook #'+doom-dashboard|init 'append)
 
 
 ;;


### PR DESCRIPTION
This needs to be appended so it runs after `project-mode`.