### PR TITLE
Fix a regexp bug of (defadvice! +plantuml--fix-atstart-in-org-src-blocks-a ...)

### DIFF
--- a/modules/lang/plantuml/config.el
+++ b/modules/lang/plantuml/config.el
@@ -30,7 +30,7 @@
       (let* ((origin-body body)
              (fix-body
               (replace-regexp-in-string
-               "^[[:blank:]]*\\(@start\\)"
+               "^[[:blank:]\n]*\\(@start\\)"
                "\\\\\\1"
                origin-body)))
         (list fix-body params))))

--- a/modules/lang/plantuml/config.el
+++ b/modules/lang/plantuml/config.el
@@ -30,7 +30,7 @@
       (let* ((origin-body body)
              (fix-body
               (replace-regexp-in-string
-               "^\\w*\\(@start\\)"
+               "^[[:blank:]]*\\(@start\\)"
                "\\\\\\1"
                origin-body)))
         (list fix-body params))))


### PR DESCRIPTION
Sorry for my negligence, the whitespace at the beginning of the regular expression should be [[:blank:]], and I mistakenly wrote \\w .