### PR TITLE
Add go-add-tags for go-mode

### DIFF
--- a/modules/lang/go/README.org
+++ b/modules/lang/go/README.org
@@ -35,6 +35,7 @@ This module provides no flags.
 + [[https://github.com/syohex/emacs-go-eldoc][go-eldoc]]
 + [[https://github.com/dominikh/go-mode.el][go-guru]]
 + [[https://github.com/manute/gorepl-mode][gorepl-mode]]
++ [[https://github.com/syohex/emacs-go-add-tags][go-add-tags]]
 + [[https://github.com/mdempsky/gocode][company-go]]*
 
 * Prerequisites

--- a/modules/lang/go/config.el
+++ b/modules/lang/go/config.el
@@ -25,6 +25,7 @@
 
   (map! :map go-mode-map
         :localleader
+        "a" #'go-add-tags
         "e" #'+go/play-buffer-or-region
         "i" #'go-goto-imports      ; Go to imports
         (:prefix ("h" . "help")

--- a/modules/lang/go/packages.el
+++ b/modules/lang/go/packages.el
@@ -5,6 +5,7 @@
 (package! go-guru)
 (package! go-mode)
 (package! gorepl-mode)
+(package! go-add-tags)
 
 (when (featurep! :completion company)
   (package! company-go))


### PR DESCRIPTION
Hello. This pull request add the package [go-add-tags](https://github.com/syohex/emacs-go-add-tags) to :lang go module.
Here is a screencast of what it does (taken from repository):
https://github.com/syohex/emacs-go-add-tags/blob/master/image/go-add-tags.gif
