### PR TITLE
Use doom-private-dir for default banner path

### DIFF
--- a/modules/ui/doom-dashboard/config.el
+++ b/modules/ui/doom-dashboard/config.el
@@ -16,7 +16,7 @@ while they run.")
   "The path to the image file to be used in on the dashboard. The path is
 relative to `+doom-dashboard-banner-dir'. If nil, always use the ASCII banner.")
 
-(defvar +doom-dashboard-banner-dir (concat (DIR!) "banners/")
+(defvar +doom-dashboard-banner-dir (concat doom-private-dir "banners/")
   "Where to look for `+doom-dashboard-banner-file'.")
 
 (defvar +doom-dashboard-banner-padding '(4 . 4)


### PR DESCRIPTION
This is a bit more convenient than hiding them away in `~/.emacs.d/modules/ui/doom-dashboard/banners`.