### PR TITLE
lang/scala: replace ensime with metals

### DIFF
--- a/modules/lang/scala/config.el
+++ b/modules/lang/scala/config.el
@@ -15,23 +15,6 @@
     (add-hook 'scala-mode-local-vars-hook #'lsp!)))
 
 
-(use-package! ensime
-  :unless (featurep! +lsp)
-  :defer t
-  :config
-  (setq ensime-startup-snapshot-notification nil
-        ensime-startup-notification nil
-        ensime-eldoc-hints 'all
-        ;; let DOOM handle company setup
-        ensime-completion-style nil)
-
-  (set-company-backend! 'scala-mode '(ensime-company company-yasnippet))
-
-  ;; Fix void-variable imenu-auto-rescan error caused by `ensime--setup-imenu'
-  ;; trying to make imenu variables buffer local before imenu is loaded.
-  (require 'imenu))
-
-
 (use-package! sbt-mode
   :after scala-mode
   :config (set-repl-handler! 'scala-mode #'+scala/open-repl))

--- a/modules/lang/scala/doctor.el
+++ b/modules/lang/scala/doctor.el
@@ -1,0 +1,9 @@
+;;; lang/scala/doctor.el -*- lexical-binding: t; -*-
+
+(assert! (or (not (featurep! +lsp))
+             (featurep! :tools lsp))
+         "This module requires (:tools lsp)")
+
+(if (and (featurep! +lsp)
+         (not (executable-find "metals-emacs")))
+    (warn! "metals-emacs isn't installed"))

--- a/modules/lang/scala/packages.el
+++ b/modules/lang/scala/packages.el
@@ -3,9 +3,3 @@
 
 (package! sbt-mode)
 (package! scala-mode)
-
-(unless (featurep! +lsp)
-  ;; Fix #1697: Ensime doesn't have a master branch and its MELPA recipe doesn't
-  ;; specify a branch. Straight can't handle packages with non-standard primary
-  ;; branches (at the time of writing), so we must specify it manually:
-  (package! ensime :recipe (:branch "2.0")))


### PR DESCRIPTION
Ensime just went missing from everywhere. On ensime.github.io, they encourage to switch to [metals](https://scalameta.org/metals/) - a new Scala language server [already supported by `lsp-mode`](https://github.com/emacs-lsp/lsp-mode#supported-languages).

This commit:
- removes `ensime` completely
- adds a `doctor.el` to check for `metals-emacs` binary

[Original issue](https://discordapp.com/channels/406534637242810369/406554085794381833/628809956103028747)
[Metals](https://scalameta.org/metals/docs/editors/emacs.html)

Closes #1846.