### PR TITLE
Updates to evil-mc config

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -409,8 +409,9 @@
           :nv "N" #'evil-mc-make-and-goto-last-cursor
           :nv "p" #'evil-mc-make-and-goto-prev-cursor
           :nv "P" #'evil-mc-make-and-goto-first-cursor
+          :nv "q" #'evil-mc-undo-all-cursors
           :nv "t" #'+multiple-cursors/evil-mc-toggle-cursors
-          :nv "u" #'evil-mc-undo-all-cursors
+          :nv "u" #'evil-mc-undo-last-added-cursor
           :nv "z" #'+multiple-cursors/evil-mc-make-cursor-here)
         (:after evil-mc
           :map evil-mc-key-map

--- a/modules/editor/multiple-cursors/config.el
+++ b/modules/editor/multiple-cursors/config.el
@@ -17,6 +17,7 @@
   (defvar evil-mc-key-map (make-sparse-keymap))
   :config
   (global-evil-mc-mode +1)
+  (setq evil-mc-enable-bar-cursor (not (or IS-MAC IS-WINDOWS)))
 
   (after! smartparens
     ;; Make evil-mc cooperate with smartparens better


### PR DESCRIPTION


`evil-mc-undo-last-added-cursor` was introduced upstsream and bound to "gru" by
default, with the `evil-mc-undo-all-cursors` binding shifted to "grq"

Bar cursors don't display well by default on Mac and Windows, see
https://github.com/gabesoft/evil-mc/issues/49

