### PR TITLE
cli/upgrade: add timeout flag

### DIFF
--- a/core/cli/upgrade.el
+++ b/core/cli/upgrade.el
@@ -13,7 +13,12 @@ following shell commands:
     bin/doom update"
   (and (doom-upgrade (or (member "-f" args)
                          (member "--force" args)))
-       (doom-packages-update doom-auto-accept)
+       (doom-packages-update
+        doom-auto-accept
+        (when-let (timeout (cadr (or (member "--timeout" args)
+                                     (member "-t" args))))
+          (string-to-number timeout)))
+
        (doom-reload-package-autoloads 'force-p)))
 
 


### PR DESCRIPTION
Since there is a lot of logic in `bin/doom upgrade` than just running
two commands, I thought we should also add a timeout flag just like
`update` has.

I was having lots of timeout issues so I found this flag helpful.