### PR TITLE
Added company-phpactor to packages

### DIFF
--- a/modules/lang/php/packages.el
+++ b/modules/lang/php/packages.el
@@ -11,7 +11,8 @@
   (package! hack-mode :recipe (:host github :repo "hhvm/hack-mode")))
 
 (unless (featurep! +lsp)
-  (package! phpactor))
+  (package! phpactor)
+  (package! company-phpactor))
 
 (when (featurep! :editor format)
   (package! php-cs-fixer))

--- a/modules/lang/php/packages.el
+++ b/modules/lang/php/packages.el
@@ -12,7 +12,8 @@
 
 (unless (featurep! +lsp)
   (package! phpactor)
-  (package! company-phpactor))
+  (when (featurep! :completion company)
+    (package! company-phpactor)))
 
 (when (featurep! :editor format)
   (package! php-cs-fixer))


### PR DESCRIPTION
Previously this was included automatically with phpactor, but now the
phpactor package call is only pulling in phpactor.el and its
requirements.

So this is necessary for proper auto-completion.