### PR TITLE
Fix readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,6 @@
   </a>
 </p>
 
-<!--p align="center">
-  <a href="docs/index.org">documentation</a>&nbsp; |&nbsp;
-  <a href="/../../tree/screenshots">screenshots</a>&nbsp; |&nbsp;
-  <a href="docs/contributing.org">contribute</a>
-  <a href="docs/faq.org">faq</a>
-</p-->
-
 - - -
 
 Quick start

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Table of Contents
 - [What is Doom Emacs](#what-is-doom-emacs)
     - [Doom's mantras](#dooms-mantras)
     - [Feature highlights](#feature-highlights)
-- [Getting Help](#getting-help)
+- [Troubleshooting](#troubleshooting)
 - [Contributing](#contributing)
 
 
@@ -154,12 +154,12 @@ contributions:
   my freelance work.
 
 
-[docs:wiki]: docs/index.org
-[docs:wiki-quickstart]: docs/getting-started.org
-[docs:wiki-modules]: docs/modules.org
-[docs:wiki-customization]: docs/customize.org
+[docs:wiki]: https://github.com/hlissner/doom-emacs/wiki
+[docs:wiki-quickstart]: https://github.com/hlissner/doom-emacs/wiki/Getting-Started#post-installation-tips
+[docs:wiki-modules]: https://github.com/hlissner/doom-emacs/wiki/Modules
+[docs:wiki-customization]: https://github.com/hlissner/doom-emacs/wiki/Customization
 [docs:contributing]: docs/contribute.org
-[docs:faq]: docs/faq.org
+[docs:faq]: https://github.com/hlissner/doom-emacs/wiki/FAQ
 
 [github:new-issue]: https://github.com/hlissner/doom-emacs/issues/new
 [doom:bindings]: modules/config/default/+evil-bindings.el

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ shoot off that bug report:
   byte-compiled config, it will make your job harder.
 - Run `bin/doom doctor` to detect common issues in your development environment.
 - Search Doom's issue tracker for mention of any error messages you've received.
-- [Visit our FAQ][docs:faq] to see if your issue is listed.
+- [Visit our FAQ][docs:wiki-faq] to see if your issue is listed.
 
 If all else fails, [file that bug report][github:new-issue]! Please include the
 behavior you've observed, the behavior you expected, and any error messages
@@ -155,12 +155,12 @@ contributions:
   my freelance work.
 
 
-[docs:wiki]: https://github.com/hlissner/doom-emacs/wiki
-[docs:wiki-quickstart]: https://github.com/hlissner/doom-emacs/wiki/getting-started
-[docs:wiki-modules]: https://github.com/hlissner/doom-emacs/wiki/Modules
-[docs:wiki-customization]: https://github.com/hlissner/doom-emacs/wiki/Customization
 [docs:contributing]: docs/contribute.org
-[docs:faq]: https://github.com/hlissner/doom-emacs/wiki/FAQ
+[docs:wiki]: https://github.com/hlissner/doom-emacs/wiki
+[docs:wiki-customization]: https://github.com/hlissner/doom-emacs/wiki/Customization
+[docs:wiki-faq]: https://github.com/hlissner/doom-emacs/wiki/FAQ
+[docs:wiki-modules]: https://github.com/hlissner/doom-emacs/wiki/Modules
+[docs:wiki-quickstart]: https://github.com/hlissner/doom-emacs/wiki/getting-started
 
 [github:new-issue]: https://github.com/hlissner/doom-emacs/issues/new
 [doom:bindings]: modules/config/default/+evil-bindings.el

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ git clone https://github.com/hlissner/doom-emacs ~/.emacs.d
 > Doom supports Emacs 25.3 and newer, but **Emacs 26.1+ is recommended.** Doom
 > works best on Linux & MacOS. Your mileage may vary on Windows.
 
+See also the [quick start guide][docs:wiki-quickstart] in the [wiki][docs:wiki].
 
 Table of Contents
 ==================
@@ -155,7 +156,7 @@ contributions:
 
 
 [docs:wiki]: https://github.com/hlissner/doom-emacs/wiki
-[docs:wiki-quickstart]: https://github.com/hlissner/doom-emacs/wiki/Getting-Started#post-installation-tips
+[docs:wiki-quickstart]: https://github.com/hlissner/doom-emacs/wiki/getting-started
 [docs:wiki-modules]: https://github.com/hlissner/doom-emacs/wiki/Modules
 [docs:wiki-customization]: https://github.com/hlissner/doom-emacs/wiki/Customization
 [docs:contributing]: docs/contribute.org

--- a/docs/contribute.org
+++ b/docs/contribute.org
@@ -1,0 +1,3 @@
+#+TITLE: Contributing Guidelines
+
+* TODO


### PR DESCRIPTION
Some cleanup and updates to the documentation, after encountering some broken links as I worked through my initial setup.

I couldn't find the contributing guide, so I made a placeholder file for it.

I only just found #1430, but this PR would supersede that one.