### PR TITLE
lang/racket: set lookup handler to find definition

### DIFF
--- a/modules/lang/racket/config.el
+++ b/modules/lang/racket/config.el
@@ -21,6 +21,7 @@
   (add-hook! 'racket-mode-hook
              #'rainbow-delimiters-mode
              #'highlight-quoted-mode)
+  (set-lookup-handlers! 'racket-mode :definition #'racket-visit-definition)
 
   (map! :localleader
         :map racket-mode-map


### PR DESCRIPTION
Add a lookup handler for racket-mode to enable `SPC c d` to jump to definition (`, g d` is already bound to `racket-visit-definition`, but not the generic Jump to definition).

This is a bit buggy if you don't already have a Racket REPL open, which `racket-visit-definition` seems to rely on. That said, racket-mode will open a basic REPL even if you have errors in the buffer and many things will still work.