### PR TITLE
doom/core: avoid the litter of session.* files

### DIFF
--- a/core/core.el
+++ b/core/core.el
@@ -196,6 +196,13 @@ users).")
       url-cache-directory          (concat doom-cache-dir "url/")
       url-configuration-directory  (concat doom-etc-dir "url/")
       gamegrid-user-score-file-directory (concat doom-etc-dir "games/"))
+;; HACK
+(with-eval-after-load 'x-win
+  (defun emacs-session-filename (session-id)
+    "Construct a filename to save a session based on SESSION-ID.
+Doom Emacs overrides this function to stop sessions from littering the user
+directory. The session files are placed by default in `doom-cache-dir'"
+    (concat doom-cache-dir "emacs-session." session-id)))
 
 
 ;;


### PR DESCRIPTION
When x-window commands emacs to quit, emacs saves a session in `.emacs.d/session.*` by default. There is no easy way to change the location of this session file. This PR overwrites the function responsible for creating the session file name `emacs-session-filename`. The new function sets the session file to reside in `doom-cache-dir`/sessions.