### PR TITLE
fix (#1673): replace references to project-file-exists-p! with projec…

### DIFF
--- a/modules/lang/java/autoload.el
+++ b/modules/lang/java/autoload.el
@@ -28,8 +28,9 @@
 
 It determines this by the existence of AndroidManifest.xml or
 src/main/AndroidManifest.xml."
-  (when (project-file-exists-p! (or "AndroidManifest.xml"
-                                    "src/main/AndroidManifest.xml"))
+  (when (or
+         (projectile-file-exists-p "AndroidManifest.xml")
+         (projectile-file-exists-p "src/main/AndroidManifest.xml"))
     (android-mode +1)))
 
 ;;;###autoload


### PR DESCRIPTION
…tile-file-exists-p.

This should fix #1673.
It actually replaces references to `project-file-exists-p!` which doesn't seem to exist, with projectile-file-exists-p.