### PR TITLE
Fixes wrong variable name: lv-use-seperator to lv-use-separator

### DIFF
--- a/modules/ui/hydra/config.el
+++ b/modules/ui/hydra/config.el
@@ -1,4 +1,4 @@
 ;;; ui/hydra/config.el -*- lexical-binding: t; -*-
 
 ;;;###package hydra
-(setq lv-use-seperator t)
+(setq lv-use-separator t)


### PR DESCRIPTION
The variable `lv-use-seperator` is not defined anywhere, but I found the variable `lv-use-separator` in the `lv.el` file, which is only one letter apart, so I guess the variable name is wrong.