### PR TITLE
rebind "\"" to cider-jack-in-cljs

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -62,7 +62,7 @@
   (map! (:localleader
           (:map clojure-mode-map
             "'"  #'cider-jack-in
-            "\"" #'cider-jack-in-clojurescript
+            "\"" #'cider-jack-in-cljs
 
             (:prefix ("e" . "eval")
               "d" #'cider-eval-defun-at-point


### PR DESCRIPTION
Originally `cider-jack-in-clojurescript` but said command was deprecated.
Copy of https://github.com/hlissner/doom-emacs/pull/1595 because history happened, and I don't know how to fix it. 😅
