### PR TITLE
lang/latex: +pdf-viewers ordering and hook type-o

### DIFF
--- a/modules/lang/latex/+viewers.el
+++ b/modules/lang/latex/+viewers.el
@@ -4,7 +4,7 @@
 (add-to-list 'TeX-view-program-selection '(output-pdf "preview-pane") 'append)
 (add-to-list 'TeX-view-program-list '("preview-pane" latex-preview-pane-mode))
 
-(dolist (viewer +latex-viewers)
+(dolist (viewer (reverse +latex-viewers))
   (pcase viewer
     (`skim
      (when (and IS-MAC
@@ -39,7 +39,7 @@
          ;; PDF Tools isn't in `TeX-view-program-list-builtin' on macs
          (add-to-list 'TeX-view-program-list '("PDF Tools" TeX-pdf-tools-sync-view)))
        ;; Update PDF buffers after successful LaTeX runs
-       (add-hook 'TeX-after-compilation-finished-function #'TeX-revert-document-buffer)))))
+       (add-hook 'TeX-after-compilation-finished-functions #'TeX-revert-document-buffer)))))
 
 
 (after! latex-preview-pane


### PR DESCRIPTION
Previously, the last viewer set in `+latex-viewers` would take
precedence. The list is now reversed before applying changes so that the
first set has precedence.

The wrong hook variable was used to revert view buffers after compilation.