### PR TITLE
lang/emacs-lisp: extract reduced flyckeck checker

### DIFF
--- a/modules/lang/emacs-lisp/autoload.el
+++ b/modules/lang/emacs-lisp/autoload.el
@@ -160,17 +160,4 @@ verbosity when editing a file in `doom-private-dir' or `doom-emacs-dir'."
     (add-to-list (make-local-variable 'flycheck-disabled-checkers)
                  'emacs-lisp-checkdoc)
     (set (make-local-variable 'flycheck-emacs-lisp-check-form)
-         (concat "(progn "
-                 (prin1-to-string
-                  `(progn
-                     (setq doom-modules ',doom-modules
-                           doom-disabled-packages ',doom-disabled-packages)
-                     (ignore-errors (load ,user-init-file t t))
-                     (setq byte-compile-warnings
-                           '(obsolete cl-functions
-                             interactive-only make-local mapcar
-                             suspicious constants))
-                     (defmacro map! (&rest _))))
-                 " "
-                 (default-value 'flycheck-emacs-lisp-check-form)
-                 ")"))))
+         +emacs-lisp-reduced-flycheck-emacs-lisp-check-form)))

--- a/modules/lang/emacs-lisp/config.el
+++ b/modules/lang/emacs-lisp/config.el
@@ -61,6 +61,21 @@ This marks a foldable marker for `outline-minor-mode' in elisp buffers.")
   ;; Flycheck's two emacs-lisp checkers produce a *lot* of false positives in
   ;; emacs configs, so we disable `emacs-lisp-checkdoc' and reduce the
   ;; `emacs-lisp' checker's verbosity.
+  (setq +emacs-lisp-reduced-flycheck-emacs-lisp-check-form
+      (concat "(progn "
+                 (prin1-to-string
+                  `(progn
+                     (setq doom-modules ',doom-modules
+                           doom-disabled-packages ',doom-disabled-packages)
+                     (ignore-errors (load ,user-init-file t t))
+                     (setq byte-compile-warnings
+                           '(obsolete cl-functions
+                             interactive-only make-local mapcar
+                             suspicious constants))
+                     (defmacro map! (&rest _))))
+                 " "
+                 (default-value 'flycheck-emacs-lisp-check-form)
+                 ")"))
   (add-hook 'flycheck-mode-hook #'+emacs-lisp-reduce-flycheck-errors-in-emacs-config-h)
 
   ;; Special syntax highlighting for elisp...


### PR DESCRIPTION
As explained at https://github.com/hlissner/doom-emacs/issues/1550#issuecomment-510206974, it can be useful to have access to the reduced emacs-lisp checker. This PR does that.

It allows to have the same syntax checker as `~/.emacs.d` and `~/.doom.d` anywhere you want by adding the following to `.dir-locals.el`:
``` elisp
((emacs-lisp-mode . ((flycheck-disabled-checkers . 'emacs-lisp-checkdoc)
                     (eval . (set (make-local-variable 'flycheck-emacs-lisp-check-form)
                                  +emacs-lisp-reduced-flycheck-emacs-lisp-check-form)))))
```