### PR TITLE
Load hydra examples without using example hydras.

### DIFF
--- a/modules/ui/hydra/config.el
+++ b/modules/ui/hydra/config.el
@@ -1,4 +1,10 @@
 ;;; ui/hydra/config.el -*- lexical-binding: t; -*-
 
+(use-package! hydra-examples
+  :commands (hydra-move-splitter-up
+             hydra-move-splitter-down
+             hydra-move-splitter-right
+             hydra-move-splitter-left))
+
 ;;;###package hydra
 (setq lv-use-seperator t)


### PR DESCRIPTION
`+hydra/window-nav` uses functions from `hydra-examples.el` but the file
is never loaded. Adding this does not actually define any hydras (this
would require `hydra-examples-verbatim` to be `t`), it just load the
utility functions to make the hydras defined in doom work.