### PR TITLE
Add localleader bindings to org-agenda

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -305,6 +305,9 @@ between the two."
             "e" #'org-table-edit-formulas
             "=" #'org-table-eval-formulas))))
 
+(map! :map org-agenda-mode-map
+      :localleader
+      "s" #'org-agenda-schedule)
 
 (defun +org|setup-evil-keybinds (&rest args)
   (unless args ; lookout for recursive requires

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -303,14 +303,14 @@ between the two."
             "c" #'org-table-create
             "r" #'org-table-recalculate
             "e" #'org-table-edit-formulas
-            "=" #'org-table-eval-formulas))))
+            "=" #'org-table-eval-formulas)))
 
-(map! :map org-agenda-mode-map
-      :localleader
-      "d" #'org-agenda-deadline
-      "r" #'org-agenda-refile
-      "s" #'org-agenda-schedule
-      "t" #'org-agenda-todo)
+  (map! :map org-agenda-mode-map
+        :localleader
+        "d" #'org-agenda-deadline
+        "r" #'org-agenda-refile
+        "s" #'org-agenda-schedule
+        "t" #'org-agenda-todo))
 
 (defun +org|setup-evil-keybinds (&rest args)
   (unless args ; lookout for recursive requires

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -249,6 +249,7 @@ between the two."
         "T" #'org-todo-list
         "l" #'org-insert-link
         "L" #'org-store-link
+        "q" #'org-set-tags
         "r" #'org-refile
         "s" #'org-schedule
         "'" #'org-edit-special
@@ -308,6 +309,7 @@ between the two."
   (map! :map org-agenda-mode-map
         :localleader
         "d" #'org-agenda-deadline
+        "q" #'org-agenda-set-tags
         "r" #'org-agenda-refile
         "s" #'org-agenda-schedule
         "t" #'org-agenda-todo))

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -307,7 +307,10 @@ between the two."
 
 (map! :map org-agenda-mode-map
       :localleader
-      "s" #'org-agenda-schedule)
+      "d" #'org-agenda-deadline
+      "r" #'org-agenda-refile
+      "s" #'org-agenda-schedule
+      "t" #'org-agenda-todo)
 
 (defun +org|setup-evil-keybinds (&rest args)
   (unless args ; lookout for recursive requires


### PR DESCRIPTION
This PR adds some localleader bindings to `org-agenda-mode-map` that reflect those of `org-mode-map`. I only included the bindings that are useful to manipulate meta-information (schedule, deadline, refine, and todo state).