### PR TITLE
Create calfw calendar with correct grid width

### DIFF
--- a/modules/app/calendar/autoload.el
+++ b/modules/app/calendar/autoload.el
@@ -16,6 +16,7 @@
   (if (featurep! :feature workspaces)
       (progn
         (+workspace-switch "Calendar" t)
+        (doom/switch-to-scratch-buffer)
         (+calendar--init)
         (+workspace/display))
     (setq +calendar--wconf (current-window-configuration))

--- a/modules/app/calendar/autoload.el
+++ b/modules/app/calendar/autoload.el
@@ -21,6 +21,7 @@
         (+workspace/display))
     (setq +calendar--wconf (current-window-configuration))
     (delete-other-windows)
+    (doom/switch-to-scratch-buffer)
     (+calendar--init)))
 
 ;;;###autoload


### PR DESCRIPTION
## Description
This PR addresses issue #1190 regarding calfw grid size when opening the calendar with `=calendar` from the calendar module.

## Problem
* Calfw calendar displays with an incorrect grid size
* Caused by [the new calendar workspace](https://github.com/hlissner/doom-emacs/blob/be6efd8dbff18c29953c4af8bfef88b8091added/modules/app/calendar/autoload.el#L18) displaying the doom splash screen with window margins
* Calfw [uses the selected window](https://github.com/kiwanami/emacs-calfw/blob/03abce97620a4a7f7ec5f911e669da9031ab9088/calfw.el#L784) to determine the size of the calendar grid

## Solution
* Selects the scratch buffer before creating the calendar
* Calfw generates the calendar grid based off of the resulting correct window margins

## Verification
* Calendar displays correctly with both workspace feature enabled and disabled
* Calendar displays correctly  while having the distraction free `writeroom-mode` active
