### PR TITLE
[WIP] Experimental fixes for undo-tree

### DIFF
--- a/core/core-editor.el
+++ b/core/core-editor.el
@@ -409,11 +409,13 @@ files, so we replace calls to `pp' with the much faster `prin1'."
   ;; Branching & persistent undo
   :after-call doom-switch-buffer-hook after-find-file
   :config
-  (setq undo-tree-auto-save-history nil ; disable because unstable
-        ;; undo-in-region is known to cause undo history corruption, which can
-        ;; be very destructive! Disabling it deters the error, but does not fix
-        ;; it entirely!
-        undo-tree-enable-undo-in-region nil
+  (setq undo-tree-auto-save-history t
+        ;; Increase undo-limits by a factor of ten to avoid emacs prematurely
+        ;; truncating the undo history and corrupting the tree. See
+        ;; https://github.com/syl20bnr/spacemacs/issues/12110
+        undo-limit 800000
+        undo-strong-limit 12000000
+        undo-outer-limit 120000000
         undo-tree-history-directory-alist
         `(("." . ,(concat doom-cache-dir "undo-tree-hist/"))))
 

--- a/core/packages.el
+++ b/core/packages.el
@@ -32,7 +32,10 @@
   ;; potato.
   :recipe (:host github :repo "hlissner/emacs-so-long"))
 (package! osx-clipboard :ignore (not IS-MAC))
-(package! undo-tree)
+(package! undo-tree
+  ;; NOTE The version of undo-tree published to ELPA is over 5 years old and
+  ;; missing some fixes. Just use the maintainer's repo directly.
+  :recipe (:host nil :repo "http://www.dr-qubit.org/git/undo-tree.git"))
 (package! ws-butler)
 (package! xclip :ignore (not IS-LINUX))
 


### PR DESCRIPTION
Increase `undo-limit`, `undo-strong-limit` and `undo-outer-limit` by a factor of ten, which should prevent emacs from prematurely truncating the undo history and corrupting the tree.

Restore `undo-tree-auto-save-history` which was disabled to avoid exacerbating the undo history truncation.

Change the `undo-tree` recipe to grab the latest version from the maintainer's repostiory instead of the outdated ELPA version.

Restore `undo-tree-enable-undo-in-region` which should be fixed in the latest version of `undo-tree`.

**WARNING:** There may still be a problem with `undo-tree-auto-save-history` causing a stack overflow on startup while deserializing the saved history.  This needs testing!  If you decide to test it, be prepared for undo history corruption!