### PR TITLE
Fixing up csharp mode's keybinds (mostly unit-test ones)

### DIFF
--- a/modules/lang/csharp/config.el
+++ b/modules/lang/csharp/config.el
@@ -36,7 +36,6 @@
         :map omnisharp-mode-map
         "b" #'omnisharp-recompile
         (:prefix "r"
-          "i"  #'omnisharp-fix-code-issue-at-point
           "u"  #'omnisharp-fix-usings
           "r"  #'omnisharp-rename
           "a"  #'omnisharp-show-last-auto-complete-result

--- a/modules/lang/csharp/config.el
+++ b/modules/lang/csharp/config.el
@@ -52,6 +52,9 @@
           "ti" #'omnisharp-current-type-information
           "td" #'omnisharp-current-type-documentation)
         (:prefix "t"
+          "s" #'omnisharp-unit-test-at-point
+          "l" #'omnisharp-unit-test-last
+          "b" #'omnisharp-unit-test-buffer)))
 
 
 (when (featurep! +unity)

--- a/modules/lang/csharp/config.el
+++ b/modules/lang/csharp/config.el
@@ -52,9 +52,6 @@
           "ti" #'omnisharp-current-type-information
           "td" #'omnisharp-current-type-documentation)
         (:prefix "t"
-          "r" (λ! (omnisharp-unit-test "fixture"))
-          "s" (λ! (omnisharp-unit-test "single"))
-          "a" (λ! (omnisharp-unit-test "all")))))
 
 
 (when (featurep! +unity)


### PR DESCRIPTION
*TL;DR* Found that the unit test keybinds are using broken keybinds that don't work
anymore. Decided to fix them, along with any keybinds that seem to not work.

I personally found this to actually hinder my workflow, and added my
own keybinds to use the updated functions. However, the dead keybinds that don't
work anymore would always come up on which-key, almost trying to ridicule me for
my laziness in not fixing this issue myself. So here I am to fix it!

Not much of a big change so I doubt any real review is needed. Each commit has
decent information (well I suppose anyway).