### PR TITLE
Bindings for Clojure and Web modules

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -60,9 +60,11 @@
   (setq cider-repl-display-help-banner nil)
 
   (map! (:localleader
-          (:map clojure-mode-map
-            "'"  #'cider-jack-in
+          (:map (clojure-mode-map clojurescript-mode-map)
+            "'"  #'cider-jack-in-clj
             "\"" #'cider-jack-in-cljs
+            "c"  #'cider-connect-clj
+            "C"  #'cider-connect-cljs
 
             (:prefix ("e" . "eval")
               "d" #'cider-eval-defun-at-point
@@ -83,6 +85,7 @@
               "g" #'cider-grimoire-web
               "j" #'cider-javadoc)
             (:prefix ("i" . "inspect")
+              "e" #'cider-enlighten-mode
               "i" #'cider-inspect
               "r" #'cider-inspect-last-result)
             (:prefix ("m" . "macro")
@@ -113,6 +116,7 @@
         (:when (featurep! :editor evil +everywhere)
           :map cider-repl-mode-map
           :i [S-return] #'cider-repl-newline-and-indent
+          :i [M-return] #'cider-repl-return
           (:localleader
             ("n" #'cider-repl-set-ns
              "q" #'cider-quit

--- a/modules/lang/web/+html.el
+++ b/modules/lang/web/+html.el
@@ -64,7 +64,7 @@
           :desc "Rehighlight buffer" "h" #'web-mode-buffer-highlight
           :desc "Indent buffer"      "i" #'web-mode-buffer-indent
 
-          (:prefix "a"
+          (:prefix ("a" . "attribute")
             "b" #'web-mode-attribute-beginning
             "e" #'web-mode-attribute-end
             "i" #'web-mode-attribute-insert
@@ -74,7 +74,7 @@
             "p" #'web-mode-attribute-previous
             "p" #'web-mode-attribute-transpose)
 
-          (:prefix "b"
+          (:prefix ("b" . "block")
             "b" #'web-mode-block-beginning
             "c" #'web-mode-block-close
             "e" #'web-mode-block-end
@@ -83,7 +83,7 @@
             "p" #'web-mode-block-previous
             "s" #'web-mode-block-select)
 
-          (:prefix "d"
+          (:prefix ("d" . "dom")
             "a" #'web-mode-dom-apostrophes-replace
             "d" #'web-mode-dom-errors-show
             "e" #'web-mode-dom-entities-encode
@@ -92,7 +92,7 @@
             "t" #'web-mode-dom-traverse
             "x" #'web-mode-dom-xpath)
 
-          (:prefix "e"
+          (:prefix ("e" . "element")
             "/" #'web-mode-element-close
             "a" #'web-mode-element-content-select
             "b" #'web-mode-element-beginning
@@ -112,7 +112,7 @@
             "v" #'web-mode-element-vanish
             "w" #'web-mode-element-wrap)
 
-          (:prefix "t"
+          (:prefix ("t" . "tag")
             "a" #'web-mode-tag-attributes-sort
             "b" #'web-mode-tag-beginning
             "e" #'web-mode-tag-end


### PR DESCRIPTION
Salut!

I added some bindings to _Clojure_ and _Web_ modules.

**Clojure**
- map the bindings to _clojure-map-mode_ AND _clojurescript-mode-map_
- modify _cider-jack-in_ to _cider-jack-in-clj_
- add bindings for _cider-connect-*_
- add binding for _cider-enlighten-mode_
- add binding for _cider-repl-return_

**Web**
- add prefix descriptions
