### PR TITLE
Add .svelte to web-mode

### DIFF
--- a/modules/lang/web/+html.el
+++ b/modules/lang/web/+html.el
@@ -8,6 +8,7 @@
   :mode "\\.as[cp]x\\'"
   :mode "\\.hbs\\'"
   :mode "\\.mustache\\'"
+  :mode "\\.svelte\\'"
   :mode "\\.tsx\\'"
   :mode "\\.vue\\'"
   :mode "\\.twig\\'"


### PR DESCRIPTION
With the merge of https://github.com/fxbois/web-mode/pull/1074, web-mode now supports Svelte templates. This change activates web mode when opening a `.svelte` file.