### PR TITLE
fix small spelling mistake in fonts.el

### DIFF
--- a/core/autoload/fonts.el
+++ b/core/autoload/fonts.el
@@ -50,7 +50,7 @@ FRAME parameter defaults to current frame."
     (let ((new-size (+ (string-to-number (aref font xlfd-regexp-pixelsize-subnum))
                        increment)))
       (unless (> new-size 0)
-        (error "Font is to small at %d" new-size))
+        (error "Font is too small at %d" new-size))
       (aset font xlfd-regexp-pixelsize-subnum (number-to-string new-size)))
     ;; Set point size & width to "*", so frame width will adjust to new font size
     (aset font xlfd-regexp-pointsize-subnum "*")


### PR DESCRIPTION
There is a small spelling mistake in `fonts.el`. This is just a small PR to fix it. 