### PR TITLE
Fix ivy-switch-buffer virtual buffer support

### DIFF
--- a/modules/completion/ivy/autoload/ivy.el
+++ b/modules/completion/ivy/autoload/ivy.el
@@ -90,7 +90,8 @@ Buffers that are considered unreal (see `doom-real-buffer-p') are dimmed with
               :preselect (buffer-name (other-buffer (current-buffer)))
               :matcher #'ivy--switch-buffer-matcher
               :keymap ivy-switch-buffer-map
-              :caller #'+ivy--switch-buffer)))
+              ;; NOTE A clever disguise, needed for virtual buffers.
+              :caller #'ivy-switch-buffer)))
 
 ;;;###autoload
 (defun +ivy/switch-workspace-buffer (&optional arg)


### PR DESCRIPTION
Fixes #1406

Yes this is a dubious hack, but it works, and ivy-resume still works.  Not sure that there's anything else which could be affected.