### PR TITLE
Document company +tng flag

### DIFF
--- a/modules/completion/company/README.org
+++ b/modules/completion/company/README.org
@@ -30,6 +30,8 @@ https://assets.doomemacs.org/completion/company/overlay.png
 + =+childframe= Enables displaying completion candidates in a child frame,
   rather than an overlay or tooltip (among with other UI enhancements). *This
   requires GUI Emacs 26.1+.*
++ =+tng= Enables completion using only ~TAB~. Pressing ~TAB~ will select the
+  next completion suggestion, while ~S-TAB~ will select the previous one.
 
 ** Plugins
 + [[https://github.com/company-mode/company-mode][company-mode]]


### PR DESCRIPTION
Just documenting `+tng` flag that I saw looking at `company/config.el` code and it wasn't documented before.