### PR TITLE
Fix defadvice bug of Chinese and Japanese org-html-paragraph

### DIFF
--- a/modules/input/chinese/config.el
+++ b/modules/input/chinese/config.el
@@ -35,13 +35,13 @@
   "Join consecutive Chinese lines into a single long line without unwanted space
 when exporting org-mode to html."
   :filter-args #'org-html-paragraph
-  (cl-destructuring-bind (paragraph content info) args
+  (cl-destructuring-bind (paragraph contents info) args
     (let* ((fix-regexp "[[:multibyte:]]")
            (origin-contents
             (replace-regexp-in-string
              "<[Bb][Rr] */>"
              ""
-             content))
+             contents))
            (fixed-contents
             (replace-regexp-in-string
              (concat "\\(" fix-regexp "\\) *\n *\\(" fix-regexp "\\)")

--- a/modules/input/chinese/config.el
+++ b/modules/input/chinese/config.el
@@ -35,16 +35,16 @@
   "Join consecutive Chinese lines into a single long line without unwanted space
 when exporting org-mode to html."
   :filter-args #'org-html-paragraph
-  (cl-destructuring-bind (paragraph contents info) args
-    (let* ((fix-regexp "[[:multibyte:]a-zA-Z0-9]")
-           (origin-contents contents)
+  (cl-destructuring-bind (paragraph content info) args
+    (let* ((fix-regexp "[[:multibyte:]]")
+           (origin-contents
+            (replace-regexp-in-string
+             "<[Bb][Rr] */>"
+             ""
+             content))
            (fixed-contents
             (replace-regexp-in-string
-             (concat "\\("
-                     fix-regexp
-                     "\\) *\\(<[Bb][Rr] */>\\)?\n *\\("
-                     fix-regexp
-                     "\\)")
-             "\\1\\3"
+             (concat "\\(" fix-regexp "\\) *\n *\\(" fix-regexp "\\)")
+             "\\1\\2"
              origin-contents)))
       (list paragraph fixed-contents info))))

--- a/modules/input/japanese/config.el
+++ b/modules/input/japanese/config.el
@@ -45,13 +45,13 @@
   "Join consecutive Japanese lines into a single long line without unwanted space
 when exporting org-mode to html."
     :filter-args #'org-html-paragraph
-  (cl-destructuring-bind (paragraph content info) args
+  (cl-destructuring-bind (paragraph contents info) args
     (let* ((fix-regexp "[[:multibyte:]]")
            (origin-contents
             (replace-regexp-in-string
              "<[Bb][Rr] */>"
              ""
-             content))
+             contents))
            (fixed-contents
             (replace-regexp-in-string
              (concat "\\(" fix-regexp "\\) *\n *\\(" fix-regexp "\\)")

--- a/modules/input/japanese/config.el
+++ b/modules/input/japanese/config.el
@@ -44,7 +44,7 @@
 (defadvice! +japanese--org-html-paragraph-a (args)
   "Join consecutive Japanese lines into a single long line without unwanted space
 when exporting org-mode to html."
-    :filter-args #'org-html-paragraph
+  :filter-args #'org-html-paragraph
   (cl-destructuring-bind (paragraph contents info) args
     (let* ((fix-regexp "[[:multibyte:]]")
            (origin-contents

--- a/modules/input/japanese/config.el
+++ b/modules/input/japanese/config.el
@@ -44,17 +44,17 @@
 (defadvice! +japanese--org-html-paragraph-a (args)
   "Join consecutive Japanese lines into a single long line without unwanted space
 when exporting org-mode to html."
-  :filter-args #'org-html-paragraph
-  (cl-destructuring-bind (paragraph contents info) args
-    (let* ((fix-regexp "[[:multibyte:]a-zA-Z0-9]")
-           (origin-contents contents)
+    :filter-args #'org-html-paragraph
+  (cl-destructuring-bind (paragraph content info) args
+    (let* ((fix-regexp "[[:multibyte:]]")
+           (origin-contents
+            (replace-regexp-in-string
+             "<[Bb][Rr] */>"
+             ""
+             content))
            (fixed-contents
             (replace-regexp-in-string
-             (concat "\\("
-                     fix-regexp
-                     "\\) *\\(<[Bb][Rr] */>\\)?\n *\\("
-                     fix-regexp
-                     "\\)")
-             "\\1\\3"
+             (concat "\\(" fix-regexp "\\) *\n *\\(" fix-regexp "\\)")
+             "\\1\\2"
              origin-contents)))
       (list paragraph fixed-contents info))))


### PR DESCRIPTION
Previously submitted a fix in issues, which is the processing of \<br /\>\n in Chinese and English mixed text. Later, I found that this would be invalid for the case of \<br /\>\n between pure English, so I made the following changes: first delete only \<br /\>, then \n between multi-byte text Delete, so you can adapt to all situations.