### PR TITLE
feat: org-habit

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -124,6 +124,7 @@
         +babel           ; running code in org
         +capture         ; org-capture in and outside of Emacs
         +export          ; Exporting org to whatever you want
+        +habit           ; Keep track of your habits
         +present         ; Emacs for presentations
         +protocol)       ; Support for org-protocol:// links
        ;;perl              ; write code no one else can comprehend

--- a/modules/lang/org/+habit.el
+++ b/modules/lang/org/+habit.el
@@ -1,7 +1,5 @@
 ;;; lang/org/+habit.el -*- lexical-binding: t; -*-
 
-(require 'org-habit)
-
 (defvar +org-habit-graph-padding 2
   "The padding added to the end of the consistency graph")
 
@@ -11,8 +9,9 @@
 (defvar +org-habit-graph-window-ratio 0.3
   "The ratio of the consistency graphs relative to the window width")
 
-(defun +org-habit-resize-graph()
+(defun +org-habit|resize-graph()
   "Right align and resize the consistency graphs based on `+org-habit-graph-window-ratio'"
+  (require 'org-habit)
   (let* ((total-days (float (+ org-habit-preceding-days org-habit-following-days)))
          (preceding-days-ratio (/ org-habit-preceding-days total-days))
          (graph-width (floor (* (window-width) +org-habit-graph-window-ratio)))
@@ -26,4 +25,4 @@
     (setq-local org-habit-following-days following-days)
     (setq-local org-habit-graph-column graph-column-adjusted)))
 
-(add-hook! 'org-agenda-mode-hook #'+org-habit-resize-graph)
+(add-hook 'org-agenda-mode-hook #'+org-habit|resize-graph)

--- a/modules/lang/org/+habit.el
+++ b/modules/lang/org/+habit.el
@@ -1,0 +1,29 @@
+;;; lang/org/+habit.el -*- lexical-binding: t; -*-
+
+(require 'org-habit)
+
+(defvar +org-habit-graph-padding 2
+  "The padding added to the end of the consistency graph")
+
+(defvar +org-habit-min-width 30
+  "Hides the consistency graph if the `org-habit-graph-column' is less than this value")
+
+(defvar +org-habit-graph-window-ratio 0.3
+  "The ratio of the consistency graphs relative to the window width")
+
+(defun +org-habit-resize-graph()
+  "Right align and resize the consistency graphs based on `+org-habit-graph-window-ratio'"
+  (let* ((total-days (float (+ org-habit-preceding-days org-habit-following-days)))
+         (preceding-days-ratio (/ org-habit-preceding-days total-days))
+         (graph-width (floor (* (window-width) +org-habit-graph-window-ratio)))
+         (preceding-days (floor (* graph-width preceding-days-ratio)))
+         (following-days (- graph-width preceding-days))
+         (graph-column (- (window-width) (+ preceding-days following-days)))
+         (graph-column-adjusted (if (> graph-column +org-habit-min-width)
+                                    (- graph-column +org-habit-graph-padding)
+                                  nil)))
+    (setq-local org-habit-preceding-days preceding-days)
+    (setq-local org-habit-following-days following-days)
+    (setq-local org-habit-graph-column graph-column-adjusted)))
+
+(add-hook! 'org-agenda-mode-hook #'+org-habit-resize-graph)

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -514,5 +514,6 @@ conditions where a window's buffer hasn't changed at the time this hook is run."
   (if (featurep! +babel)    (load! "+babel"))
   (if (featurep! +capture)  (load! "+capture"))
   (if (featurep! +export)   (load! "+export"))
+  (if (featurep! +habit)    (load! "+habit"))
   (if (featurep! +present)  (load! "+present"))
   (if (featurep! +protocol) (load! "+protocol")))


### PR DESCRIPTION
Added a simple way to make the org-habit consistency graphs align to the
right margin as well as being responsive to the width of the window.

This is added as a feature to the org module.