### PR TITLE
README.md: Fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Table of Contents
     - [Doom's mantras](#dooms-mantras)
     - [Feature highlights](#feature-highlights)
 - [Getting Help](#getting-help)
-- [Contributing](#contributing)
+- [Contributing](#troubleshooting)
 
 
 What is Doom Emacs
@@ -166,7 +166,7 @@ contributions:
 [docs:wiki-modules]: docs/modules.org
 [docs:wiki-customization]: docs/customize.org
 [docs:contributing]: docs/contribute.org
-[docs:faq]: docs/faq.org
+[docs:faq]: https://github.com/hlissner/doom-emacs/wiki/FAQ
 
 [github:new-issue]: https://github.com/hlissner/doom-emacs/issues/new
 [doom:bindings]: modules/config/default/+evil-bindings.el


### PR DESCRIPTION
There were a couple of broken links on the README.

Getting Help was pointing to a section that doesn't exist anymore.

docs:faq was pointing to a 404 for me. 

docs:contributing still points to a 404, I'm not sure where you wanted it to point.