### PR TITLE
Added pyimport support

### DIFF
--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -206,3 +206,18 @@ called.")
   (add-to-list 'global-mode-string
                '(conda-env-current-name (" conda:" conda-env-current-name " "))
                'append))
+
+
+;; Import managements
+(def-package! pyimport
+  :after python
+  :init
+  (map! :after python
+        :map 'python-mode-map
+        :localleader
+        (:prefix ("i" . "insert")
+          :desc "Missing imports" "m" #'pyimport-insert-missing)
+        (:prefix ("r" . "remove")
+          :desc "Unused imports" "r" #'pyimport-remove-unused)
+        )
+  )

--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -94,6 +94,17 @@ called.")
         "u" #'anaconda-mode-find-references))
 
 
+(def-package! pyimport
+  :after python
+  :config
+  (map! :map python-mode-map
+        :localleader
+        (:prefix ("i" . "insert")
+          :desc "Missing imports" "m" #'pyimport-insert-missing)
+        (:prefix ("r" . "remove")
+          :desc "Unused imports" "r" #'pyimport-remove-unused)))
+
+
 (def-package! nose
   :commands nose-mode
   :preface (defvar nose-mode-map (make-sparse-keymap))
@@ -206,18 +217,3 @@ called.")
   (add-to-list 'global-mode-string
                '(conda-env-current-name (" conda:" conda-env-current-name " "))
                'append))
-
-
-;; Import managements
-(def-package! pyimport
-  :after python
-  :init
-  (map! :after python
-        :map 'python-mode-map
-        :localleader
-        (:prefix ("i" . "insert")
-          :desc "Missing imports" "m" #'pyimport-insert-missing)
-        (:prefix ("r" . "remove")
-          :desc "Unused imports" "r" #'pyimport-remove-unused)
-        )
-  )

--- a/modules/lang/python/packages.el
+++ b/modules/lang/python/packages.el
@@ -20,3 +20,6 @@
 ;; Testing frameworks
 (package! nose)
 (package! python-pytest)
+
+;; Import managements
+(package! pyimport)


### PR DESCRIPTION
Added pyimport support.
I figured that it just uses modules imported in currently opened python files, and don't looks for installed modules.

Keybindings :
- Import missing module via `<LocalLeader> i m`
- Remove unused imports via `<LocalLeader> r u`