### PR TITLE
Add a shortcut to clear search highlight: `SPC / c`

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -520,6 +520,7 @@
       ;;; <leader> / --- search
       (:prefix-map ("/" . "search")
         :desc "Search buffer"                 "b" #'swiper
+        :desc "Clear search highlight"        "c" #'evil-ex-nohighlight
         :desc "Search current directory"      "d" #'+default/search-from-cwd
         :desc "Jump to symbol"                "i" #'imenu
         :desc "Jump to link"                  "l" #'ace-link


### PR DESCRIPTION
Yup, press `SPC / c` to clear the search highlight