### PR TITLE
Fix evil-window "c" binding

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -140,7 +140,6 @@
         "C-r"     #'winner-redo
         "o"       #'doom/window-enlargen
         ;; Delete window
-        "c"       #'+workspace/close-window-or-workspace
         "C-C"     #'ace-delete-window)
 
       ;; Plugins


### PR DESCRIPTION
Instead of relying on the optional ":ui workspaces" feature, the
built-in `evil-window-delete` is used and
`+workspace/close-window-or-workspace` is only used if ":ui workspaces" is
enabled.

Fixes https://github.com/hlissner/doom-emacs/issues/1640.

