### PR TITLE
Use mdfind for counsel-locate on a Mac

### DIFF
--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -226,6 +226,8 @@ evil-ex-specific constructs, so we disable it solely in evil-ex."
   :config
   (set-popup-rule! "^\\*ivy-occur" :size 0.35 :ttl 0 :quit nil)
 
+  (when IS-MAC
+    (setq counsel-locate-cmd #'counsel-locate-cmd-mdfind))
   (setq counsel-find-file-ignore-regexp "\\(?:^[#.]\\)\\|\\(?:[#~]$\\)\\|\\(?:^Icon?\\)"
         counsel-describe-function-function #'helpful-callable
         counsel-describe-variable-function #'helpful-variable


### PR DESCRIPTION
This is the more sensible option as locate isn't configured by default
and spotlight is turned on by default.