### PR TITLE
Cider map fixes

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -82,7 +82,7 @@
               "R" #'cider-restart
               "b" #'cider-switch-to-repl-buffer
               "B" #'+clojure/cider-switch-to-repl-buffer-and-switch-ns
-              "c" #'cider-repl-clear-buffer)))
+              "c" #'cider-find-and-clear-repl-output)))
 
         (:when (featurep! :feature evil +everywhere)
           :map cider-repl-mode-map

--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -87,6 +87,12 @@
         (:when (featurep! :feature evil +everywhere)
           :map cider-repl-mode-map
           :i [S-return] #'cider-repl-newline-and-indent
+          (:localleader
+            ("n" #'cider-repl-set-ns
+             "q" #'cider-quit
+             "r" #'cider-ns-refresh
+             "R" #'cider-restart
+             "c" #'cider-repl-clear-buffer))
           :map cider-repl-history-mode-map
           :i [return]  #'cider-repl-history-insert-and-quit
           :i "q"  #'cider-repl-history-quit


### PR DESCRIPTION
This PR fixes #1293 by biding `SPC m r c` to `'cider-find-and-clear-repl-output`.

Also, it adds some maps to `cider-repl` major mode that are similar to maps already available in `SPC m r`.