### PR TITLE
Uniquify completion candidates of whole lines

### DIFF
--- a/modules/completion/company/autoload.el
+++ b/modules/completion/company/autoload.el
@@ -129,12 +129,13 @@ C-x C-l."
     (`candidates
      (all-completions
       arg
-      (split-string
-       (replace-regexp-in-string
-        "^[\t\s]+" ""
-        (concat (buffer-substring-no-properties (point-min) (line-beginning-position))
-                (buffer-substring-no-properties (line-end-position) (point-max))))
-       "\\(\r\n\\|[\n\r]\\)" t)))))
+      (delete-dups
+       (split-string
+        (replace-regexp-in-string
+         "^[\t\s]+" ""
+         (concat (buffer-substring-no-properties (point-min) (line-beginning-position))
+                 (buffer-substring-no-properties (line-end-position) (point-max))))
+        "\\(\r\n\\|[\n\r]\\)" t))))))
 
 ;;;###autoload
 (defun +company/dict-or-keywords ()


### PR DESCRIPTION
If the same line is present more than once in the buffer, it will be
offered more than once as a candidate. This commit deletes duplicate
lines from the completion list.
