### PR TITLE
Use variable for `fd-find` binary name

### DIFF
--- a/core/core-projects.el
+++ b/core/core-projects.el
@@ -10,6 +10,8 @@ Emacs.")
 (defvar doom-projectile-cache-purge-non-projects nil
   "If non-nil, non-projects are purged from the cache on `kill-emacs-hook'.")
 
+(defvar doom-projectile-fd-binary "fd"
+  "name of `fd-find' executable binary")
 
 ;;
 ;;; Packages
@@ -101,10 +103,11 @@ c) are not valid projectile projects."
   ;; If fd exists, use it for git and generic projects
   ;; fd is a rust program that is significantly faster. It also respects
   ;; .gitignore. This is recommended in the projectile docs
-  (when (executable-find "fd")
-    (setq projectile-git-command "fd . --type f -0 -H -E .git"
+  (when (executable-find doom-projectile-fd-binary)
+    (setq projectile-git-command (concat
+                                  doom-projectile-fd-binary
+                                  " . --type f -0 -H -E .git")
           projectile-generic-command projectile-git-command)))
-
 
 ;;
 ;; Project-based minor modes

--- a/core/doctor.el
+++ b/core/doctor.el
@@ -18,7 +18,7 @@
              (/ size 1024))
       (explain! "Consider deleting it from your system (manually)"))))
 
-(when! (not (executable-find "fd"))
+(when! (not (executable-find doom-projectile-fd-binary))
   (warn! "Couldn't find the `fd' binary; project file searches will be slightly slower"))
 
 (let ((default-directory "~"))


### PR DESCRIPTION
Binary name is not `fd` in some distribution eg, it is `fdfind` in debian