### PR TITLE
fix: format-all upstream definitions

### DIFF
--- a/modules/editor/format/autoload/format.el
+++ b/modules/editor/format/autoload/format.el
@@ -5,7 +5,7 @@
 buffer.")
 
 ;;;###autoload
-(autoload 'format-all-probe "format-all")
+(autoload 'format-all--probe "format-all")
 
 (defun +format--delete-whole-line (&optional arg)
   "Delete the current line without putting it in the `kill-ring'.
@@ -93,7 +93,7 @@ Stolen shamelessly from go-mode"
 
 (defun +format-completing-read ()
   (require 'format-all)
-  (let* ((fmtlist (mapcar #'symbol-name (hash-table-keys format-all-format-table)))
+  (let* ((fmtlist (mapcar #'symbol-name (hash-table-keys format-all--format-table)))
          (fmt (completing-read "Formatter: " fmtlist)))
     (if fmt (cons (intern fmt) t))))
 
@@ -122,8 +122,8 @@ See `+format/buffer' for the interactive version of this function, and
 `+format|buffer' to use as a `before-save-hook' hook."
   (if (not formatter)
       'no-formatter
-    (let ((f-function (gethash formatter format-all-format-table))
-          (executable (format-all-formatter-executable formatter))
+    (let ((f-function (gethash formatter format-all--format-table))
+          (executable (format-all--formatter-executable formatter))
           (indent 0))
       (pcase-let
           ((`(,output ,errput ,first-diff)
@@ -180,7 +180,7 @@ See `+format/buffer' for the interactive version of this function, and
   "Format the source code in the current buffer."
   (interactive "P")
   (let ((+format-with (or (if arg (+format-completing-read)) +format-with)))
-    (pcase-let ((`(,formatter ,mode-result) (format-all-probe)))
+    (pcase-let ((`(,formatter ,mode-result) (format-all--probe)))
       (pcase
           (+format-buffer
            formatter mode-result

--- a/modules/editor/format/autoload/settings.el
+++ b/modules/editor/format/autoload/settings.el
@@ -25,7 +25,7 @@
 
 
 (defun +format--make-command (formatter &rest _)
-  `(format-all-buffer-thunk
+  `(format-all--buffer-thunk
     (lambda (input)
       (with-silent-modifications
         (setq buffer-file-name ,(buffer-file-name (buffer-base-buffer))
@@ -42,7 +42,7 @@
 (defun +format--make-function (formatter &rest _)
   `(progn
      (doom-log "formatter (functionp) %s" #',formatter)
-     (format-all-buffer-thunk #',formatter)))
+     (format-all--buffer-thunk #',formatter)))
 
 (defun +format--make-shell-command (command ok-statuses error-regexp)
   (+format--make-shell-command-list (split-string command " " t)
@@ -66,25 +66,25 @@
                   (setq args (append subargs args)))))))
      (doom-log "formatter (arglist) %s" args)
      (if ,(and (or ok-statuses error-regexp) t)
-         (apply #'format-all-buffer-hard
+         (apply #'format-all--buffer-hard
                 ',ok-statuses ,error-regexp
                 (reverse args))
-       (apply #'format-all-buffer-easy (reverse args)))))
+       (apply #'format-all--buffer-easy (reverse args)))))
 
 (cl-defun +format--set (name &key function modes unset)
   (declare (indent defun))
-  (when (and unset (not (gethash name format-all-format-table)))
+  (when (and unset (not (gethash name format-all--format-table)))
     (error "'%s' formatter does not exist to be unset" name))
-  (puthash name function format-all-format-table)
+  (puthash name function format-all--format-table)
   (dolist (mode (doom-enlist modes))
     (cl-destructuring-bind (m &optional probe)
         (doom-enlist mode)
       (if unset
           (puthash m (assq-delete-all name (gethash key format-all-mode-table))
                    format-all-mode-table)
-        (format-all-pushhash
+        (format-all--pushhash
          m (cons name (if probe `(lambda () ,probe)))
-         format-all-mode-table)))))
+         format-all--mode-table)))))
 
 ;;;###autodef
 (cl-defun set-formatter!
@@ -99,7 +99,7 @@ FORMATTER can be a symbol referring to another formatter, a function, string or
 nested list.
 
   If a function, it should be a formatter function that
-    `format-all-buffer-thunk' will accept.
+    `format-all--buffer-thunk' will accept.
   If a string, it is assumed to be a shell command that the buffer's text will
     be piped to (through stdin).
   If a list, it should represent a shell command as a list of arguments. Each
@@ -173,7 +173,7 @@ Advanced examples:
     :filter
     (lambda (output errput first-diff)
       (list output
-            (format-all-remove-ansi-color errput)
+            (format-all--remove-ansi-color errput)
             first-diff)))"
   (declare (indent defun))
   (cl-check-type name symbol)

--- a/modules/editor/format/config.el
+++ b/modules/editor/format/config.el
@@ -47,7 +47,7 @@ This is controlled by `+format-on-save-enabled-modes'."
 
 ;; Allow a specific formatter to be used by setting `+format-with', either
 ;; buffer-locally or let-bound.
-(advice-add #'format-all-probe :around #'+format*probe)
+(advice-add #'format-all--probe :around #'+format*probe)
 
 ;; Doom uses a modded `format-all-buffer', which
 ;;   1. Doesn't move the cursorafter reformatting,

--- a/modules/editor/format/test/test-format.el
+++ b/modules/editor/format/test/test-format.el
@@ -8,12 +8,12 @@
 
 ;;
 (describe "editor/format"
-  :var (format-all-format-table
-        format-all-mode-table)
+  :var (format-all--format-table
+        format-all--mode-table)
 
   (before-each
-    (setq format-all-format-table (make-hash-table)
-          format-all-mode-table (make-hash-table)))
+    (setq format-all--format-table (make-hash-table)
+          format-all--mode-table (make-hash-table)))
 
   (describe "set-formatter!"
     (before-each
@@ -21,25 +21,25 @@
 
     (it "defines a formatter"
       (set-formatter! 'new (lambda () (interactive)))
-      (expect (gethash 'new format-all-mode-table) :to-equal nil)
-      (expect (functionp (gethash 'new format-all-format-table))))
+      (expect (gethash 'new format-all--mode-table) :to-equal nil)
+      (expect (functionp (gethash 'new format-all--format-table))))
 
     (it "defines a formatter with modes"
       (set-formatter! 'new (lambda () (interactive))
         :modes '(a-mode (b-mode "x")))
-      (expect (gethash 'a-mode format-all-mode-table)
+      (expect (gethash 'a-mode format-all--mode-table)
               :to-equal '((new)))
-      (expect (gethash 'b-mode format-all-mode-table)
+      (expect (gethash 'b-mode format-all--mode-table)
               :to-equal '((new . (lambda () "x")))))
 
     (it "replaces a pre-existing formatter"
-      (let ((old-fn (gethash 'test format-all-format-table)))
+      (let ((old-fn (gethash 'test format-all--format-table)))
         (set-formatter! 'test "echo")
-        (expect (gethash 'test format-all-format-table) :not :to-equal old-fn)))
+        (expect (gethash 'test format-all--format-table) :not :to-equal old-fn)))
 
     (it "unsets a pre-existing formatter"
       (set-formatter! 'test nil)
-      (expect (gethash 'test format-all-format-table) :to-be nil))
+      (expect (gethash 'test format-all--format-table) :to-be nil))
 
     (it "errors when unsetting non-existent formatter"
       (expect (set-formatter! 'doesnt-exist nil) :to-throw)))


### PR DESCRIPTION
This should fix [1470](https://github.com/hlissner/doom-emacs/issues/1470)

I'm completely new to emacs and have no clue what I'm doing, so be warned and bear with me if this is is all bonkers ;)