### PR TITLE
Advice pdf-tools to display retina image on Emacs NS-port master

### DIFF
--- a/modules/tools/pdf/autoload/pdf.el
+++ b/modules/tools/pdf/autoload/pdf.el
@@ -1,0 +1,24 @@
+;;; tools/pdf/autoload/pdf.el -*- lexical-binding: t; -*-
+;;;###autoload
+(defun *pdf-pdf-view-use-scaling-p ()
+    "Return t if scaling should be used."
+    (and (or (and (eq system-type 'darwin) (string-equal emacs-version "27.0.50"))
+             (memq (pdf-view-image-type)
+                   '(imagemagick image-io)))
+         pdf-view-use-scaling))
+;;;###autoload
+(defun *pdf-pdf-view-create-page (page &optional window)
+  "Create an image of PAGE for display on WINDOW."
+  (let* ((size (pdf-view-desired-image-size page window))
+         (width (if (not (pdf-view-use-scaling-p))
+                    (car size)
+                  (* 2 (car size))))
+         (data (pdf-cache-renderpage
+                page width width))
+         (hotspots (pdf-view-apply-hotspot-functions
+                    window page size)))
+    (pdf-view-create-image data
+      :width width
+      :scale (if (pdf-view-use-scaling-p) 0.5 1)
+      :map hotspots
+      :pointer 'arrow)))

--- a/modules/tools/pdf/config.el
+++ b/modules/tools/pdf/config.el
@@ -20,7 +20,12 @@
   (add-hook! 'pdf-view-mode-hook
     (add-hook 'kill-buffer-hook #'+pdf-cleanup-windows-h nil t))
 
-  (setq-default pdf-view-display-size 'fit-page)
+  (setq-default pdf-view-display-size 'fit-page
+                pdf-view-use-scaling t
+                pdf-view-use-imagemagick nil)
+
+  (advice-add 'pdf-view-use-scaling-p :override #'*pdf-pdf-view-use-scaling-p)
+  (advice-add 'pdf-view-create-page :override #'*pdf-pdf-view-create-page)
   ;; Turn off cua so copy works
   (add-hook! 'pdf-view-mode-hook (cua-mode 0))
   ;; Handle PDF-tools related popups better


### PR DESCRIPTION
This PR patch pdf-tools to enable retina display on Emacs NS-port master branch.

PR to `pdf-tools`: https://github.com/politza/pdf-tools/pull/501

This PR will be removed if that one gets merged.