### PR TITLE
Fix +ivy-buffer-preview no longer ignoring virtuals

### DIFF
--- a/modules/completion/ivy/autoload/ivy.el
+++ b/modules/completion/ivy/autoload/ivy.el
@@ -35,7 +35,7 @@ temporary/special buffers in `font-lock-comment-face'."
 ;; Library
 
 (defun +ivy--switch-buffer-preview ()
-  (let (ivy-use-virtual-buffers)
+  (let (ivy-use-virtual-buffers ivy--virtual-buffers)
     (counsel--switch-buffer-update-fn)))
 
 (defalias '+ivy--switch-buffer-preview-all #'counsel--switch-buffer-update-fn)


### PR DESCRIPTION
Upstream updated `counsel--switch-buffer-update-fn` to check
`ivy--virtual-buffers` instead of `ivy-use-virtual-buffers`.