### PR TITLE
Enable `better-jumper-mode` when loaded

### DIFF
--- a/core/core-editor.el
+++ b/core/core-editor.el
@@ -152,6 +152,7 @@ savehist file."
   (global-set-key [remap evil-jump-forward]  #'better-jumper-jump-forward)
   (global-set-key [remap evil-jump-backward] #'better-jumper-jump-backward)
   :config
+  (better-jumper-mode +1)
   (add-hook 'better-jumper-post-jump-hook #'recenter)
 
   (defun doom*set-jump (orig-fn &rest args)


### PR DESCRIPTION
As per request when submitting `better-jumper` to MELPA, I've added a minor mode. This pull request enables `better-jumper-mode` when the package is loaded.