### PR TITLE
Pass 'f' through to `evil-surround`

### DIFF
--- a/modules/feature/evil/config.el
+++ b/modules/feature/evil/config.el
@@ -184,6 +184,7 @@ line with a linewise comment.")
 
 (def-package! evil-embrace
   :commands (embrace-add-pair embrace-add-pair-regexp)
+  :hook (prog-mode . +evil|embrace-prog-mode-hook)
   :hook (LaTeX-mode . embrace-LaTeX-mode-hook)
   :hook (org-mode . embrace-org-mode-hook)
   :hook ((ruby-mode enh-ruby-mode) . embrace-ruby-mode-hook)
@@ -201,6 +202,10 @@ line with a linewise comment.")
 
   (defun +evil|embrace-lisp-mode-hook ()
     (embrace-add-pair-regexp ?f "([^ ]+ " ")" #'+evil--embrace-elisp-fn))
+
+  (defun +evil|embrace-prog-mode-hook ()
+    (when (not (derived-mode-p 'emacs-lisp-mode 'lisp-mode))
+      (add-to-list 'evil-embrace-evil-surround-keys ?f)))
 
   ;; Add escaped-sequence support to embrace
   (setf (alist-get ?\\ (default-value 'embrace--pairs-list))


### PR DESCRIPTION
Currently `evil-embrace` surrounds with the 'f' character instead of passing it through to `evil-surround` which specifically handles it to create a surrounding function.

An example is in scala mode. Currently if I were to highlight `test` and press `s f` then evil embrace would simply surround it with 'f': `ftestf`. After this update it would instead forward to `evil-surround` which would then prompt for a function name and surround it with a function call like `function(test)`.

I've added this as a general `prog-mode` hook because it does the correct thing in most C-based languages (scala, c, c++, java, javascript, etc) and I think people rarely actually want to surround something with 'f'. I've added an exception for lisp modes which you've already properly handled via `evil-surround`.