### PR TITLE
Disable fuzzy-matching for swiper-isearch

### DIFF
--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -261,6 +261,7 @@ immediately runs it on the current candidate (ending the ivy session)."
           (counsel-rg . ivy--regex-plus)
           (counsel-grep . ivy--regex-plus)
           (swiper . ivy--regex-plus)
+          (swiper-isearch . ivy--regex-plus)
           (t . ivy--regex-fuzzy))
         ivy-initial-inputs-alist nil))
 


### PR DESCRIPTION
Upstream recently added `swiper-isearch`, which is a more isearch-like variant of `swiper`.  Like swiper, it shouldn't fuzzy-match.