### PR TITLE
Set locate-command in tools macos

### DIFF
--- a/modules/tools/macos/autoload.el
+++ b/modules/tools/macos/autoload.el
@@ -1,6 +1,9 @@
 ;;; tools/macos/autoload.el -*- lexical-binding: t; -*-
 
 ;;;###autoload
+(setq locate-command "mdfind")
+
+;;;###autoload
 (defun +macos-open-with (&optional app-name path)
   "Send PATH to APP-NAME on OSX."
   (interactive)
@@ -17,8 +20,6 @@
                             (format "'%s'" path)))))
     (message "Running: %s" command)
     (shell-command command)))
-
-(setq locate-command "mdfind")
 
 ;;;###autoload
 (defmacro +macos--open-with (id &optional app dir)

--- a/modules/tools/macos/autoload.el
+++ b/modules/tools/macos/autoload.el
@@ -18,6 +18,8 @@
     (message "Running: %s" command)
     (shell-command command)))
 
+(setq locate-command "mdfind")
+
 ;;;###autoload
 (defmacro +macos--open-with (id &optional app dir)
   `(defun ,(intern (format "+macos/%s" id)) ()


### PR DESCRIPTION
It should be mdfind since spot light is on by default.

I think you could still improve things further by not making users that prefer `locate` on a mac to override two options, but this is better already.