### PR TITLE
One dot in wrong place

### DIFF
--- a/modules/ui/popup/README.org
+++ b/modules/ui/popup/README.org
@@ -65,7 +65,7 @@ Multiple popup rules can be defined with ~set-popup-rules!~:
    ("^\\*\\(?:scratch\\|Messages\\)" :transient t)
    ("^\\*Help" :slot -1 :size 0.2 :select t)
    ("^\\*doom:"
-    :size . 0.35 :select t :modeline t :quit t :transient t)))
+    :size 0.35 :select t :modeline t :quit t :transient t)))
 #+END_SRC
 
 Omitted parameters in a ~set-popup-rules!~ will use the defaults set in


### PR DESCRIPTION
Not sure what I am doing, but I cannot run the example with the `.` and the example on the previous line also use `:size` without a `.` before the size value.