### PR TITLE
Choose which spell checker flyspell will use

### DIFF
--- a/modules/tools/flyspell/config.el
+++ b/modules/tools/flyspell/config.el
@@ -54,7 +54,7 @@ Since spellchecking can be slow in some buffers, this can be disabled with:
               nil
               utf-8))))
 
-    (_ (warn "Spell checker not found. Either install `aspell' of `hunspell'"))))
+    (_ (warn "Spell checker not found. Either install `aspell' or `hunspell'"))))
 
 
 ;; `flyspell' (built-in)

--- a/modules/tools/flyspell/config.el
+++ b/modules/tools/flyspell/config.el
@@ -13,48 +13,48 @@ Since spellchecking can be slow in some buffers, this can be disabled with:
 
 (after! ispell
   (setq-default ispell-dictionary "english")
+  (add-to-list 'ispell-extra-args "--dont-tex-check-comments")
 
-  (let ((no-flags (and (not (featurep! +aspell)) (not (featurep! +hunspell)))))
-    ;; Enable either aspell or hunspell.
-    ;; If no module flags are given, enable either aspell or hunspell if their
-    ;; ... binary is found.
-    ;; If one of the flags `+aspell' or `+hunspell' is given, try to only
-    ;; ... enable that spell checker and not the other.
-    (cond
-     ((and (or no-flags (featurep! +aspell))
-           (executable-find "aspell"))
-      (setq ispell-program-name "aspell"
-            ispell-extra-args '("--sug-mode=ultra" "--run-together"))
+  ;; Enable either aspell or hunspell.
+  ;;   If no module flags are given, enable either aspell or hunspell if their
+  ;;     binary is found.
+  ;;   If one of the flags `+aspell' or `+hunspell' is given, only enable that
+  ;;     spell checker.
+  (pcase (cond ((featurep! +aspell)   'aspell)
+               ((featurep! +hunspell) 'hunspell)
+               ((executable-find "aspell")   'aspell)
+               ((executable-find "hunspell") 'hunspell))
+    (`aspell
+     (setq ispell-program-name "aspell"
+           ispell-extra-args '("--sug-mode=ultra" "--run-together"))
 
-      (setq-hook! 'text-mode-hook
-        ispell-extra-args (remove "--run-together" ispell-extra-args))
+     (defun +flyspell|remove-run-together-switch-for-aspell ()
+       (setq-local ispell-extra-args (remove "--run-together" ispell-extra-args)))
+     (add-hook 'text-mode-hook #'+flyspell|remove-run-together-switch-for-aspell)
 
-      (defun +flyspell*setup-ispell-extra-args (orig-fun &rest args)
-        (let ((ispell-extra-args (remove "--run-together" ispell-extra-args)))
-          (ispell-kill-ispell t)
-          (apply orig-fun args)
-          (ispell-kill-ispell t)))
-      (advice-add #'ispell-word :around #'+flyspell*setup-ispell-extra-args)
-      (advice-add #'flyspell-auto-correct-word :around #'+flyspell*setup-ispell-extra-args))
+     (defun +flyspell*setup-ispell-extra-args (orig-fun &rest args)
+       (let ((ispell-extra-args (remove "--run-together" ispell-extra-args)))
+         (ispell-kill-ispell t)
+         (apply orig-fun args)
+         (ispell-kill-ispell t)))
+     (advice-add #'ispell-word :around #'+flyspell*setup-ispell-extra-args)
+     (advice-add #'flyspell-auto-correct-word :around #'+flyspell*setup-ispell-extra-args))
 
-     ((and (or no-flags (featurep! +hunspell))
-           (executable-find "hunspell"))
-      (setq ispell-program-name "hunspell"
-            ;; Don't use `ispell-cmd-args', it isn't respected with hunspell.
-            ;; Hack ispell-local-dictionary-alist instead.
-            ispell-dictionary-alist
-            `((,ispell-local-dictionary
-               "[[:alpha:]]"
-               "[^[:alpha:]]"
-               "[']"
-               nil
-               ("-d" ,ispell-local-dictionary)
-               nil
-               utf-8))))
-     
-     t (user-error "Spell checker not found. Either install `aspell' of `hunspell'")))
+    (`hunspell
+     (setq ispell-program-name "hunspell"
+           ;; Don't use `ispell-cmd-args', it isn't respected with hunspell.
+           ;; Hack ispell-local-dictionary-alist instead.
+           ispell-dictionary-alist
+           `((,ispell-local-dictionary
+              "[[:alpha:]]"
+              "[^[:alpha:]]"
+              "[']"
+              nil
+              ("-d" ,ispell-local-dictionary)
+              nil
+              utf-8))))
 
-  (add-to-list 'ispell-extra-args "--dont-tex-check-comments"))
+    (_ (warn "Spell checker not found. Either install `aspell' of `hunspell'"))))
 
 
 ;; `flyspell' (built-in)

--- a/modules/tools/flyspell/config.el
+++ b/modules/tools/flyspell/config.el
@@ -14,34 +14,45 @@ Since spellchecking can be slow in some buffers, this can be disabled with:
 (after! ispell
   (setq-default ispell-dictionary "english")
 
-  (cond ((executable-find "aspell")
-         (setq ispell-program-name "aspell"
-               ispell-extra-args '("--sug-mode=ultra" "--run-together"))
+  (let ((no-flags (and (not (featurep! +aspell)) (not (featurep! +hunspell)))))
+    ;; Enable either aspell or hunspell.
+    ;; If no module flags are given, enable either aspell or hunspell if their
+    ;; ... binary is found.
+    ;; If one of the flags `+aspell' or `+hunspell' is given, try to only
+    ;; ... enable that spell checker and not the other.
+    (cond
+     ((and (or no-flags (featurep! +aspell))
+           (executable-find "aspell"))
+      (setq ispell-program-name "aspell"
+            ispell-extra-args '("--sug-mode=ultra" "--run-together"))
 
-         (setq-hook! 'text-mode-hook
-           ispell-extra-args (remove "--run-together" ispell-extra-args))
+      (setq-hook! 'text-mode-hook
+        ispell-extra-args (remove "--run-together" ispell-extra-args))
 
-         (defun +flyspell*setup-ispell-extra-args (orig-fun &rest args)
-           (let ((ispell-extra-args (remove "--run-together" ispell-extra-args)))
-             (ispell-kill-ispell t)
-             (apply orig-fun args)
-             (ispell-kill-ispell t)))
-         (advice-add #'ispell-word :around #'+flyspell*setup-ispell-extra-args)
-         (advice-add #'flyspell-auto-correct-word :around #'+flyspell*setup-ispell-extra-args))
+      (defun +flyspell*setup-ispell-extra-args (orig-fun &rest args)
+        (let ((ispell-extra-args (remove "--run-together" ispell-extra-args)))
+          (ispell-kill-ispell t)
+          (apply orig-fun args)
+          (ispell-kill-ispell t)))
+      (advice-add #'ispell-word :around #'+flyspell*setup-ispell-extra-args)
+      (advice-add #'flyspell-auto-correct-word :around #'+flyspell*setup-ispell-extra-args))
 
-        ((executable-find "hunspell")
-         (setq ispell-program-name "hunspell"
-               ;; Don't use `ispell-cmd-args', it isn't respected with hunspell.
-               ;; Hack ispell-local-dictionary-alist instead.
-               ispell-dictionary-alist
-               `((,ispell-local-dictionary
-                  "[[:alpha:]]"
-                  "[^[:alpha:]]"
-                  "[']"
-                  nil
-                  ("-d" ,ispell-local-dictionary)
-                  nil
-                  utf-8)))))
+     ((and (or no-flags (featurep! +hunspell))
+           (executable-find "hunspell"))
+      (setq ispell-program-name "hunspell"
+            ;; Don't use `ispell-cmd-args', it isn't respected with hunspell.
+            ;; Hack ispell-local-dictionary-alist instead.
+            ispell-dictionary-alist
+            `((,ispell-local-dictionary
+               "[[:alpha:]]"
+               "[^[:alpha:]]"
+               "[']"
+               nil
+               ("-d" ,ispell-local-dictionary)
+               nil
+               utf-8))))
+     
+     t (user-error "Spell checker not found. Either install `aspell' of `hunspell'")))
 
   (add-to-list 'ispell-extra-args "--dont-tex-check-comments"))
 


### PR DESCRIPTION
* Previously, a user could not choose which spell checker to use.
  Instead, the first one found was used.
* This PR adds the flags `+aspell` and `+hunspell` which allow a user to
  choose which spellchcker to use (even if both are installed).
* Report an error if spell checking is enabled but no spell checker
  is found.