### PR TITLE
Add doom-solarized-dark to +doom-solaire-themes

### DIFF
--- a/modules/ui/doom/config.el
+++ b/modules/ui/doom/config.el
@@ -10,6 +10,7 @@
     (doom-one . t)
     (doom-one-light . t)
     (doom-opera . t)
+    (doom-solarized-dark . t)
     (doom-solarized-light)
     (doom-spacegrey)
     (doom-vibrant)


### PR DESCRIPTION
This is need to call `solaire-mode-swap-bg` if the theme is `doom-solarized-dark`.