### PR TITLE
Rust documentation change

### DIFF
--- a/modules/lang/rust/README.org
+++ b/modules/lang/rust/README.org
@@ -44,8 +44,8 @@ Some commands require additional crates to be installed to work, e.g. ~cargo
 add~.
 #+BEGIN_SRC sh
 rustup component add rustfmt
-rustup component add cargo-check
-rustup component add cargo-edit
+cargo install cargo-check
+cargo install cargo-edit
 #+END_SRC
 
 * Features


### PR DESCRIPTION
`rustup component` doesn't find the mentioned packages in the toolchain, whereas `cargo install` builds the binaries required and install them in your `PATH`.