### PR TITLE
Fix package-installed-p hack for rustic

### DIFF
--- a/modules/lang/rust/config.el
+++ b/modules/lang/rust/config.el
@@ -55,17 +55,12 @@
   (add-hook 'rustic-mode-hook #'rainbow-delimiters-mode)
 
   (defadvice! +rust--dont-install-packages-p (orig-fn &rest args)
-    :override #'rustic-setup-rls
+    :around #'rustic-setup-rls
     (cl-letf (;; `rustic-setup-rls' uses `package-installed-p' unnecessarily, to
               ;; try to detect rls. This breaks because Doom lazy loads
               ;; package.el, and doesn't use package.el to begin with.
               ((symbol-function #'package-installed-p)
-               (symbol-function #'ignore))
-              ;; rustic really wants to manages its own dependencies. I wish it
-              ;; wouldn't. Doom already does; we don't need its help.
-              ((symbol-function #'rustic-install-rls-client-p)
-               (lambda (&rest _)
-                 (message "No RLS server running."))))
+               (symbol-function #'identity)))
       (apply orig-fn args))))
 
 

--- a/modules/lang/rust/config.el
+++ b/modules/lang/rust/config.el
@@ -56,11 +56,18 @@
 
   (defadvice! +rust--dont-install-packages-p (orig-fn &rest args)
     :around #'rustic-setup-rls
-    (cl-letf (;; `rustic-setup-rls' uses `package-installed-p' unnecessarily, to
-              ;; try to detect rls. This breaks because Doom lazy loads
-              ;; package.el, and doesn't use package.el to begin with.
+    (cl-letf (;; `rustic-setup-rls' uses `package-installed-p' to determine if
+              ;; lsp-mode/elgot are available. This breaks because Doom doesn't
+              ;; use package.el to begin with (and lazy loads it).
               ((symbol-function #'package-installed-p)
-               (symbol-function #'identity)))
+               (lambda (pkg)
+                 (require pkg nil t)))
+              ;; If lsp/elgot isn't available, it attempts to install lsp-mode
+              ;; via package.el. Doom manages its own dependencies so we disable
+              ;; that behavior.
+              ((symbol-function #'rustic-install-rls-client-p)
+               (lambda (&rest _)
+                 (message "No RLS server running."))))
       (apply orig-fn args))))
 
 


### PR DESCRIPTION
Fix override/around typo.

Stubbing package-installed-p to return true is sufficient, rustic happily activates the configured backend (lsp), which is then autoloaded properly.