### PR TITLE
ox-hugo for (:lang org)

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -127,6 +127,7 @@
        ;;ocaml             ; an objective camel
        (org              ; organize your plain life in plain text
         +dragndrop       ; drag & drop files/images into org buffers
+        ;+hugo           ; use Emacs for hugo blogging
         +ipython         ; ipython/jupyter support for babel
         +pandoc          ; export-with-pandoc support
         +present)        ; using org-mode for presentations

--- a/modules/lang/org/README.org
+++ b/modules/lang/org/README.org
@@ -61,6 +61,8 @@ https://www.mfoot.com/blog/2015/11/22/literate-emacs-configuration-with-org-mode
 + =+pandoc= Enables pandoc integration into the Org exporter.
 + =+present= Enables integration with reveal.js, beamer and org-tree-slide, so
   Emacs can be used for presentations.
++ =+hugo= Enables integration with [[https://gohugo.io][hugo]] to export from
+  Emacs well formed (blackfriday) markdown.
 
 ** Plugins
 + [[https://orgmode.org/][org-plus-contrib]]
@@ -99,6 +101,8 @@ https://www.mfoot.com/blog/2015/11/22/literate-emacs-configuration-with-org-mode
   + [[https://github.com/anler/centered-window-mode][centered-window]]
   + [[https://github.com/takaxp/org-tree-slide][org-tree-slide]]
   + [[https://github.com/yjwen/org-reveal][ox-reveal]]
++ =+hugo=
+  + [[https://github.com/kaushalmodi/ox-hugo][ox-hugo]]
 
 ** Hacks
 + The window is recentered when following links.

--- a/modules/lang/org/README.org
+++ b/modules/lang/org/README.org
@@ -62,7 +62,7 @@ https://www.mfoot.com/blog/2015/11/22/literate-emacs-configuration-with-org-mode
 + =+present= Enables integration with reveal.js, beamer and org-tree-slide, so
   Emacs can be used for presentations.
 + =+hugo= Enables integration with [[https://gohugo.io][hugo]] to export from
-  Emacs well formed (blackfriday) markdown.
+  Emacs well-formed ([[https://github.com/russross/blackfriday][blackfriday]]) markdown.
 
 ** Plugins
 + [[https://orgmode.org/][org-plus-contrib]]

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -868,6 +868,7 @@ compelling reason, so..."
 
   ;;; Custom org modules
   (if (featurep! +dragndrop) (load! "contrib/dragndrop"))
+  (if (featurep! +hugo)      (load! "contrib/+hugo"))
   (if (featurep! +ipython)   (load! "contrib/ipython"))
   (if (featurep! +present)   (load! "contrib/present"))
 

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -394,10 +394,6 @@ file isn't in `org-directory'."
             (mathjax . t)
             (variable . "revealjs-url=https://cdn.jsdelivr.net/npm/reveal.js@3/"))))
 
-  (when (featurep! +hugo)
-    (use-package! ox-hugo
-      :after ox)))
-
 
 
 (defun +org-init-habit-h ()
@@ -566,10 +562,7 @@ between the two."
           (:prefix ("b" . "from beamer")
             :desc "to latex"            "l" #'org-beamer-export-to-latex
             :desc "to latex & open"     "L" #'org-beamer-export-as-latex
-            :desc "as pdf"              "p" #'org-beamer-export-to-pdf)
-          (:when (featurep! +hugo)
-            :desc "to hugo"        "h" #'org-hugo-export-to-md
-            :desc "to hugo & open" "H" #'org-hugo-export-as-md))
+            :desc "as pdf"              "p" #'org-beamer-export-to-pdf))
         (:prefix ("g" . "goto")
           "g" #'org-goto
           (:when (featurep! :completion ivy)

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -392,8 +392,7 @@ file isn't in `org-directory'."
     (setq org-pandoc-options
           '((standalone . t)
             (mathjax . t)
-            (variable . "revealjs-url=https://cdn.jsdelivr.net/npm/reveal.js@3/"))))
-
+            (variable . "revealjs-url=https://cdn.jsdelivr.net/npm/reveal.js@3/")))))
 
 
 (defun +org-init-habit-h ()

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -392,7 +392,12 @@ file isn't in `org-directory'."
     (setq org-pandoc-options
           '((standalone . t)
             (mathjax . t)
-            (variable . "revealjs-url=https://cdn.jsdelivr.net/npm/reveal.js@3/")))))
+            (variable . "revealjs-url=https://cdn.jsdelivr.net/npm/reveal.js@3/"))))
+
+  (when (featurep! +hugo)
+    (use-package! ox-hugo
+      :after ox)))
+
 
 
 (defun +org-init-habit-h ()
@@ -561,7 +566,10 @@ between the two."
           (:prefix ("b" . "from beamer")
             :desc "to latex"            "l" #'org-beamer-export-to-latex
             :desc "to latex & open"     "L" #'org-beamer-export-as-latex
-            :desc "as pdf"              "p" #'org-beamer-export-to-pdf))
+            :desc "as pdf"              "p" #'org-beamer-export-to-pdf)
+          (:when (featurep! +hugo)
+            :desc "to hugo"        "h" #'org-hugo-export-to-md
+            :desc "to hugo & open" "H" #'org-hugo-export-as-md))
         (:prefix ("g" . "goto")
           "g" #'org-goto
           (:when (featurep! :completion ivy)

--- a/modules/lang/org/contrib/+hugo.el
+++ b/modules/lang/org/contrib/+hugo.el
@@ -10,15 +10,9 @@
         (:prefix ("H" . "hugo")
           :desc "Subtree or File to Md to file"        "H" #'org-hugo-export-wim-to-md
           :desc "File to Md file"                      "h" #'org-hugo-export-to-md
-          :desc "Subtree or File to Md to file & open" "O" '(lambda ()
-                                                              (interactive)
-                                                              (org-open-file (org-hugo-export-wim-to-md)))
-          :desc "File to Md file & open"               "o" '(lambda ()
-                                                              (interactive)
-                                                              (org-open-file (org-hugo-export-to-md)))
-          :desc "All subtrees (or File) to Md file(s)" "A" '(lambda ()
-                                                              (interactive)
-                                                              (org-hugo-export-wim-to-md :all-subtrees))
+          :desc "Subtree or File to Md to file & open" "O" '(λ! (org-open-file (org-hugo-export-wim-to-md)))
+          :desc "File to Md file & open"               "o" '(λ! (org-open-file (org-hugo-export-to-md)))
+          :desc "All subtrees (or File) to Md file(s)" "A" '(λ! (org-hugo-export-wim-to-md :all-subtrees))
           :desc "File to a temporary Md buffer"        "t" #'org-hugo-export-as-md)))
 
 ;;; +hugo.el ends here

--- a/modules/lang/org/contrib/+hugo.el
+++ b/modules/lang/org/contrib/+hugo.el
@@ -1,12 +1,30 @@
 ;;; +hugo.el --- ox-hugo support -*- lexical-binding: t; -*-
 ;;;###if (featurep! +hugo)
 
+(defun org-hugo-doom-subtree-to-file-and-open ()
+  (interactive)
+  (org-open-file (org-hugo-export-wim-to-md)))
+
+(defun org-hugo-doom-to-file-and-open ()
+  (interactive)
+  (org-open-file (org-hugo-export-to-md)))
+
+(defun org-hugo-doom-all-subtrees-to-files ()
+  (interactive)
+  (org-hugo-export-wim-to-md :all-subtrees))
+
 (use-package! ox-hugo
-  :after ox
-  (map! :map org-mode-map
-        :localleader
-        (:prefix ("e" . "export")
-          :desc "to hugo"        "h" #'org-hugo-export-to-md
-          :desc "to hugo & open" "H" #'org-hugo-export-as-md)))
+  :after ox)
+
+(map! :map org-mode-map
+      :localleader
+      (:prefix "e"
+        (:prefix ("H" . "hugo")
+          :desc "Subtree to file"         "H" #'org-hugo-export-wim-to-md
+          :desc "To file"                 "h" #'org-hugo-export-wim-to-md
+          :desc "Subtree to file & open"  "O" #'org-hugo-doom-subtree-to-file-and-open
+          :desc "To file & open"          "o" #'org-hugo-doom-to-file-and-open
+          :desc "All subtrees to files"   "a" #'org-hugo-doom-all-subtrees-to-files
+          :desc "To temporary buffer"     "t" #'org-hugo-export-as-md)))
 
 ;;; +hugo.el ends here

--- a/modules/lang/org/contrib/+hugo.el
+++ b/modules/lang/org/contrib/+hugo.el
@@ -3,7 +3,7 @@
 
 (use-package! ox-hugo
   :after ox
-  :init
+  :preface
   (map! :map org-mode-map
         :localleader
         (:prefix "e"

--- a/modules/lang/org/contrib/+hugo.el
+++ b/modules/lang/org/contrib/+hugo.el
@@ -10,9 +10,9 @@
           (:prefix ("H" . "hugo")
             :desc "Subtree or File to Md to file"        "H" #'org-hugo-export-wim-to-md
             :desc "File to Md file"                      "h" #'org-hugo-export-to-md
-            :desc "Subtree or File to Md to file & open" "O" '(λ! (org-open-file (org-hugo-export-wim-to-md)))
-            :desc "File to Md file & open"               "o" '(λ! (org-open-file (org-hugo-export-to-md)))
-            :desc "All subtrees (or File) to Md file(s)" "A" '(λ! (org-hugo-export-wim-to-md :all-subtrees))
+            :desc "Subtree or File to Md to file & open" "O" (λ! (org-open-file (org-hugo-export-wim-to-md)))
+            :desc "File to Md file & open"               "o" (λ! (org-open-file (org-hugo-export-to-md)))
+            :desc "All subtrees (or File) to Md file(s)" "A" (λ! (org-hugo-export-wim-to-md :all-subtrees))
             :desc "File to a temporary Md buffer"        "t" #'org-hugo-export-as-md))))
 
 ;;; +hugo.el ends here

--- a/modules/lang/org/contrib/+hugo.el
+++ b/modules/lang/org/contrib/+hugo.el
@@ -1,18 +1,6 @@
 ;;; +hugo.el --- ox-hugo support -*- lexical-binding: t; -*-
 ;;;###if (featurep! +hugo)
 
-(defun org-hugo-doom-subtree-to-file-and-open ()
-  (interactive)
-  (org-open-file (org-hugo-export-wim-to-md)))
-
-(defun org-hugo-doom-to-file-and-open ()
-  (interactive)
-  (org-open-file (org-hugo-export-to-md)))
-
-(defun org-hugo-doom-all-subtrees-to-files ()
-  (interactive)
-  (org-hugo-export-wim-to-md :all-subtrees))
-
 (use-package! ox-hugo
   :after ox)
 
@@ -20,11 +8,17 @@
       :localleader
       (:prefix "e"
         (:prefix ("H" . "hugo")
-          :desc "Subtree to file"         "H" #'org-hugo-export-wim-to-md
-          :desc "To file"                 "h" #'org-hugo-export-wim-to-md
-          :desc "Subtree to file & open"  "O" #'org-hugo-doom-subtree-to-file-and-open
-          :desc "To file & open"          "o" #'org-hugo-doom-to-file-and-open
-          :desc "All subtrees to files"   "a" #'org-hugo-doom-all-subtrees-to-files
-          :desc "To temporary buffer"     "t" #'org-hugo-export-as-md)))
+          :desc "Subtree or File to Md to file"        "H" #'org-hugo-export-wim-to-md
+          :desc "File to Md file"                      "h" #'org-hugo-export-to-md
+          :desc "Subtree or File to Md to file & open" "O" '(lambda ()
+                                                              (interactive)
+                                                              (org-open-file (org-hugo-export-wim-to-md)))
+          :desc "File to Md file & open"               "o" '(lambda ()
+                                                              (interactive)
+                                                              (org-open-file (org-hugo-export-to-md)))
+          :desc "All subtrees (or File) to Md file(s)" "A" '(lambda ()
+                                                              (interactive)
+                                                              (org-hugo-export-wim-to-md :all-subtrees))
+          :desc "File to a temporary Md buffer"        "t" #'org-hugo-export-as-md)))
 
 ;;; +hugo.el ends here

--- a/modules/lang/org/contrib/+hugo.el
+++ b/modules/lang/org/contrib/+hugo.el
@@ -2,17 +2,17 @@
 ;;;###if (featurep! +hugo)
 
 (use-package! ox-hugo
-  :after ox)
-
-(map! :map org-mode-map
-      :localleader
-      (:prefix "e"
-        (:prefix ("H" . "hugo")
-          :desc "Subtree or File to Md to file"        "H" #'org-hugo-export-wim-to-md
-          :desc "File to Md file"                      "h" #'org-hugo-export-to-md
-          :desc "Subtree or File to Md to file & open" "O" '(λ! (org-open-file (org-hugo-export-wim-to-md)))
-          :desc "File to Md file & open"               "o" '(λ! (org-open-file (org-hugo-export-to-md)))
-          :desc "All subtrees (or File) to Md file(s)" "A" '(λ! (org-hugo-export-wim-to-md :all-subtrees))
-          :desc "File to a temporary Md buffer"        "t" #'org-hugo-export-as-md)))
+  :after ox
+  :init
+  (map! :map org-mode-map
+        :localleader
+        (:prefix "e"
+          (:prefix ("H" . "hugo")
+            :desc "Subtree or File to Md to file"        "H" #'org-hugo-export-wim-to-md
+            :desc "File to Md file"                      "h" #'org-hugo-export-to-md
+            :desc "Subtree or File to Md to file & open" "O" '(λ! (org-open-file (org-hugo-export-wim-to-md)))
+            :desc "File to Md file & open"               "o" '(λ! (org-open-file (org-hugo-export-to-md)))
+            :desc "All subtrees (or File) to Md file(s)" "A" '(λ! (org-hugo-export-wim-to-md :all-subtrees))
+            :desc "File to a temporary Md buffer"        "t" #'org-hugo-export-as-md))))
 
 ;;; +hugo.el ends here

--- a/modules/lang/org/contrib/+hugo.el
+++ b/modules/lang/org/contrib/+hugo.el
@@ -1,0 +1,12 @@
+;;; +hugo.el --- ox-hugo support -*- lexical-binding: t; -*-
+;;;###if (featurep! +hugo)
+
+(use-package! ox-hugo
+  :after ox
+  (map! :map org-mode-map
+        :localleader
+        (:prefix ("e" . "export")
+          :desc "to hugo"        "h" #'org-hugo-export-to-md
+          :desc "to hugo & open" "H" #'org-hugo-export-as-md)))
+
+;;; +hugo.el ends here

--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -52,3 +52,6 @@
 
 (when (featurep! +journal)
   (package! org-journal))
+
+(when (featurep! +hugo)
+  (package! ox-hugo))

--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -53,6 +53,8 @@
 (when (featurep! +journal)
   (package! org-journal))
 
-(package! ox-hugo
-  :when (featurep! +hugo)
-  :after ox)
+(when (featurep! +hugo)
+  (package! ox-hugo :recipe (:host github
+                             :repo "kaushalmodi/ox-hugo"
+                             :nonrecursive t
+                             :files (:defaults "*.el"))))

--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -56,5 +56,4 @@
 (when (featurep! +hugo)
   (package! ox-hugo :recipe (:host github
                              :repo "kaushalmodi/ox-hugo"
-                             :nonrecursive t
-                             :files (:defaults "*.el"))))
+                             :nonrecursive t)))

--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -53,5 +53,6 @@
 (when (featurep! +journal)
   (package! org-journal))
 
-(when (featurep! +hugo)
-  (package! ox-hugo))
+(package! ox-hugo
+  :when (featurep! +hugo)
+  :after ox)


### PR DESCRIPTION
add support for [ox-hugo](https://github.com/kaushalmodi/ox-hugo) to the org module. The change is straightforward as most of the module configuration is done in the org-files themselves.