### PR TITLE
Add :editor objed module

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -49,6 +49,7 @@
        ;;(format +onsave)  ; automated prettiness
        ;;lispy             ; vim for lisp, for people who dont like vim
        multiple-cursors  ; editing in many places at once
+       ;;objed             ; text object editing for the innocent
        ;;parinfer          ; turn lisp into python, sort of
        rotate-text       ; cycle region at point between text candidates
        snippets          ; my elves. They type so I don't have to

--- a/modules/editor/objed/README.org
+++ b/modules/editor/objed/README.org
@@ -1,0 +1,11 @@
+#+TITLE: :editor objed
+
+This modules adds [[https://github.com/clemera/objed][objed]], a global minor-mode for navigating and manipulating
+text objects. It combines the ideas of versor-mode and other editors like Vim or
+Kakoune and tries to align them with regular Emacs conventions.
+
+Note that `objed` is intended as an *alternative* to the `evil` module, for
+people who prefer standard Emacs key-bindings and conventions. It's not
+recommended to use these modules together.
+
+See the project [[https://github.com/clemera/objed][README]] for information on keybinds and usage.

--- a/modules/editor/objed/README.org
+++ b/modules/editor/objed/README.org
@@ -1,11 +1,13 @@
-#+TITLE: :editor objed
+#+TITLE:   editor/objed
+#+DATE:    May 30, 2019
+#+SINCE:   v2.1
 
 This modules adds [[https://github.com/clemera/objed][objed]], a global minor-mode for navigating and manipulating
 text objects. It combines the ideas of versor-mode and other editors like Vim or
 Kakoune and tries to align them with regular Emacs conventions.
 
-Note that `objed` is intended as an *alternative* to the `evil` module, for
-people who prefer standard Emacs key-bindings and conventions. It's not
-recommended to use these modules together.
+Note that =objed= is intended as an *alternative* to =evil=, for people who
+prefer standard Emacs key-bindings and conventions. It's not recommended to use
+these modules together.
 
-See the project [[https://github.com/clemera/objed][README]] for information on keybinds and usage.
+[[https://github.com/clemera/objed][See the objed project README]] for information on keybinds and usage.

--- a/modules/editor/objed/config.el
+++ b/modules/editor/objed/config.el
@@ -1,0 +1,30 @@
+;;; editor/objed/config.el -*- lexical-binding: t; -*-
+
+(def-package! objed
+  :after-call pre-command-hook
+  :config
+
+  ;; Prevent undo actions from exiting edit state
+  (add-to-list 'objed-keeper-commands 'undo-tree-undo)
+  (add-to-list 'objed-keeper-commands 'undo-tree-redo)
+  (add-to-list 'objed-keeper-commands 'undo-tree-visualize)
+
+  (defvar +objed--extra-face-remaps nil)
+
+  (defun +objed*add-face-remaps (&rest _)
+    "Add extra face remaps when objed activates."
+    (when (memq 'objed-hl (assq 'hl-line face-remapping-alist))
+      (push (face-remap-add-relative 'solaire-hl-line-face 'objed-hl)
+            +objed--extra-face-remaps)))
+
+  (defun +objed*remove-face-remaps (&rest _)
+    "Remove extra face remaps when objed de-activates."
+    (unless (memq 'objed-hl (assq 'hl-line face-remapping-alist))
+      (dolist (remap +objed--extra-face-remaps)
+        (face-remap-remove-relative remap))
+      (setq +objed--extra-face-remaps nil)))
+
+  (advice-add 'objed--init :after #'+objed*add-face-remaps)
+  (advice-add 'objed--reset :after #'+objed*remove-face-remaps)
+
+  (objed-mode +1))

--- a/modules/editor/objed/packages.el
+++ b/modules/editor/objed/packages.el
@@ -1,0 +1,4 @@
+;; -*- no-byte-compile: t; -*-
+;;; editor/objed/packages.el
+
+(package! objed)

--- a/modules/ui/modeline/config.el
+++ b/modules/ui/modeline/config.el
@@ -57,11 +57,11 @@
   ;; Remove unused segments & extra padding
   (doom-modeline-def-modeline 'main
     '(bar window-number matches buffer-info remote-host buffer-position selection-info)
-    '(misc-info persp-name irc mu4e github debug input-method buffer-encoding lsp major-mode process vcs checker))
+    '(objed-state misc-info persp-name irc mu4e github debug input-method buffer-encoding lsp major-mode process vcs checker))
 
   (doom-modeline-def-modeline 'special
     '(bar window-number matches buffer-info-simple buffer-position selection-info)
-    '(misc-info persp-name debug input-method irc-buffers buffer-encoding lsp major-mode process checker))
+    '(objed-state misc-info persp-name debug input-method irc-buffers buffer-encoding lsp major-mode process checker))
 
   (doom-modeline-def-modeline 'project
     '(bar window-number buffer-default-directory)


### PR DESCRIPTION
Integrates `objed` with Doom Emacs to provide text-object manipulation for non-evil users.

See https://github.com/clemera/objed