### PR TITLE
tools/eval: change evil-append-line to evil-insert-state

### DIFF
--- a/modules/tools/eval/autoload/repl.el
+++ b/modules/tools/eval/autoload/repl.el
@@ -32,12 +32,7 @@
                    (+eval-repl-mode +1))
                  (puthash key buffer +eval-repl-buffers)
                  buffer)))
-    (with-current-buffer buffer
-      (goto-char (if (and (derived-mode-p 'comint-mode)
-                          (cdr comint-last-prompt))
-                     (cdr comint-last-prompt)
-                   (point-max)))
-      buffer)))
+    buffer))
 
 (defun +eval-open-repl (prompt-p &optional other-window-p)
   (let ((command (cdr (assq major-mode +eval-repls))))
@@ -65,7 +60,7 @@
       (error "Couldn't find a valid REPL for %s" major-mode))
     (when (+eval--ensure-in-repl-buffer command other-window-p)
       (when (bound-and-true-p evil-mode)
-        (call-interactively #'evil-append-line))
+        (evil-insert-state))
       t)))
 
 ;;;###autoload


### PR DESCRIPTION
With some programs under term-mode (e.g. zsh, julia), evil-normal-state
at point-max moves to the beginning of the next blank line. When
switching to the REPL buffer, evil-append-line will append a new line,
which will cause a new prompt to be created. Don't move point and don't
call evil-append-line to fix the problem. Also, change to
evil-insert-state which is likely the most desired behavior.

------------

I have installed julia-repl and configured

```elisp
  (set-repl-handler! 'julia-mode #'julia-repl)
```

```
julia>
|              <-- evil-normal-state will move point here
```

After switching back to the REPL buffer with `SPC o r`, I will see a julia prompt with no command

```
julia>     # no command due to evil-append-line

julia> 
```

This PR fixes the problem. From my experience, `(call-interactively #'evil-append-line)` is not very useful, so I just deleted it and added `(evil-insert-state)` instead.

zsh (without rc file) under term-mode has a similar behavior, but bash (without rc file) does not. I haven't figured out the reason.

----------

I have considered another approach:

```elisp
(when (bolp) (forward-char -1))
```

It works if point is at the end of line. However, the approach will cause the evaluation of the line if the point is not at the end. This is weird.
```
julia> 1 |+ 2    # point is not at the end
```

After switching back to the REPL buffer:
```
julia> 1 + 2 + 2   # + 2 was appended. weird

julia> 
```