### PR TITLE
modules/ui: Add zoom-frm module

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -37,6 +37,7 @@
        vi-tilde-fringe   ; fringe tildes to mark beyond EOB
        window-select     ; visually switch windows
        workspaces        ; tab emulation, persistence & separate workspaces
+       zoom-frm          ; allow to zoom a frame
 
        :editor
        (evil +everywhere); come to the dark side, we have cookies

--- a/modules/ui/zoom-frm/README.org
+++ b/modules/ui/zoom-frm/README.org
@@ -1,0 +1,35 @@
+#+TITLE:   ui/zoom-frm
+#+DATE:    May 5, 2019
+#+SINCE:   {replace with next tagged release version}
+#+STARTUP: inlineimages
+
+* Table of Contents :TOC_3:noexport:
+- [[#description][Description]]
+  - [[#module-flags][Module Flags]]
+  - [[#plugins][Plugins]]
+  - [[#hacks][Hacks]]
+- [[#prerequisites][Prerequisites]]
+- [[#features][Features]]
+- [[#configuration][Configuration]]
+- [[#troubleshooting][Troubleshooting]]
+
+* Description
+Allow to zoom a frame, so that text appears larger or smaller.
+Different from increasing the font size, this affects all buffers.
+
+** Module Flags
+This module provides no flags.
+
+** Plugins
++ [[https://github.com/emacsmirror/zoom-frm][zoom-frm]]
+
+** Hacks
+
+* Prerequisites
+This module has no prereqisites.
+
+* Features
+
+* Configuration
+
+* Troubleshooting

--- a/modules/ui/zoom-frm/autoload.el
+++ b/modules/ui/zoom-frm/autoload.el
@@ -1,0 +1,10 @@
+;;; ui/zoom-frm/autoload.el -*- lexical-binding: t; -*-
+
+;;;###autoload (autoload 'doom-frame-zoom-hydra/body "ui/zoom-frm/autoload.el" nil t)
+(defhydra doom-frame-zoom-hydra (:hint t :color red)
+  "
+      Frame zoom: _j_:zoom in, _k_:zoom out, _0_:reset
+"
+  ("j" zoom-frm-in "in")
+  ("k" zoom-frm-out "out")
+  ("0" zoom-frm-unzoom "reset"))

--- a/modules/ui/zoom-frm/packages.el
+++ b/modules/ui/zoom-frm/packages.el
@@ -1,0 +1,7 @@
+;; -*- no-byte-compile: t; -*-
+;;; ui/zoom-frm/packages.el
+
+(packages!
+ (frame-fns :recipe (:fetcher github :repo "emacsmirror/frame-fns"))
+ (frame-cmds :recipe (:fetcher github :repo "emacsmirror/frame-cmds"))
+ (zoom-frm :recipe (:fetcher github :repo "emacsmirror/zoom-frm")))


### PR DESCRIPTION
This module adds `zoom-frm` support.

The hydra is based on the `doom-text-zoom-hydra`, just using `zoom-frm` functions instead.