### PR TITLE
[WIP] Organize local leader maps

### DIFF
--- a/modules/lang/agda/config.el
+++ b/modules/lang/agda/config.el
@@ -13,6 +13,7 @@
   :config
   (map! :map agda2-mode-map
         :localleader
+        ;; FIXME organize according to conventions?
         "?"   #'agda2-show-goals
         "."   #'agda2-goal-and-context-and-inferred
         ","   #'agda2-goal-and-context

--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -75,15 +75,27 @@
               "E" #'cider-macroexpand-all)
             (:prefix ("n" . "namespace")
               "n" #'cider-browse-ns
-              "N" #'cider-browse-ns-all)
-            (:prefix ("r" . "repl") ; FIXME r ~ refactor
+              "N" #'cider-browse-ns-all
+              "r" #'cider-ns-refresh)
+            (:prefix ("c" . "connection")
+              (:prefix ("l" . "link")
+                "b" 'sesman-link-with-buffer
+                "d" 'sesman-link-with-directory
+                "p" 'sesman-link-with-project
+                "u" 'sesman-unlink)
               "n" #'cider-repl-set-ns
               "q" #'cider-quit
-              "r" #'cider-refresh
               "R" #'cider-restart
               "b" #'cider-switch-to-repl-buffer
               "B" #'+clojure/cider-switch-to-repl-buffer-and-switch-ns
-              "c" #'cider-repl-clear-buffer)))
+              "c" #'cider-repl-clear-buffer
+              "i" #'sesman-info
+              ;; TODO add bindings for the following?
+              ;; sesman-browser
+              ;; sesman-start (interface for all cider-jack-in-* and cider-connect-* commands)
+              ;; sesman-restart instead of cider-restart?
+              ;; sesman-quit instead of cider-quit?
+              )))
 
         (:when (featurep! :feature evil +everywhere)
           :map cider-repl-mode-map
@@ -105,7 +117,7 @@
   :config
   (map! :map clojure-mode-map
         :localleader
-        :desc "refactor" "R" #'hydra-cljr-help-menu/body))
+        :desc "refactor" "r" #'hydra-cljr-help-menu/body))
 
 
 (def-package! flycheck-joker

--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -56,7 +56,7 @@
               "r" #'cider-eval-region
               "R" #'cider-insert-region-in-repl
               "u" #'cider-undef)
-            (:prefix ("g" . "go/jump")
+            (:prefix ("g" . "goto")
               "b" #'cider-pop-back
               "g" #'cider-find-var
               "n" #'cider-find-ns)

--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -49,6 +49,7 @@
             "\"" #'cider-jack-in-clojurescript
 
             (:prefix ("e" . "eval")
+              "b" #'cider-eval-buffer
               "d" #'cider-eval-defun-at-point
               "D" #'cider-insert-defun-in-repl
               "e" #'cider-eval-last-sexp

--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -76,7 +76,7 @@
             (:prefix ("n" . "namespace")
               "n" #'cider-browse-ns
               "N" #'cider-browse-ns-all)
-            (:prefix ("r" . "repl")
+            (:prefix ("r" . "repl") ; FIXME r ~ refactor
               "n" #'cider-repl-set-ns
               "q" #'cider-quit
               "r" #'cider-refresh

--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -71,7 +71,7 @@
               "r" #'cider-inspect-last-result)
             (:prefix ("m" . "macro")
               "e" #'cider-macroexpand-1
-              "E" #'cider-macroexpand-al)
+              "E" #'cider-macroexpand-all)
             (:prefix ("n" . "namespace")
               "n" #'cider-browse-ns
               "N" #'cider-browse-ns-all)

--- a/modules/lang/common-lisp/config.el
+++ b/modules/lang/common-lisp/config.el
@@ -111,11 +111,11 @@ bin/doom while packages at compile-time (not a runtime though)."
           "r" #'sly-compile-region)
         (:prefix ("e" . "eval")
           "b" #'sly-eval-buffer
+          "d" #'sly-eval-defun
           "e" #'sly-eval-last-expression
           "E" #'sly-eval-print-last-expression
-          "f" #'sly-eval-defun
-          "F" #'sly-undefine-function
-          "r" #'sly-eval-region)
+          "r" #'sly-eval-region
+          "u" #'sly-undefine-function)
         (:prefix ("m" . "macro")
           "e" #'+common-lisp/macrostep/body
           "E" #'macrostep-expand)

--- a/modules/lang/common-lisp/config.el
+++ b/modules/lang/common-lisp/config.el
@@ -79,7 +79,7 @@ bin/doom while packages at compile-time (not a runtime though)."
   (map! :localleader
         :map sly-mode-map
         "'" #'sly
-        (:prefix "g"
+        (:prefix ("g" . "goto")
           "b" #'sly-pop-find-definition-stack
           "d" #'sly-edit-definition
           "D" #'sly-edit-definition-other-window

--- a/modules/lang/common-lisp/config.el
+++ b/modules/lang/common-lisp/config.el
@@ -87,7 +87,7 @@ bin/doom while packages at compile-time (not a runtime though)."
           "N" #'sly-previous-note
           "s" #'sly-stickers-next-sticker
           "S" #'sly-stickers-prev-sticker)
-        (:prefix "h"
+        (:prefix ("h" . "help")
           "<" #'sly-who-calls
           ">" #'sly-calls-who
           "~" #'hyperspec-lookup-format
@@ -109,7 +109,7 @@ bin/doom while packages at compile-time (not a runtime though)."
           "l" #'sly-load-file
           "n" #'sly-remove-notes
           "r" #'sly-compile-region)
-        (:prefix "e"
+        (:prefix ("e" . "eval")
           "b" #'sly-eval-buffer
           "e" #'sly-eval-last-expression
           "E" #'sly-eval-print-last-expression
@@ -124,7 +124,7 @@ bin/doom while packages at compile-time (not a runtime though)."
           "q" #'sly-quit-lisp
           "r" #'sly-restart-inferior-lisp
           "s" #'sly-mrepl-sync)
-        (:prefix "s"
+        (:prefix ("s" . "stickers")
           "b" #'sly-stickers-toggle-break-on-stickers
           "c" #'sly-stickers-clear-defun-stickers
           "C" #'sly-stickers-clear-buffer-stickers

--- a/modules/lang/common-lisp/config.el
+++ b/modules/lang/common-lisp/config.el
@@ -116,7 +116,7 @@ bin/doom while packages at compile-time (not a runtime though)."
           "f" #'sly-eval-defun
           "F" #'sly-undefine-function
           "r" #'sly-eval-region)
-        (:prefix "m"
+        (:prefix ("m" . "macro")
           "e" #'+common-lisp/macrostep/body
           "E" #'macrostep-expand)
         (:prefix "r"

--- a/modules/lang/common-lisp/config.el
+++ b/modules/lang/common-lisp/config.el
@@ -102,7 +102,7 @@ bin/doom while packages at compile-time (not a runtime though)."
           "r" #'sly-who-references
           "s" #'sly-who-specializes
           "S" #'sly-who-sets)
-        (:prefix "c"
+        (:prefix ("b" . "build")
           "c" #'sly-compile-file
           "C" #'sly-compile-and-load-file
           "f" #'sly-compile-defun

--- a/modules/lang/common-lisp/config.el
+++ b/modules/lang/common-lisp/config.el
@@ -119,7 +119,7 @@ bin/doom while packages at compile-time (not a runtime though)."
         (:prefix ("m" . "macro")
           "e" #'+common-lisp/macrostep/body
           "E" #'macrostep-expand)
-        (:prefix "r"
+        (:prefix ("r" . "repl") ;; FIXME r ~ "refactor"
           "c" #'sly-mrepl-clear-repl
           "q" #'sly-quit-lisp
           "r" #'sly-restart-inferior-lisp
@@ -131,7 +131,7 @@ bin/doom while packages at compile-time (not a runtime though)."
           "f" #'sly-stickers-fetch
           "r" #'sly-stickers-replay
           "s" #'sly-stickers-dwim)
-        (:prefix "t"
+        (:prefix ("t" . "trace") ;; FIXME move to ("d" . "debug")?
           "t" #'sly-toggle-trace-fdefinition
           "T" #'sly-toggle-fancy-trace
           "u" #'sly-untrace-all))

--- a/modules/lang/csharp/config.el
+++ b/modules/lang/csharp/config.el
@@ -41,7 +41,7 @@
           "r"  #'omnisharp-rename
           "a"  #'omnisharp-show-last-auto-complete-result
           "o"  #'omnisharp-show-overloads-at-point)
-        (:prefix "f"
+        (:prefix ("g" . "goto")
           "u"  #'omnisharp-find-usages
           "i"  #'omnisharp-find-implementations
           "f"  #'omnisharp-navigate-to-current-file-member

--- a/modules/lang/emacs-lisp/config.el
+++ b/modules/lang/emacs-lisp/config.el
@@ -72,6 +72,9 @@ This marks a foldable marker for `outline-minor-mode' in elisp buffers.")
 
   (map! :localleader
         :map emacs-lisp-mode-map
+        (:prefix ("g" . "goto")
+          "f" #'find-function
+          "v" #'find-variable)
         "m" #'macrostep-expand))
 
 

--- a/modules/lang/emacs-lisp/config.el
+++ b/modules/lang/emacs-lisp/config.el
@@ -72,7 +72,7 @@ This marks a foldable marker for `outline-minor-mode' in elisp buffers.")
 
   (map! :localleader
         :map emacs-lisp-mode-map
-        "e" #'macrostep-expand))
+        "m" #'macrostep-expand))
 
 
 ;;

--- a/modules/lang/emacs-lisp/config.el
+++ b/modules/lang/emacs-lisp/config.el
@@ -72,6 +72,11 @@ This marks a foldable marker for `outline-minor-mode' in elisp buffers.")
 
   (map! :localleader
         :map emacs-lisp-mode-map
+        (:prefix ("e" . "eval")
+          "b" #'eval-buffer
+          "d" #'eval-defun
+          "e" #'eval-last-sexp
+          "r" #'eval-region)
         (:prefix ("g" . "goto")
           "f" #'find-function
           "v" #'find-variable)

--- a/modules/lang/idris/config.el
+++ b/modules/lang/idris/config.el
@@ -8,12 +8,13 @@
     :file #'idris-load-file)
   (map! :localleader
         :map idris-mode-map
+        ;; TODO standardize?
         "r" #'idris-load-file
         "t" #'idris-type-at-point
-        "d" #'idris-add-clause
-        "l" #'idris-make-lemma
-        "c" #'idris-case-split
-        "w" #'idris-make-with-block
-        "m" #'idris-add-missing
+        "d" #'idris-add-clause          ; ac (:prefix "a" . "add")
+        "l" #'idris-make-lemma          ; al
+        "c" #'idris-case-split          ; as
+        "w" #'idris-make-with-block     ; ab
+        "m" #'idris-add-missing         ; am
         "p" #'idris-proof-search
         "h" #'idris-docs-at-point))

--- a/modules/lang/java/+eclim.el
+++ b/modules/lang/java/+eclim.el
@@ -32,7 +32,7 @@
           "p"  #'eclim-problems
           "r"  #'meghanada-reference
           "t"  #'meghanada-typeinfo)
-        (:prefix "b"
+        (:prefix ("b" . "build")
           "b"  #'eclim-project-build
           "c"  #'eclim-project-create
           "d"  #'eclim-project-delete

--- a/modules/lang/java/+eclim.el
+++ b/modules/lang/java/+eclim.el
@@ -18,13 +18,13 @@
 
   (map! :localleader
         :map java-mode-map
-        (:prefix "r"
+        (:prefix ("r" . "refactor")
           "gc" #'eclim-java-constructor
           "gg" #'eclim-java-generate-getter-and-setter
           "oi" #'eclim-java-import-organize
           "f"  #'eclim-java-format
           "r"  #'eclim-java-refactor-rename-symbol-at-point)
-        (:prefix "h"
+        (:prefix ("h" . "help")
           "."  #'eclim-java-show-documentation-for-current-element
           "r"  #'eclim-java-find-references
           "c"  #'eclim-java-call-hierarchy

--- a/modules/lang/java/+meghanada.el
+++ b/modules/lang/java/+meghanada.el
@@ -24,6 +24,6 @@
         (:prefix "h"
           "r"  #'meghanada-reference
           "t"  #'meghanada-typeinfo)
-        (:prefix "b"
+        (:prefix ("b" . "build")
           "f"  #'meghanada-compile-file
           "p"  #'meghanada-compile-project)))

--- a/modules/lang/java/+meghanada.el
+++ b/modules/lang/java/+meghanada.el
@@ -16,12 +16,12 @@
 
   (map! :localleader
         :map java-mode-map
-        (:prefix "r"
+        (:prefix ("r" . "refactor")
           "ia" #'meghanada-import-all
           "io" #'meghanada-optimize-import
           "l"  #'meghanada-local-variable
           "f"  #'meghanada-code-beautify)
-        (:prefix "h"
+        (:prefix ("h" . "help")
           "r"  #'meghanada-reference
           "t"  #'meghanada-typeinfo)
         (:prefix ("b" . "build")

--- a/modules/lang/javascript/config.el
+++ b/modules/lang/javascript/config.el
@@ -172,8 +172,9 @@
         :map tide-mode-map
         "R"   #'tide-restart-server
         "f"   #'tide-reformat
-        "rs"  #'tide-rename-symbol
-        "roi" #'tide-organize-imports))
+        (:prefix ("r" . "refactor")
+          "s" #'tide-rename-symbol
+          "oi" #'tide-organize-imports)))
 
 
 (def-package! xref-js2
@@ -202,7 +203,7 @@
 
 ;; `skewer-mode'
 (map! :localleader
-      :prefix "s"
+      :prefix ("s" . "skewer")
       (:after skewer-mode
         :map skewer-mode-map
         "E" #'skewer-eval-last-expression
@@ -225,7 +226,7 @@
 (map! :after npm-mode
       :localleader
       :map npm-mode-keymap
-      :prefix "n"
+      :prefix ("n" . "npm")
       "n" #'npm-mode-npm-init
       "i" #'npm-mode-npm-install
       "s" #'npm-mode-npm-install-save

--- a/modules/lang/javascript/config.el
+++ b/modules/lang/javascript/config.el
@@ -57,6 +57,7 @@
   (after! projectile
     (add-to-list 'projectile-globally-ignored-directories "node_modules"))
 
+  ;; FIXME move to skewer-mode map! form below?
   (map! :map js2-mode-map
         :localleader
         "S" #'+javascript/skewer-this-buffer))

--- a/modules/lang/ledger/config.el
+++ b/modules/lang/ledger/config.el
@@ -41,6 +41,7 @@
 
         :localleader
         :map ledger-mode-map
+        ;; FIXME is this evil specific?
         "a" #'ledger-add-transaction
         "t" #'ledger-toggle-current
         "d" #'ledger-delete-current-transaction

--- a/modules/lang/markdown/config.el
+++ b/modules/lang/markdown/config.el
@@ -47,7 +47,7 @@
           :n "M-r" #'browse-url-of-file)
         (:localleader
           "o" #'markdown-open
-          "b" #'markdown-preview
+          "b" #'markdown-preview ; FIXME p?
           (:prefix ("i" . "insert")
             "t" #'markdown-toc-generate-toc
             "i" #'markdown-insert-image

--- a/modules/lang/markdown/config.el
+++ b/modules/lang/markdown/config.el
@@ -48,7 +48,7 @@
         (:localleader
           "o" #'markdown-open
           "b" #'markdown-preview
-          (:prefix "i"
+          (:prefix ("i" . "insert")
             "t" #'markdown-toc-generate-toc
             "i" #'markdown-insert-image
             "l" #'markdown-insert-link))))

--- a/modules/lang/nix/config.el
+++ b/modules/lang/nix/config.el
@@ -10,7 +10,7 @@
   (map! :localleader
         :map nix-mode-map
         "f" #'nix-update-fetch
-        "p" #'nix-format-buffer
+        "p" #'nix-format-buffer ; FIXME F?
         "r" #'nix-repl-show
         "s" #'nix-shell
         "b" #'nix-build

--- a/modules/lang/ocaml/config.el
+++ b/modules/lang/ocaml/config.el
@@ -41,8 +41,8 @@
 
     (map! :localleader
           :map tuareg-mode-map
-          "t" #'merlin-type-enclosing
-          "a" #'tuareg-find-alternate-file)
+          "t" #'merlin-type-enclosing   ; FIXME ht? t ~ tests
+          "a" #'tuareg-find-alternate-file) ; FIXME ga?
 
     (def-package! merlin-eldoc
       :hook (merlin-mode . merlin-eldoc-setup))

--- a/modules/lang/php/config.el
+++ b/modules/lang/php/config.el
@@ -27,7 +27,7 @@
 
   (map! :localleader
         :map php-mode-map
-        :prefix "t"
+        :prefix ("t" . "test")
         "r" #'phpunit-current-project
         "a" #'phpunit-current-class
         "s" #'phpunit-current-test))
@@ -58,7 +58,7 @@
 
   (map! :localleader
         :map php-mode-map
-        :prefix "r"
+        :prefix ("r" . "refactor")
         "cc" #'phpactor-copy-class
         "mc" #'phpactor-move-class
         "oi" #'phpactor-offset-info
@@ -71,7 +71,7 @@
   :config
   (map! :localleader
         :map php-refactor-mode-map
-        :prefix "r"
+        :prefix ("r" . "refactor")
         "cv" #'php-refactor--convert-local-to-instance-variable
         "u"  #'php-refactor--optimize-use
         "xm" #'php-refactor--extract-method

--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -89,7 +89,7 @@ called.")
           "d" #'anaconda-mode-find-definitions
           "a" #'anaconda-mode-find-assignments
           "f" #'anaconda-mode-find-file
-          "u" #'anaconda-mode-find-references)))
+          "u" #'anaconda-mode-find-references))) ; FIXME r?
 
 
 (def-package! nose
@@ -122,8 +122,8 @@ called.")
         :map python-mode-map
         :prefix ("t" . "test")
         "f" #'python-pytest-file
-        "k" #'python-pytest-file-dwim
-        "m" #'python-pytest-repeat
+        "k" #'python-pytest-file-dwim   ; FIXME t?
+        "m" #'python-pytest-repeat      ; FIXME r?
         "p" #'python-pytest-popup))
 
 

--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -84,12 +84,12 @@ called.")
     (add-hook 'anaconda-mode-hook #'evil-normalize-keymaps))
   (map! :localleader
         :map anaconda-mode-map
-        :prefix "f"
-        "d" #'anaconda-mode-find-definitions
         "h" #'anaconda-mode-show-doc
-        "a" #'anaconda-mode-find-assignments
-        "f" #'anaconda-mode-find-file
-        "u" #'anaconda-mode-find-references))
+        (:prefix ("g" . "goto")
+          "d" #'anaconda-mode-find-definitions
+          "a" #'anaconda-mode-find-assignments
+          "f" #'anaconda-mode-find-file
+          "u" #'anaconda-mode-find-references)))
 
 
 (def-package! nose

--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -104,7 +104,7 @@ called.")
 
   (map! :localleader
         :map nose-mode-map
-        :prefix "t"
+        :prefix ("t" . "test")
         "r" #'nosetests-again
         "a" #'nosetests-all
         "s" #'nosetests-one
@@ -120,7 +120,7 @@ called.")
   (map! :after python
         :localleader
         :map python-mode-map
-        :prefix "t"
+        :prefix ("t" . "test")
         "f" #'python-pytest-file
         "k" #'python-pytest-file-dwim
         "m" #'python-pytest-repeat

--- a/modules/lang/racket/config.el
+++ b/modules/lang/racket/config.el
@@ -45,7 +45,7 @@
           "d" #'racket-visit-definition
           "m" #'racket-visit-module
           "r" #'racket-open-require-path)
-        (:prefix "s"
+        (:prefix ("e" . "eval")
           "d" #'racket-send-definition
-          "l" #'racket-send-last-sexp
+          "e" #'racket-send-last-sexp
           "r" #'racket-send-region)))

--- a/modules/lang/racket/config.el
+++ b/modules/lang/racket/config.el
@@ -36,11 +36,10 @@
         "t" #'racket-test
         "u" #'racket-backward-up-list
         "y" #'racket-insert-lambda
-        (:prefix "e"
+        (:prefix ("m" . "macro")
           "d" #'racket-expand-definition
-          "l" #'racket-expand-last-sexp
-          "r" #'racket-expand-region
-          "a" #'racket-expand-again)
+          "e" #'racket-expand-last-sexp
+          "r" #'racket-expand-region)
         (:prefix "g"
           "d" #'racket-visit-definition
           "m" #'racket-visit-module

--- a/modules/lang/racket/config.el
+++ b/modules/lang/racket/config.el
@@ -40,11 +40,11 @@
           "d" #'racket-expand-definition
           "e" #'racket-expand-last-sexp
           "r" #'racket-expand-region)
-        (:prefix "g"
+        (:prefix ("g" . "goto")
+          "b" #'racket-unvisit
           "d" #'racket-visit-definition
           "m" #'racket-visit-module
-          "r" #'racket-open-require-path
-          "b" #'racket-unvisit)
+          "r" #'racket-open-require-path)
         (:prefix "s"
           "d" #'racket-send-definition
           "l" #'racket-send-last-sexp

--- a/modules/lang/ruby/config.el
+++ b/modules/lang/ruby/config.el
@@ -46,12 +46,12 @@
         "h"  #'robe-doc
         "rr" #'robe-rails-refresh
         ;; inf-enh-ruby-mode
-        :prefix "s"
-        "f"  #'ruby-send-definition
-        "F"  #'ruby-send-definition-and-go
-        "r"  #'ruby-send-region
-        "R"  #'ruby-send-region-and-go
-        "i"  #'ruby-switch-to-inf))
+        (:prefix ("e" . "eval")
+          "d" #'ruby-send-definition
+          "D" #'ruby-send-definition-and-go
+          "r" #'ruby-send-region
+          "R" #'ruby-send-region-and-go
+          "i" #'ruby-switch-to-inf)))
 
 
 ;; NOTE Must be loaded before `robe-mode'

--- a/modules/lang/ruby/config.el
+++ b/modules/lang/ruby/config.el
@@ -125,7 +125,7 @@
     (add-hook 'rspec-mode-hook #'evil-normalize-keymaps))
   :config
   (map! :localleader
-        :prefix "t"
+        :prefix ("t" . "test")
         :map (rspec-verifiable-mode-map rspec-dired-mode-map rspec-mode-map)
         "a" #'rspec-verify-all
         "r" #'rspec-rerun
@@ -153,7 +153,7 @@
     (add-hook 'minitest-mode-hook #'evil-normalize-keymaps))
   (map! :localleader
         :map minitest-mode-map
-        :prefix "t"
+        :prefix ("t" . "test")
         "r" #'minitest-rerun
         "a" #'minitest-verify-all
         "s" #'minitest-verify-single

--- a/modules/lang/ruby/config.el
+++ b/modules/lang/ruby/config.el
@@ -80,7 +80,7 @@
   (map! :after enh-ruby-mode
         :localleader
         :map enh-ruby-mode-map
-        :prefix "k"
+        :prefix "k" ;; FIXME should this belong under "b" ~ build prefix?
         "k" #'rake
         "r" #'rake-rerun
         "R" #'rake-regenerate-cache
@@ -92,7 +92,7 @@
   (map! :after enh-ruby-mode
         :localleader
         :map enh-ruby-mode-map
-        :prefix "b"
+        :prefix ("b" . "bundle") ; FIXME convention: b ~ build
         "c" #'bundle-check
         "C" #'bundle-console
         "i" #'bundle-install

--- a/modules/lang/rust/config.el
+++ b/modules/lang/rust/config.el
@@ -10,7 +10,7 @@
 
   (map! :map rust-mode-map
         :localleader
-        :prefix "b"
+        :prefix ("b" . "build")
         :desc "cargo build" "b" (λ! (compile "cargo build --color always"))
         :desc "cargo check" "c" (λ! (compile "cargo check --color always"))
         :desc "cargo run"   "r" (λ! (compile "cargo run --color always"))

--- a/modules/lang/web/+css.el
+++ b/modules/lang/web/+css.el
@@ -5,7 +5,7 @@
 
 (map! :map (css-mode-map scss-mode-map less-css-mode-map)
       :localleader
-      "rb" #'+css/toggle-inline-or-block)
+      "rb" #'+css/toggle-inline-or-block) ;; FIXME why rb?
 
 (after! (:any css-mode sass-mode)
   (set-docsets! '(css-mode scss-mode sass-mode)
@@ -45,7 +45,7 @@
   :hook (css-mode . counsel-css-imenu-setup)
   :init
   (map! :map (css-mode-map scss-mode-map less-css-mode-map)
-        :localleader ";" #'counsel-css))
+        :localleader ";" #'counsel-css)) ;; FIXME why semicolon
 
 
 (def-package! helm-css-scss
@@ -53,7 +53,7 @@
   :defer t
   :init
   (map! :map (css-mode-map scss-mode-map less-css-mode-map)
-        :localleader ";" #'helm-css-scss)
+        :localleader ";" #'helm-css-scss) ;; FIXME
   :config
   (setq helm-css-scss-split-direction #'split-window-vertically
         helm-css-scss-split-with-multiple-windows t))

--- a/modules/lang/web/+html.el
+++ b/modules/lang/web/+html.el
@@ -64,7 +64,7 @@
           :desc "Rehighlight buffer" "h" #'web-mode-buffer-highlight
           :desc "Indent buffer"      "i" #'web-mode-buffer-indent
 
-          (:prefix "a"
+          (:prefix ("a" . "attribute")
             "b" #'web-mode-attribute-beginning
             "e" #'web-mode-attribute-end
             "i" #'web-mode-attribute-insert
@@ -74,7 +74,7 @@
             "p" #'web-mode-attribute-previous
             "p" #'web-mode-attribute-transpose)
 
-          (:prefix "b"
+          (:prefix ("b" . "block")
             "b" #'web-mode-block-beginning
             "c" #'web-mode-block-close
             "e" #'web-mode-block-end
@@ -83,7 +83,7 @@
             "p" #'web-mode-block-previous
             "s" #'web-mode-block-select)
 
-          (:prefix "d"
+          (:prefix ("d" . "DOM")
             "a" #'web-mode-dom-apostrophes-replace
             "d" #'web-mode-dom-errors-show
             "e" #'web-mode-dom-entities-encode
@@ -92,7 +92,7 @@
             "t" #'web-mode-dom-traverse
             "x" #'web-mode-dom-xpath)
 
-          (:prefix "e"
+          (:prefix ("e" . "element")
             "/" #'web-mode-element-close
             "a" #'web-mode-element-content-select
             "b" #'web-mode-element-beginning
@@ -112,7 +112,7 @@
             "v" #'web-mode-element-vanish
             "w" #'web-mode-element-wrap)
 
-          (:prefix "t"
+          (:prefix ("t" . "tag")
             "a" #'web-mode-tag-attributes-sort
             "b" #'web-mode-tag-beginning
             "e" #'web-mode-tag-end


### PR DESCRIPTION
This PR is an attempt to standardize local leader keymaps and prefixes across different language modules, which currently have some inconsistencies.

Since these changes might lead to breaking of workflows for some users, I'll be marking it as a WIP draft and pushing commits incrementally for review and discussion :)

Summary of changes:
- `"m"` prefix for macroexpansion across various lisps 
  - `"me"` to expand current / last sexp
  - Sole command in elisp given its own binding instead of being prefixed
- `"g"` prefix as "goto" across language major modes
  - This is a breaking change for csharp and python which used the "f" prefix
- `"b"` prefix as "build" in programming language modes
  - Breaking change for common-lisp which used "c"
- `"e"` prefix as "eval", with the following conventions:
  `eb` ~ eval entire buffer
  `ed` ~ eval top-level definition / defun
  `ee` ~ eval last expression
  `er`~ eval region
  `eu` ~ un-define definition
  - breaking change for the Ruby and Racket modules which used "s" as the prefix.
- new: `"c"` prefix as REPL "connection"
  - only applied in `clojure-mode` so far, but could be extended to other languages
  - Leaves the "r" prefix for "refactor" instead of sometimes meaning "repl"
  - Conceptually separates common REPL related commands into ones involving evaluating and sending things: "e" and those involving managing sessions and connections with language servers: "c". 
