### PR TITLE
Fix install command for clippy, uses rustup

### DIFF
--- a/modules/lang/rust/README.org
+++ b/modules/lang/rust/README.org
@@ -46,7 +46,7 @@ Some features have additional dependencies:
   add rustfmt-preview~
 + The following commands require:
   + ~cargo-process-check~: ~cargo install cargo-check~
-  + ~cargo-process-clippy~: ~cargo install clippy~
+  + ~cargo-process-clippy~: ~rustup component add clippy-preview~
   + ~cargo-process-{add,rm,upgrade}~: ~cargo install cargo-edit~
 
 * Features


### PR DESCRIPTION
Trying to install with cargo fails with the following error:

```
Caused by:
  failed to run custom build command for `clippy v0.0.302`

Caused by:
  process didn't exit successfully: `/var/folders/66/180ynjt55z74l338gh0stq0c0000gn/T/cargo-installkNqJBB/release/build/clippy-bcde765a4c9acf93/build-script-build` (exit code: 1)
--- stderr

error: Clippy is no longer available via crates.io

help: please run `rustup component add clippy-preview` instead
```

Just a tiny doc update
