### PR TITLE
Add symbol-overlay package to :ui

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -35,6 +35,7 @@
         +all             ; catch all popups that start with an asterix
         +defaults)       ; default popup rules
        ;;pretty-code       ; replace bits of code with pretty symbols
+       ;;symbol-overlay    ; highlight symbols in the same buffer with easy navigation
        ;;tabbar            ; FIXME an (incomplete) tab bar for Emacs
        ;;treemacs          ; a project drawer, like neotree but cooler
        ;;unicode           ; extended unicode support for various languages

--- a/modules/ui/symbol-overlay/config.el
+++ b/modules/ui/symbol-overlay/config.el
@@ -1,0 +1,8 @@
+;;; ui/symbol-overlay/config.el -*- lexical-binding: t; -*-
+
+(def-package! symbol-overlay
+  :config
+  (map! :leader
+        "c o" 'symbol-overlay-put)
+  (map! :map symbol-overlay-map
+        [escape] 'symbol-overlay-put))

--- a/modules/ui/symbol-overlay/packages.el
+++ b/modules/ui/symbol-overlay/packages.el
@@ -1,0 +1,4 @@
+;; -*- no-byte-compile: t; -*-
+;;; ui/symbol-overlay/packages.el
+
+(package! symbol-overlay)


### PR DESCRIPTION
symbol-overlay is an easy-to-use package, with symbol-overlay-put, the
symbol under the cursor will be highlighted across the whole buffer, and
then when cursor if in the symbol, n/p can be used to navigate the symbol.

For more detailed description, please refer to
https://github.com/wolray/symbol-overlay