### PR TITLE
Correct Javascript module tide format mapping

### DIFF
--- a/modules/lang/javascript/config.el
+++ b/modules/lang/javascript/config.el
@@ -173,7 +173,7 @@
   (map! :localleader
         :map tide-mode-map
         "R"   #'tide-restart-server
-        "f"   #'tide-reformat
+        "f"   #'tide-format
         "rs"  #'tide-rename-symbol
         "roi" #'tide-organize-imports))
 


### PR DESCRIPTION
Updated the format mapping for the Javascript module to use the correctly named tide-format.

See: https://github.com/ananthakumaran/tide#commands
