### PR TITLE
Fix +ivy-buffer-icons counsel-projectile transformers

### DIFF
--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -107,7 +107,8 @@ immediately runs it on the current candidate (ending the ivy session)."
                        'counsel-projectile-find-file
                        '(:columns
                          ((all-the-icons-icon-for-file (:width 2 :align right))
-                          (ivy-rich-candidate)))))))
+                          (ivy-rich-candidate)))))
+      (ivy-rich-reload)))
 
   ;; Remove built-in coloring of buffer list; we do our own
   (setq ivy-switch-buffer-faces-alist nil)


### PR DESCRIPTION
Our custom transformers might be added after `ivy-rich-mode` has registered its transformers with ivy.  We need to call `ivy-rich-reload` to ensure the latest transformers are installed.

This fixes the bug where icons are not present in `counsel-projectile-find-file` until toggling `ivy-rich-mode` off and on again.