### PR TITLE
Fix magit-clone error

### DIFF
--- a/modules/tools/magit/autoload.el
+++ b/modules/tools/magit/autoload.el
@@ -113,14 +113,15 @@ control in buffers."
               "Destination: "
               magit-clone-default-directory
               name nil name)))))
-  (magit-clone
+  (magit-clone-regular
    (cond ((string-match-p "^[^/]+$" url-or-repo)
           (require 'ghub)
           (format +magit-default-clone-url (ghub--username (ghub--host)) url-or-repo))
          ((string-match-p "^\\([^/]+\\)/\\([^/]+\\)/?$" url-or-repo)
           (apply #'format +magit-default-clone-url (split-string url-or-repo "/" t)))
          (url-or-repo))
-   dir))
+   dir
+   nil))
 
 
 ;;


### PR DESCRIPTION
magit-clone function has changed signature to work with transient.
So using the new magit-clone-regular instead.

Signed-off-by: Huy Duong <huy.duong@employmenthero.com>