### PR TITLE
magit-todos 1.2 removed magit-todos-require-colon

### DIFF
--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -68,7 +68,7 @@ It is passed a user and repository name.")
 (def-package! magit-todos
   :after magit
   :config
-  (setq magit-todos-require-colon nil)
+  (setq magit-todos-keyword-suffix "\\(?:([^)]+)\\)?:?")
   (define-key magit-todos-section-map "j" nil)
   (advice-add #'magit-todos-mode :around #'doom*shut-up)
   (magit-todos-mode +1))


### PR DESCRIPTION
https://github.com/alphapapa/magit-todos/tree/3c59aa03b217b55b1baa0e88470e10996aaeea9b#12

Since `magit-todos` 1.2 `magit-todos-require-colon` has been removed. The default value of `magit-todos-keyword-suffix` is `"\\(?:([^)]+)\\)?:"` which require a colon as suffix to the keywords.