### PR TITLE
Don't open `doom-fallback-buffer` on del workspace

### DIFF
--- a/modules/feature/workspaces/autoload/workspaces.el
+++ b/modules/feature/workspaces/autoload/workspaces.el
@@ -255,7 +255,7 @@ workspace to delete."
                   (if (+workspace-exists-p +workspace--last)
                       +workspace--last
                     (car (+workspace-list-names))))
-                 (unless (doom-buffer-frame-predicate (current-buffer))
+                 (unless (doom-buffer-frame-predicate (window-buffer))
                    (switch-to-buffer (doom-fallback-buffer))))
                 (t
                  (+workspace-switch +workspaces-main t)


### PR DESCRIPTION
The `current-buffer` wasn't being updated after switching workspaces and
was therefore failing the `doom-buffer-frame-predicate` check. As a result
deleting a workspace resulted in the previous window's buffer being 
replaced with the doom dashboard.

Replacing it with `window-buffer` seems to target the intended buffer and 
prevents this from occuring.
