### PR TITLE
Set python version from .python-version file

### DIFF
--- a/modules/lang/python/autoload/pyenv.el
+++ b/modules/lang/python/autoload/pyenv.el
@@ -1,0 +1,30 @@
+;;; lang/python/autoload/pyenv.el -*- lexical-binding: t; -*-
+;;;###if (featurep! +pyenv)
+
+;;;###autoload
+(defvar +pyenv--version nil)
+
+;;;###autoload
+(defun +python-pyenv-mode-set-auto-h ()
+  "Set pyenv-mode version from buffer-local variable."
+  (when (eq major-mode 'python-mode)
+    (when (not (local-variable-p '+pyenv--version))
+      (make-local-variable '+pyenv--version)
+      (setq +pyenv--version (+python-pyenv-read-version-from-file)))
+    (if +pyenv--version
+        (pyenv-mode-set +pyenv--version)
+      (pyenv-mode-unset))))
+
+;;;###autoload
+(defun +python-pyenv-read-version-from-file ()
+  "Read pyenv version from .python-version file."
+  (when-let (root-path (projectile-locate-dominating-file default-directory ".python-version"))
+    (let* ((file-path (expand-file-name ".python-version" root-path))
+           (version
+            (with-temp-buffer
+              (insert-file-contents-literally file-path)
+              (string-trim (buffer-string)))))
+      (if (member version (pyenv-mode-versions))
+          version  ;; return.
+        (message "pyenv: version `%s' is not installed (set by `%s')."
+                 version file-path)))))

--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -211,7 +211,9 @@ called.")
   :config
   (pyenv-mode +1)
   (when (executable-find "pyenv")
-    (add-to-list 'exec-path (expand-file-name "shims" (or (getenv "PYENV_ROOT") "~/.pyenv")))))
+    (add-to-list 'exec-path (expand-file-name "shims" (or (getenv "PYENV_ROOT") "~/.pyenv"))))
+  (add-hook 'python-mode-hook #'+python-pyenv-mode-set-auto-h)
+  (add-hook 'doom-switch-buffer-hook #'+python-pyenv-mode-set-auto-h))
 
 
 (use-package! conda


### PR DESCRIPTION
Hi,

This should solve #736 . The pupose is to set correct pyenv version as stated in leading `.python-version` file.

I'm not an elisp guru. I'm thinking of the following improvements:

- ~~set pyenv-version only on python-mode buffers~~
- ~~saving .python-version in some projectile per-project register ?~~

Any help appreciated.