### PR TITLE
tools/lsp: cache company candidates automagically

### DIFF
--- a/modules/tools/lsp/config.el
+++ b/modules/tools/lsp/config.el
@@ -68,4 +68,6 @@
         (setq-local company-backends
                     (cons 'company-lsp
                           (remq 'company-capf company-backends)))
-        (remove-hook 'company-mode-hook #'+lsp-init-company-h t)))))
+        (remove-hook 'company-mode-hook #'+lsp-init-company-h t))))
+  :config
+  (setq company-lsp-cache-candidates 'auto)) ;; cache candidates for better performance


### PR DESCRIPTION
When opening a buffer, company-mode is not activated and therefore there's no completion. this was introduced in 149b2617 and now fixes the mistake