### PR TITLE
lang/plantuml: fix jar download path (again)

### DIFF
--- a/modules/lang/plantuml/autoload.el
+++ b/modules/lang/plantuml/autoload.el
@@ -6,5 +6,5 @@
   (interactive)
   (if (file-exists-p plantuml-jar-path)
       (user-error "plantuml.jar already installed")
-    (url-copy-file "https://datapacket.dl.sourceforge.net/project/plantuml/plantuml.jar"
+    (url-copy-file "https://downloads.sourceforge.net/project/plantuml/plantuml.jar"
                    plantuml-jar-path)))


### PR DESCRIPTION
Now this should redirect to the auto-selected mirror.

Related: #1637 #1639