### PR TITLE
Fix the multi-face form of custom-set-faces!

### DIFF
--- a/core/autoload/themes.el
+++ b/core/autoload/themes.el
@@ -4,7 +4,7 @@
   (cond ((listp (car spec))
          (cl-loop for face in (car spec)
                   collect
-                  (doom--custom-theme-set-face `(,face ,(cdr spec)))))
+                  (car (doom--custom-theme-set-face (cons face (cdr spec))))))
         ((keywordp (cadr spec))
          `((,(car spec) ((t ,(cdr spec))))))
         (`((,(car spec) ,(cdr spec))))))


### PR DESCRIPTION
We need to unwrap the outer list returned by the inner calls `doom--custom-theme-set-face`.

Also need to flatten the face with the rest of the spec list so that:
```
((foo bar baz) :weight bold)
```

Is equivalent to:
```
(foo :weight bold)
(bar :weight bold)
(baz :weight bold)
```

Instead of:
```
(foo (:weight bold))
(bar (:weight bold))
(baz (:weight bold))
```