### PR TITLE
Call renamed hook in the +cc/reload-compile-db autoload

### DIFF
--- a/modules/lang/cc/autoload.el
+++ b/modules/lang/cc/autoload.el
@@ -103,7 +103,7 @@ simpler."
       (rtags-call-rc :silent t "-J" (or (doom-project-root) default-directory))))
   ;; then irony
   (when (and (featurep 'irony) irony-mode)
-    (+cc|irony-init-compile-options)))
+    (+cc-init-irony-compile-options-h)))
 
 ;;;###autoload
 (defun +cc/imenu ()


### PR DESCRIPTION
It seems that during the renaming hooks to a new convention one call in the cc lang feature autoloads remained unchanged which causes `Symbol's function is void: +cc|irony-init-compile-options`. This PR fixes that.