### PR TITLE
keep remote files in recentf

### DIFF
--- a/core/autoload/files.el
+++ b/core/autoload/files.el
@@ -129,6 +129,10 @@ MATCH is a string regexp. Only entries that match it will be included."
            short-new-name)
           (short-new-name))))
 
+(defun doom--file-truename (filename)
+  "Like `file-truename' but only if a connection to the file already exists."
+  (if (file-remote-p filename nil t) (file-truename filename)
+    filename))
 
 ;;
 ;; Commands

--- a/core/core-editor.el
+++ b/core/core-editor.el
@@ -105,9 +105,9 @@ detected.")
         recentf-auto-cleanup 'never
         recentf-max-menu-items 0
         recentf-max-saved-items 300
-        recentf-filename-handlers '(file-truename abbreviate-file-name)
+        recentf-filename-handlers '(doom--file-truename abbreviate-file-name)
         recentf-exclude
-        (list #'file-remote-p "\\.\\(?:gz\\|gif\\|svg\\|png\\|jpe?g\\)$"
+        (list "\\.\\(?:gz\\|gif\\|svg\\|png\\|jpe?g\\)$"
               "^/tmp/" "^/ssh:" "\\.?ido\\.last$" "\\.revive$" "/TAGS$"
               "^/var/folders/.+$"
               ;; ignore private DOOM temp files


### PR DESCRIPTION
Verify that there is a connection to the file before trying to find it's
truename when recentf-cleanup is called. Complete explanation at https://github.com/hlissner/doom-emacs/issues/1444#issuecomment-497962273.
Fix hlissner#1444 for good (hopefully).