### PR TITLE
[emacs lisp] Add bindings for debugging defuns

### DIFF
--- a/modules/lang/emacs-lisp/autoload.el
+++ b/modules/lang/emacs-lisp/autoload.el
@@ -174,3 +174,15 @@ verbosity when editing a file in `doom-private-dir' or `doom-emacs-dir'."
                  " "
                  (default-value 'flycheck-emacs-lisp-check-form)
                  ")"))))
+
+;;;###autoload
+(defun +emacs-lisp-edebug-instrument-defun-on ()
+  "Toggle on instrumentalisation for the function under `defun'."
+  (interactive)
+  (eval-defun 'edebugit))
+
+;;;###autoload
+(defun +emacs-lisp-edebug-instrument-defun-off ()
+  "Toggle off instrumentalisation for the function under `defun'."
+  (interactive)
+  (eval-defun nil))

--- a/modules/lang/emacs-lisp/autoload.el
+++ b/modules/lang/emacs-lisp/autoload.el
@@ -176,13 +176,13 @@ verbosity when editing a file in `doom-private-dir' or `doom-emacs-dir'."
                  ")"))))
 
 ;;;###autoload
-(defun +emacs-lisp-edebug-instrument-defun-on ()
+(defun +emacs-lisp/edebug-instrument-defun-on ()
   "Toggle on instrumentalisation for the function under `defun'."
   (interactive)
   (eval-defun 'edebugit))
 
 ;;;###autoload
-(defun +emacs-lisp-edebug-instrument-defun-off ()
+(defun +emacs-lisp/edebug-instrument-defun-off ()
   "Toggle off instrumentalisation for the function under `defun'."
   (interactive)
   (eval-defun nil))

--- a/modules/lang/emacs-lisp/config.el
+++ b/modules/lang/emacs-lisp/config.el
@@ -77,8 +77,10 @@ This marks a foldable marker for `outline-minor-mode' in elisp buffers.")
 
   (map! :localleader
         :map emacs-lisp-mode-map
-        "e" #'macrostep-expand))
-
+        "e" #'macrostep-expand
+        (:prefix ("d" . "debug")
+          ("f" #'+emacs-lisp-edebug-instrument-defun-on)
+          ("F" #'+emacs-lisp-edebug-instrument-defun-off))))
 
 ;;
 ;;; Packages

--- a/modules/lang/emacs-lisp/config.el
+++ b/modules/lang/emacs-lisp/config.el
@@ -79,8 +79,8 @@ This marks a foldable marker for `outline-minor-mode' in elisp buffers.")
         :map emacs-lisp-mode-map
         "e" #'macrostep-expand
         (:prefix ("d" . "debug")
-          ("f" #'+emacs-lisp-edebug-instrument-defun-on)
-          ("F" #'+emacs-lisp-edebug-instrument-defun-off))))
+          ("f" #'+emacs-lisp/edebug-instrument-defun-on)
+          ("F" #'+emacs-lisp/edebug-instrument-defun-off))))
 
 ;;
 ;;; Packages


### PR DESCRIPTION
`, d f` - turn on debugging for defun
`, d F` - turn off debugging for defun
