### PR TITLE
Add helm-org (bound but not installed).

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -904,3 +904,13 @@ compelling reason, so..."
       (org-clock-load))
     :config
     (add-hook 'kill-emacs-hook #'org-clock-save)))
+
+  (use-package! helm-org
+    :if (featurep! :completion helm)
+    :defer t
+    :init
+    (progn
+      (add-to-list 'helm-completing-read-handlers-alist
+                   '(org-capture . helm-org-completing-read-tags))
+      (add-to-list 'helm-completing-read-handlers-alist
+                   '(org-set-tags . helm-org-completing-read-tags))))

--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -36,6 +36,8 @@
   (package! ob-rust))
 
 ;;; Modules
+(when (featurep! :completion helm)
+  (package! helm-org))
 (when (featurep! +dragndrop)
   (package! org-download))
 (when (featurep! +gnuplot)


### PR DESCRIPTION
As the title states, commands from this package are bound, but the package is not installed. Let me know if I should fix anything. 