### PR TITLE
Fix quoting of command in λ!!

### DIFF
--- a/core/core-lib.el
+++ b/core/core-lib.el
@@ -180,9 +180,9 @@ at the values with which this function was called."
 (defun λ!! (command &optional arg)
   "Expands to a command that interactively calls COMMAND with prefix ARG."
   (declare (doc-string 1))
-  `(lambda () (interactive)
-     (let ((current-prefix-arg ,arg))
-       (call-interactively ,command))))
+  (lambda () (interactive)
+     (let ((current-prefix-arg arg))
+       (call-interactively command))))
 (defalias 'lambda!! 'λ!!)
 
 (define-obsolete-function-alias 'FILE! 'file!) ; DEPRECATED


### PR DESCRIPTION
``` emacs-lisp
(lambda!! #'avy-goto-char-timer t)
```

Before:

``` emacs-lisp
(lambda nil
  (interactive)
  (let ((current-prefix-arg t))
    (call-interactively avy-goto-char-timer)))
```

After:

``` emacs-lisp
(lambda nil
  (interactive)
  (let ((current-prefix-arg t))
    (call-interactively
     (function avy-goto-char-timer))))
```