### PR TITLE
Fixes for ivy-switch-buffer icons

### DIFF
--- a/modules/completion/ivy/autoload/ivy.el
+++ b/modules/completion/ivy/autoload/ivy.el
@@ -34,14 +34,19 @@ Buffers that are considered unreal (see `doom-real-buffer-p') are dimmed with
 
 ;;;###autoload
 (defun +ivy-rich-buffer-icon (candidate)
-  "Display the icon for CANDIDATE buffer.
-
-Otherwise show the fundamental-mode icon."
-  (with-current-buffer candidate
-    (let ((icon (all-the-icons-icon-for-mode major-mode)))
-      (if (symbolp icon)
-          (all-the-icons-icon-for-mode 'fundamental-mode)
-        icon))))
+  "Display the icon for CANDIDATE buffer."
+  ;; NOTE This is inspired by `all-the-icons-ivy-buffer-transformer', minus the
+  ;; buffer name and extra padding as those are handled by `ivy-rich'.
+  (propertize "\t" 'display
+              (if-let* ((buffer (get-buffer candidate))
+                        (mode (buffer-local-value 'major-mode buffer)))
+                  (or
+                   (all-the-icons-ivy--icon-for-mode mode)
+                   (all-the-icons-ivy--icon-for-mode (get mode 'derived-mode-parent))
+                   (funcall
+                    all-the-icons-ivy-family-fallback-for-buffer
+                    all-the-icons-ivy-name-fallback-for-buffer))
+                (all-the-icons-icon-for-file candidate))))
 
 
 ;;

--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -88,7 +88,7 @@ immediately runs it on the current candidate (ending the ivy session)."
   :after ivy
   :config
   (when (featurep! +icons)
-    (cl-pushnew '(all-the-icons-ivy-icon-for-file (:width 2 :align right))
+    (cl-pushnew '(+ivy-rich-buffer-icon)
                 (cadr (plist-get ivy-rich-display-transformers-list
                                  'ivy-switch-buffer))))
 


### PR DESCRIPTION
Corrects the ivy-switch-buffer transformer to use buffer icons (not file icons), and fixes alignment issues in the icon display.