### PR TITLE
lang/racket: Fix smart open bracket insertion

### DIFF
--- a/modules/lang/racket/config.el
+++ b/modules/lang/racket/config.el
@@ -16,12 +16,13 @@
   (set-rotate-patterns! 'racket-mode
     :symbols '(("#true" "#false")))
 
-  (setq racket-smart-open-bracket-enable t)
-
   (add-hook! 'racket-mode-hook
              #'rainbow-delimiters-mode
              #'highlight-quoted-mode)
   (set-lookup-handlers! 'racket-mode :definition #'racket-visit-definition)
+
+  (map! :map (racket-mode-map racket-repl-mode-hook)
+        :i "[" #'racket-smart-open-bracket)
 
   (map! :localleader
         :map racket-mode-map


### PR DESCRIPTION
`racket-smart-open-bracket-enable` has been replaced by a function that inserts the right type of bracket (see https://github.com/greghendershott/racket-mode/commit/669275b3a620a940ce1c52610909577e94abf55f), which we need to bind to [ in insert mode.

This feature used to work, then Issue #1452 was filed to request it be configurable, then it broke, and now I'm fixing it. This indicates that maybe instead of just fixing it we should make it configurable, or users should do this customization themselves and this PR should just stop setting the obsolete `racket-smart-open-bracket-enable` flag. Note that DrRacket does not enable this setting by default.
