### PR TITLE
fix rustc detection

### DIFF
--- a/modules/lang/rust/doctor.el
+++ b/modules/lang/rust/doctor.el
@@ -5,8 +5,8 @@
              (featurep! :tools lsp))
          "This module requires (:tools lsp)")
 
-(unless (executable-find "rust")
-  (warn! "Couldn't find rust binary"))
+(unless (executable-find "rustc")
+  (warn! "Couldn't find rustc binary"))
 
 (unless (executable-find "cargo")
   (warn! "Couldn't find cargo binary"))


### PR DESCRIPTION
There is no `rust` binary in Rust, but a `rustc` one for its compiler.