### PR TITLE
fix: bump languagetool jar search depth on macos

### DIFF
--- a/modules/app/write/config.el
+++ b/modules/app/write/config.el
@@ -23,7 +23,7 @@
                  (locate-file "libexec/languagetool-commandline.jar"
                               (doom-files-in "/usr/local/Cellar/languagetool"
                                              :type 'dirs
-                                             :depth 1)))
+                                             :depth 2)))
                 (IS-LINUX
                  "/usr/share/java/languagetool/languagetool-commandline.jar")))))
 


### PR DESCRIPTION
On macos, the libexec directory for languagetool, as installed by brew,
lives in a version directory. To find the jar, we need to increase the
search depth, since the version directory will change with every version.

Example of brew-installed languagetool:
```bash
$ tree -L 2 /usr/local/Cellar/languagetool
=>
/usr/local/Cellar/languagetool
└── 4.6
    ├── CHANGES.md
    ├── CHANGES.txt
    ├── COPYING.txt
    ├── INSTALL_RECEIPT.json
    ├── README.md
    ├── bin
    └── libexec
```