### PR TITLE
lang/plantuml: change mirror for +plantuml/install

### DIFF
--- a/modules/lang/plantuml/autoload.el
+++ b/modules/lang/plantuml/autoload.el
@@ -6,5 +6,5 @@
   (interactive)
   (if (file-exists-p plantuml-jar-path)
       (user-error "plantuml.jar already installed")
-    (url-copy-file "https://kent.dl.sourceforge.net/project/plantuml/plantuml.jar"
+    (url-copy-file "https://datapacket.dl.sourceforge.net/project/plantuml/plantuml.jar"
                    plantuml-jar-path)))


### PR DESCRIPTION
This is the one they currently redirect to.

Fixes #1637.
