### PR TITLE
Add support for Elixir LSP via elixir-ls

### DIFF
--- a/modules/lang/elixir/config.el
+++ b/modules/lang/elixir/config.el
@@ -29,6 +29,9 @@
     (sp-local-pair "do " " end" :unless '(sp-in-comment-p sp-in-string-p))
     (sp-local-pair "fn " " end" :unless '(sp-in-comment-p sp-in-string-p)))
 
+  (when (featurep! +lsp)
+    (add-hook 'elixir-mode-local-vars-hook #'lsp!))
+
   (use-package! alchemist-company
     :when (featurep! :completion company)
     :commands alchemist-company

--- a/modules/tools/lsp/README.org
+++ b/modules/tools/lsp/README.org
@@ -32,6 +32,7 @@ As of this writing, this is the state of LSP support in Doom Emacs:
 | Module           | Major modes                                             | Default language server                                       |
 |------------------+---------------------------------------------------------+---------------------------------------------------------------|
 | [[../../lang/cc/README.org][:lang cc]]         | c-mode, c++-mode, objc-mode                             | ccls                                                          |
+| [[../../lang/elixir/README.org][:lang elixir]]     | elixir-mode                                             | elixir-ls                                                     |
 | [[../../lang/go/README.org][:lang go]]         | go-mode                                                 | go-langserver                                                 |
 | [[../../lang/haskell/README.org][:lang haskell]]    | haskell-mode                                            | haskell-ide-engine                                            |
 | [[../../lang/javascript/README.org][:lang javascript]] | js2-mode, rjsx-mode, typescript-mode                    | typescript-language-server                                    |


### PR DESCRIPTION
- Document Elixir with LSP via elixir-ls
- Add `+lsp` flag to `:lang elixir`

Goes with #1510.
