### PR TITLE
Remove flycheck-rust since it is no longer used.

### DIFF
--- a/modules/lang/rust/packages.el
+++ b/modules/lang/rust/packages.el
@@ -4,8 +4,6 @@
 (when EMACS26+
   (package! rustic))
 (package! rust-mode)
-(when (featurep! :tools flycheck)
-  (package! flycheck-rust))
 (unless (featurep! +lsp)
   (package! racer))
 


### PR DESCRIPTION
Removing the dependency for flycheck-rust since it is no longer used and causes problems when required without being set up.