### PR TITLE
Add scheme module

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -141,6 +141,7 @@
        ;;ruby              ; 1.step {|i| p "Ruby is #{i.even? ? 'love' : 'life'}"}
        ;;rust              ; Fe2O3.unwrap().unwrap().unwrap().unwrap()
        ;;scala             ; java, but good
+       ;;scheme            ; a fully conniving family of lisps
        sh                ; she sells {ba,z,fi}sh shells on the C xor
        ;;solidity          ; do you need a blockchain? No.
        ;;swift             ; who asked for emoji variables?

--- a/modules/lang/scheme/README.org
+++ b/modules/lang/scheme/README.org
@@ -1,0 +1,38 @@
+#+TITLE:   lang/scheme
+#+DATE:    July 23, 2019
+#+SINCE:   {replace with next tagged release version}
+#+STARTUP: inlineimages
+
+* Table of Contents :TOC_3:noexport:
+- [[#description][Description]]
+  - [[#module-flags][Module Flags]]
+- [[#prerequisites][Prerequisites]]
+- [[#features][Features]]
+  - [[#commands][Commands]]
+    - [[#geiser][Geiser]]
+
+* Description
+This module provides an environment for hacking and having fun in scheme. It is
+powered by [[https://www.nongnu.org/geiser/geiser_1.html#introduction][geiser]].
+
+** Module Flags
+This module provides no flags.
+
+
+* Prerequisites
+This module requires you to have at least one of the supported schemes, namely:
+- [[https://www.gnu.org/software/guile][Guile]] 2.2.0 or better
+- [[https://call-cc.org][Chicken]] 4.8.0 or better
+- [[https://www.gnu.org/software/mit-scheme][MIT/GNU Scheme]] 9.1.1 or better
+- [[https://synthcode.com/scheme/chibi][Chibi Scheme]] 0.7.3 or better
+- [[https://www.scheme.com][Chez Scheme]] 9.4 or better
+
+Their executables must be present in your path for geiser to work properly.
+
+* Features
+** Commands
+*** Geiser
+| command             | key / ex command | description          |
+|---------------------+------------------+----------------------|
+| ~+scheme/open-repl~ | =:repl=          | Open the Scheme Repl |
+|                     |                  |                      |

--- a/modules/lang/scheme/README.org
+++ b/modules/lang/scheme/README.org
@@ -1,6 +1,6 @@
 #+TITLE:   lang/scheme
 #+DATE:    July 23, 2019
-#+SINCE:   {replace with next tagged release version}
+#+SINCE:   v2.0.9
 #+STARTUP: inlineimages
 
 * Table of Contents :TOC_3:noexport:

--- a/modules/lang/scheme/autoload.el
+++ b/modules/lang/scheme/autoload.el
@@ -1,0 +1,8 @@
+;;; lang/scheme/autoload.el -*- lexical-binding: t; -*-
+
+;;;###autoload
+(defun +scheme/repl (&optional arg)
+  "Open the Scheme REPL."
+  (interactive "P")
+  (switch-to-geiser arg)
+  (current-buffer))

--- a/modules/lang/scheme/config.el
+++ b/modules/lang/scheme/config.el
@@ -2,20 +2,12 @@
 
 (add-hook 'scheme-mode-hook #'rainbow-delimiters-mode)
 
-(defun +scheme/impls ()
-  `( ,@(when (featurep! +racket)  '(racket))
-     ,@(when (featurep! +guile)   '(guile))
-     ,@(when (featurep! +chicken) '(chicken))
-     ,@(when (featurep! +mit)     '(mit))
-     ,@(when (featurep! +chibi)   '(chibi))
-     ,@(when (featurep! +chez)    '(chez)) ()))
-
 (def-package! geiser
   :mode ("\\.scm\\'" . scheme-mode)
   :mode ("\\.ss\\'"  . scheme-mode)
   :commands (geiser)
   :init
-  (setq geiser-active-implementations #'+scheme/impls)
+  (setq geiser-active-implementations '(guile chicken mit chibi chez))
   (set-repl-handler! 'scheme-mode '+scheme/repl)
   (set-eval-handler! 'scheme-mode #'geiser-eval-region)
   (set-lookup-handlers! 'scheme-mode
@@ -36,7 +28,8 @@
               "R" #'geiser-eval-region-and-go)
 
             (:prefix ("h" . "help")
-              "d" 'geiser-autodoc)
+              "d" 'geiser-autodoc
+              ;; TODO add more help keybindings)
 
             (:prefix ("r" . "repl")
               "b" #'geiser-switch-to-repl

--- a/modules/lang/scheme/config.el
+++ b/modules/lang/scheme/config.el
@@ -28,8 +28,8 @@
               "R" #'geiser-eval-region-and-go)
 
             (:prefix ("h" . "help")
-              "d" 'geiser-autodoc
-              ;; TODO add more help keybindings)
+              "d" 'geiser-autodoc)
+              ;; TODO add more help keybindings
 
             (:prefix ("r" . "repl")
               "b" #'geiser-switch-to-repl

--- a/modules/lang/scheme/config.el
+++ b/modules/lang/scheme/config.el
@@ -1,0 +1,46 @@
+;;; lang/scheme/config.el -*- lexical-binding: t; -*-
+
+(add-hook 'scheme-mode-hook #'rainbow-delimiters-mode)
+
+(defun +scheme/impls ()
+  `( ,@(when (featurep! +racket)  '(racket))
+     ,@(when (featurep! +guile)   '(guile))
+     ,@(when (featurep! +chicken) '(chicken))
+     ,@(when (featurep! +mit)     '(mit))
+     ,@(when (featurep! +chibi)   '(chibi))
+     ,@(when (featurep! +chez)    '(chez)) ()))
+
+(def-package! geiser
+  :mode ("\\.scm\\'" . scheme-mode)
+  :mode ("\\.ss\\'"  . scheme-mode)
+  :commands (geiser)
+  :init
+  (setq geiser-active-implementations #'+scheme/impls)
+  (set-repl-handler! 'scheme-mode '+scheme/repl)
+  (set-eval-handler! 'scheme-mode #'geiser-eval-region)
+  (set-lookup-handlers! 'scheme-mode
+    :definition #'geiser-edit-symbol-at-point
+    :documentation #'geiser-doc-symbol-at-point)
+  :config
+  (map! (:localleader
+          (:map scheme-mode-map
+            "'" #'geiser-mode-switch-to-repl
+            "s" #'geiser-set-scheme
+
+            (:prefix ("e" . "eval")
+              "b" #'geiser-eval-buffer
+              "B" #'geiser-eval-buffer-and-go
+              "e" #'geiser-eval-definition
+              "E" #'geiser-eval-definition-and-go
+              "r" #'geiser-eval-region
+              "R" #'geiser-eval-region-and-go)
+
+            (:prefix ("h" . "help")
+              "d" 'geiser-autodoc)
+
+            (:prefix ("r" . "repl")
+              "b" #'geiser-switch-to-repl
+              "q" #'geiser-repl-exit
+              "r" #'geiser-restart-repl
+              "R" #'geiser-reload
+              "c" #'geiser-repl-clear-buffer)))))

--- a/modules/lang/scheme/packages.el
+++ b/modules/lang/scheme/packages.el
@@ -1,0 +1,4 @@
+;; -*- no-byte-compile: t; -*-
+;;; lang/scheme/packages.el
+
+(package! geiser)


### PR DESCRIPTION
Adds a simple scheme module with geiser backend, supports all major scheme implementations except racket, which I have left out considering racket has its own module that will probably serve users better.