### PR TITLE
objed: add a manual activation flag

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -249,6 +249,10 @@
         "C-S-s"        #'swiper-helm
         "C-S-r"        #'helm-resume)
 
+      ;;; objed
+      (:when (featurep! :editor objed +manual)
+        "M-SPC"     #'objed-activate)
+
       ;;; buffer management
       "C-x b"       #'persp-switch-to-buffer
       (:when (featurep! :completion ivy)
@@ -278,7 +282,7 @@
         "C-p"        #'company-search-repeat-backward
         "C-s"        (λ! (company-search-abort) (company-filter-candidates)))
 
-      ;;; ein notebokks
+      ;;; ein notebooks
       (:after ein:notebook-multilang
         :map ein:notebook-multilang-mode-map
         "C-c h" #'+ein/hydra/body)

--- a/modules/editor/objed/README.org
+++ b/modules/editor/objed/README.org
@@ -2,6 +2,11 @@
 #+DATE:    May 30, 2019
 #+SINCE:   v2.1
 
+* Table of Contents :TOC_3:noexport:
+- [[#description][Description]]
+  - [[#module-flags][Module Flags]]
+
+* Description
 This modules adds [[https://github.com/clemera/objed][objed]], a global minor-mode for navigating and manipulating
 text objects. It combines the ideas of versor-mode and other editors like Vim or
 Kakoune and tries to align them with regular Emacs conventions.
@@ -11,3 +16,7 @@ prefer standard Emacs key-bindings and conventions. It's not recommended to use
 these modules together.
 
 [[https://github.com/clemera/objed][See the objed project README]] for information on keybinds and usage.
+
+** Module Flags
++ ~+manual~ Do not turn =objed= automatically. The user is responsible for calling
+  `objed-activate` (bound to `M-SPC` if using the default Emacs bindings.)

--- a/modules/editor/objed/config.el
+++ b/modules/editor/objed/config.el
@@ -27,4 +27,5 @@
   (advice-add 'objed--init :after #'+objed*add-face-remaps)
   (advice-add 'objed--reset :after #'+objed*remove-face-remaps)
 
-  (objed-mode +1))
+  (unless (featurep! +manual)
+    (objed-mode +1)))


### PR DESCRIPTION
Setting the flag `+manual` of the `objed` module makes the user responsible for calling `objed-activate` when needed. The binding `M-SPC` is set in the default Emacs bindings.

Fix small typo.

Update `objed` README file.