### PR TITLE
Fixes for doom/kill-this-buffer-in-all-windows

### DIFF
--- a/core/autoload/buffers.el
+++ b/core/autoload/buffers.el
@@ -251,7 +251,8 @@ If DONT-SAVE, don't prompt to save modified buffers (discarding their changes)."
         (set-buffer-modified-p nil)))
     (kill-buffer buffer)
     (cl-loop for win in windows
-             if (doom-real-buffer-p (window-buffer win))
+             if (and (window-live-p win)
+                     (doom-unreal-buffer-p (window-buffer win)))
              do (with-selected-window win (previous-buffer)))))
 
 ;;;###autoload


### PR DESCRIPTION
This was erroring when run inside a popup (eg. `M-x ielm` `C-x k`) due
to a missing check for `window-live-p`.  We don't need to do anything if
the window has already gone away.

The real vs unreal check was backwards; we should only try
`previous-buffer` if the current buffer is *not* real.