### PR TITLE
Fix that git-timemachine keybinding is not working in evil mode

### DIFF
--- a/modules/emacs/vc/config.el
+++ b/modules/emacs/vc/config.el
@@ -12,6 +12,7 @@
 
   (after! evil
     ;; rehash evil keybindings so they are recognized
+    (evil-make-overriding-map git-timemachine-mode-map 'normal)
     (add-hook 'git-timemachine-mode-hook #'evil-normalize-keymaps))
 
   (when (featurep! :tools magit)


### PR DESCRIPTION
Seems like it is not working since the overriding map is not created first.

I'm not familiar with evil but this seems to be the way to do it. E.g., https://emacs.stackexchange.com/questions/14154/evil-mode-with-ggtags

