### PR TITLE
Require straight.el in doom/reload-packages

### DIFF
--- a/core/autoload/packages.el
+++ b/core/autoload/packages.el
@@ -197,6 +197,8 @@ ones."
 (defun doom/reload-packages ()
   "Reload `doom-packages', `package' and `quelpa'."
   (interactive)
+  ;; HACK straight.el must be loaded for this to work
+  (require 'straight)
   (message "Reloading packages")
   (doom-initialize-packages t)
   (message "Reloading packages...DONE"))


### PR DESCRIPTION
Because it's not loaded for some reason.

Also, `require` is not a big problem IMO: if you run this interactively, the
`require` cost probably doesn't matter much already.

Fixes #1618.