### PR TITLE
Use +pretty-code-iosevka-font-name on complete set

### DIFF
--- a/modules/ui/pretty-code/+iosevka.el
+++ b/modules/ui/pretty-code/+iosevka.el
@@ -224,7 +224,7 @@
   "Defines the character mappings for ligatures for Iosevka.")
 
 (defun +pretty-code|setup-iosevka-ligatures ()
-  (set-fontset-font t '(#Xe100 . #Xe16f) +pretty-code-iosevka-font-name)
+  (set-fontset-font t '(#Xe100 . #Xe1cc) +pretty-code-iosevka-font-name)
   (setq-default prettify-symbols-alist
                 (append prettify-symbols-alist
                         +pretty-code-iosevka-font-ligatures)))


### PR DESCRIPTION
The ligatures are defined for the fontset `#Xe100 -> #Xe1cc` but the hook function did not use that complete space for the ligatures
