### PR TITLE
Update list of lang/python considered conda homes

### DIFF
--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -205,6 +205,7 @@ called.")
                                     "~/.anaconda"
                                     "~/.miniconda"
                                     "~/.miniconda3"
+                                    "~/miniconda3"
                                     "/usr/bin/anaconda3"
                                     "/usr/local/anaconda3"
                                     "/usr/local/miniconda3")

--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -208,7 +208,8 @@ called.")
                                     "~/miniconda3"
                                     "/usr/bin/anaconda3"
                                     "/usr/local/anaconda3"
-                                    "/usr/local/miniconda3")
+                                    "/usr/local/miniconda3"
+                                    "/usr/local/Caskroom/miniconda/base")
                    if (file-directory-p dir)
                    return (setq conda-anaconda-home dir
                                 conda-env-home-directory dir))


### PR DESCRIPTION
For several years, the default location for a miniconda install has been `~/miniconda3` (`~/miniconda2` if using the python 2 version). This PR adds this path to the list considered by the conda package.