### PR TITLE
ansible: fix upstream changing function names

### DIFF
--- a/modules/tools/ansible/config.el
+++ b/modules/tools/ansible/config.el
@@ -1,16 +1,16 @@
 ;;; tools/ansible/config.el -*- lexical-binding: t; -*-
 
 (def-package! ansible
-  :commands ansible::auto-decrypt-encrypt
+  :commands ansible-auto-decrypt-encrypt
   :init
-  (put 'ansible::vault-password-file 'safe-local-variable #'stringp)
+  (put 'ansible-vault-password-file 'safe-local-variable #'stringp)
   :config
-  (setq ansible::section-face 'font-lock-variable-name-face
-        ansible::task-label-face 'font-lock-doc-face)
-  (map! :map ansible::key-map
+  (setq ansible-section-face 'font-lock-variable-name-face
+        ansible-task-label-face 'font-lock-doc-face)
+  (map! :map ansible-key-map
         :localleader
-        :desc "Decrypt buffer"          "d" #'ansible::decrypt-buffer
-        :desc "Encrypt buffer"          "e" #'ansible::encrypt-buffer
+        :desc "Decrypt buffer"          "d" #'ansible-decrypt-buffer
+        :desc "Encrypt buffer"          "e" #'ansible-encrypt-buffer
         :desc "Look up in Ansible docs" "h" #'ansible-doc))
 
 (after! ansible-doc
@@ -21,5 +21,5 @@
 
 (def-project-mode! +ansible-yaml-mode
   :modes (yaml-mode)
-  :add-hooks (ansible ansible::auto-decrypt-encrypt ansible-doc-mode)
+  :add-hooks (ansible ansible-auto-decrypt-encrypt ansible-doc-mode)
   :files ("roles/"))


### PR DESCRIPTION
A simple fix for upstream renaming all their functions.