### PR TITLE
Add vterm-mode to evil-escape-excluded-major-modes

### DIFF
--- a/modules/feature/evil/config.el
+++ b/modules/feature/evil/config.el
@@ -221,7 +221,7 @@ line with a linewise comment.")
   :after-call (evil-normal-state-exit-hook)
   :init
   (setq evil-escape-excluded-states '(normal visual multiedit emacs motion)
-        evil-escape-excluded-major-modes '(neotree-mode treemacs-mode term-mode)
+        evil-escape-excluded-major-modes '(neotree-mode treemacs-mode term-mode vterm-mode)
         evil-escape-key-sequence "jk"
         evil-escape-delay 0.25)
   (evil-define-key* '(insert replace visual operator) 'global "\C-g" #'evil-escape)


### PR DESCRIPTION
`jk` doesn't work as expected in `vterm`. 

Do I need to also check for `vterm` feature flag?

