### PR TITLE
cli: fix wrong argument and add docs

### DIFF
--- a/core/cli/upgrade.el
+++ b/core/cli/upgrade.el
@@ -16,6 +16,8 @@ following shell commands:
                          (member "--force" args)))
        (doom-packages-update
         doom-auto-accept
+        (when-let (threads (cadr (member "--threads" args)))
+          (string-to-number threads))
         (when-let (timeout (cadr (or (member "--timeout" args)
                                      (member "-t" args))))
           (string-to-number timeout)))

--- a/core/cli/upgrade.el
+++ b/core/cli/upgrade.el
@@ -10,7 +10,11 @@ following shell commands:
     git pull --rebase
     bin/doom clean
     bin/doom refresh
-    bin/doom update"
+    bin/doom update
+
+Switches:
+  -t/--timeout TTL   Seconds until a thread is timed out (default: 45)
+  --threads N        How many threads to use (default: 8)"
   (and (doom-upgrade doom-auto-accept
                      (or (member "-f" args)
                          (member "--force" args)))


### PR DESCRIPTION
----

A small fix for `doom upgrade -t TIMEOUT` that was recently broken by the new
code for `doom refresh --thread THREADS`.