### PR TITLE
lang/org: smarter smartparens in org src blocks

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -774,13 +774,17 @@ compelling reason, so..."
              (skip-chars-backward "*")
              (bolp))))
 
+    (defun +org-sp-in-src-block-p (_id action _context)
+      (and (eq action 'insert)
+           (org-in-src-block-p)))
+
     ;; make delimiter auto-closing a little more conservative
     (sp-with-modes 'org-mode
-      (sp-local-pair "*" "*" :unless '(:add sp-point-before-word-p sp-in-math-p +org-sp-point-at-bol-p))
-      (sp-local-pair "_" "_" :unless '(:add sp-point-before-word-p sp-in-math-p))
-      (sp-local-pair "/" "/" :unless '(:add sp-point-before-word-p sp-in-math-p +org-sp-point-in-checkbox-p))
-      (sp-local-pair "~" "~" :unless '(:add sp-point-before-word-p))
-      (sp-local-pair "=" "=" :unless '(:add sp-point-before-word-p sp-in-math-p)))))
+      (sp-local-pair "*" "*" :unless '(:add sp-point-before-word-p sp-in-math-p +org-sp-point-at-bol-p +org-sp-in-src-block-p))
+      (sp-local-pair "_" "_" :unless '(:add sp-point-before-word-p sp-in-math-p +org-sp-in-src-block-p))
+      (sp-local-pair "/" "/" :unless '(:add sp-point-before-word-p sp-in-math-p +org-sp-point-in-checkbox-p +org-sp-in-src-block-p))
+      (sp-local-pair "~" "~" :unless '(:add sp-point-before-word-p +org-sp-in-src-block-p))
+      (sp-local-pair "=" "=" :unless '(:add sp-point-before-word-p sp-in-math-p +org-sp-in-src-block-p)))))
 
 
 ;;


### PR DESCRIPTION
While point is in a babel src block, do not autoexpand emphasis markers.

Without this change, editing code in babel src blocks is cumbersome: every time you type `*` or `=` (among other characters), a pair is inserted that then needs to be manually deleted. This change checks if point is in a source block to decide if emphasis markers are duplicated.
