### PR TITLE
Uniquify buffer names

### DIFF
--- a/core/core-ui.el
+++ b/core/core-ui.el
@@ -191,7 +191,7 @@ read-only or not file-visiting."
  mouse-yank-at-point t           ; middle-click paste at point, not at click
  resize-mini-windows 'grow-only  ; Minibuffer resizing
  show-help-function nil          ; hide :help-echo text
- uniquify-buffer-name-style nil  ; custom modeline will show file paths anyway
+ uniquify-buffer-name-style 'post-forward-angle-brackets ; to show hints when switching buffers
  use-dialog-box nil              ; always avoid GUI
  visible-cursor nil
  x-stretch-cursor nil

--- a/modules/ui/workspaces/config.el
+++ b/modules/ui/workspaces/config.el
@@ -100,11 +100,15 @@ Uses `+workspaces-main' to determine the name of the main workspace."
   (defun +workspaces|init-persp-mode ()
     (cond (persp-mode
            ;; `persp-kill-buffer-query-function' must be last
+           (setq my-uniquify-buffer-name-style uniquify-buffer-name-style)
+           (setq uniquify-buffer-name-style nil)
            (remove-hook 'kill-buffer-query-functions 'persp-kill-buffer-query-function)
            (add-hook 'kill-buffer-query-functions 'persp-kill-buffer-query-function t)
            ;; Restrict buffer list to workspace
            (advice-add #'doom-buffer-list :override #'+workspace-buffer-list))
-          ((advice-remove #'doom-buffer-list #'+workspace-buffer-list))))
+          ((advice-remove #'doom-buffer-list #'+workspace-buffer-list))
+          (t (setq uniquify-buffer-name-style my-uniquify-buffer-name-style))))
+
   (add-hook 'persp-mode-hook #'+workspaces|init-persp-mode)
 
   (defun +workspaces|leave-nil-perspective (&rest _)


### PR DESCRIPTION
This improves buffer switching, as in this screenshot, you can see that it's not obvious which buffer is which: https://imgur.com/vC8Jaio

But with this change, this is what we get: https://imgur.com/Iki1EVD

This makes it easier to switch buffers, and to be sure what you are changing to. If there is some shortcut to expand the buffer name in minibuffer, I'm not aware of it. Either way, I believe this is a better alternative, because it gives you more information right as you want to switch buffers.
