### PR TITLE
Escape key regexps when building which-key leader prefix

### DIFF
--- a/core/core-keybinds.el
+++ b/core/core-keybinds.el
@@ -124,8 +124,8 @@ If any hook returns non-nil, all hooks after it are ignored.")
           (concat "\\(?:"
                   (cl-loop for key in (append (list doom-leader-key doom-leader-alt-key)
                                               (where-is-internal 'doom/leader))
-                           if (stringp key) collect key into keys
-                           else collect (key-description key) into keys
+                           if (stringp key) collect (regexp-quote key) into keys
+                           else collect (regexp-quote (key-description key)) into keys
                            finally return (string-join keys "\\|"))
                   "\\)"))))
 (add-hook 'doom-after-init-modules-hook #'doom|init-leader-keys)


### PR DESCRIPTION
Fixes a bug where the regexp for which-key leader prefixes aren't escaped. This it makes it possible to use regex special characters leader keys, such as `C-\`.