### PR TITLE
:lang/rust: Add rustic-lsp

### DIFF
--- a/modules/lang/rust/config.el
+++ b/modules/lang/rust/config.el
@@ -60,6 +60,11 @@
       (apply orig-fn args))))
 
 
+(use-package! rustic-lsp
+  :when EMACS26+
+  :after rustic)
+
+
 ;;
 ;;; Tools
 


### PR DESCRIPTION
Adding rustic-lsp allows users to select rust-analyzer as their language server.