### PR TITLE
Add +prescient option for :completion ivy

### DIFF
--- a/modules/completion/company/config.el
+++ b/modules/completion/company/config.el
@@ -47,6 +47,7 @@
 (def-package! company-prescient
   :hook (company-mode . company-prescient-mode)
   :config
+  ;; NOTE prescient config duplicated with `ivy'
   (setq prescient-save-file (concat doom-cache-dir "prescient-save.el"))
   (prescient-persist-mode +1))
 

--- a/modules/completion/ivy/README.org
+++ b/modules/completion/ivy/README.org
@@ -37,7 +37,8 @@ lighter, simpler and faster in many cases.
 #+end_quote
 
 ** Module Flags
-+ =+fuzzy= Enables the fuzzy method for ivy searches.
++ =+fuzzy= Enables fuzzy completion for Ivy searches.
++ =+prescient= Enables prescient filtering and sorting for Ivy searches.
 + =+childframe= Causes Ivy to display in a floating child frame, above Emacs.
   *This requires GUI Emacs 26.1+*
 + =+icons= Enables file icons for switch-{buffer,project}/find-file counsel
@@ -53,6 +54,7 @@ lighter, simpler and faster in many cases.
 + [[https://github.com/mhayashi1120/Emacs-wgrep][wgrep]]
 + [[https://github.com/DarwinAwardWinner/amx][amx]]
 + [[https://github.com/lewang/flx][flx]]* (=+fuzzy=)
++ [[https://github.com/raxod502/prescient.el][prescient]]* (=+prescient=)
 + [[https://github.com/tumashu/ivy-posframe][ivy-posframe]]* (=+childframe=)
 + [[https://github.com/asok/all-the-icons-ivy][all-the-icons-ivy]]* (=+icons=)
 

--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -294,7 +294,8 @@ immediately runs it on the current candidate (ending the ivy session)."
 
 
 (def-package! flx
-  :when (featurep! +fuzzy)
+  :when (and (featurep! +fuzzy)
+             (not (featurep! +prescient)))
   :defer t  ; is loaded by ivy
   :init
   (setq ivy-re-builders-alist
@@ -305,6 +306,33 @@ immediately runs it on the current candidate (ending the ivy session)."
           (swiper-isearch . ivy--regex-plus)
           (t . ivy--regex-fuzzy))
         ivy-initial-inputs-alist nil))
+
+
+(def-package! ivy-prescient
+  :hook (ivy-mode . ivy-prescient-mode)
+  :when (featurep! +prescient)
+  :init
+  (setq prescient-filter-method (if (featurep! +fuzzy)
+                                    '(literal regexp initialism fuzzy)
+                                  '(literal regexp initialism))
+        ivy-prescient-enable-filtering nil ;; we do this ourselves
+        ivy-initial-inputs-alist nil
+        ivy-re-builders-alist
+        '((counsel-ag . +ivy-prescient-non-fuzzy)
+          (counsel-rg . +ivy-prescient-non-fuzzy)
+          (counsel-grep . +ivy-prescient-non-fuzzy)
+          (swiper . +ivy-prescient-non-fuzzy)
+          (swiper-isearch . +ivy-prescient-non-fuzzy)
+          (t . ivy-prescient-re-builder)))
+
+  :config
+  (defun +ivy-prescient-non-fuzzy (str)
+    (let ((prescient-filter-method '(literal regexp)))
+      (ivy-prescient-re-builder str)))
+
+  ;; NOTE prescient config duplicated with `company'
+  (setq prescient-save-file (concat doom-cache-dir "prescient-save.el"))
+  (prescient-persist-mode +1))
 
 
 ;; Used by `counsel-M-x'

--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -305,7 +305,8 @@ immediately runs it on the current candidate (ending the ivy session)."
           (swiper . ivy--regex-plus)
           (swiper-isearch . ivy--regex-plus)
           (t . ivy--regex-fuzzy))
-        ivy-initial-inputs-alist nil))
+        ivy-initial-inputs-alist nil
+        ivy-flx-limit 10000))
 
 
 (def-package! ivy-prescient

--- a/modules/completion/ivy/packages.el
+++ b/modules/completion/ivy/packages.el
@@ -10,8 +10,10 @@
 (package! ivy-rich)
 (package! wgrep)
 
-(when (featurep! +fuzzy)
-  (package! flx))
+(if (featurep! +prescient)
+    (package! ivy-prescient)
+  (when (featurep! +fuzzy)
+    (package! flx)))
 
 (when (and EMACS26+ (featurep! +childframe))
   (package! ivy-posframe))


### PR DESCRIPTION
This adds the `+prescient` flag to enable the `ivy-prescient` package for filtering and sorting of ivy completions.  When used with the `+fuzzy` flag, uses prescient's fuzzy completion instead of `flx`.

Also increased the value of `ivy-flx-limit` from the default 200 to 10000.  This is a performance vs utility tradeoff, but the impact is minimal in my testing.