### PR TITLE
Update documentation of recognized latex viewers

### DIFF
--- a/modules/lang/latex/README.org
+++ b/modules/lang/latex/README.org
@@ -4,13 +4,13 @@
 #+STARTUP: inlineimages
 
 * Table of Contents :TOC_3:noexport:
-- [[Description][Description]]
-  - [[Module Flags][Module Flags]]
-  - [[Plugins][Plugins]]
-- [[Features][Features]]
-- [[Customization][Customization]]
-  - [[Specifying the location of a bibtex file & corresponding PDFs][Specifying the location of a bibtex file & corresponding PDFs]]
-  - [[Changing the PDFs viewer][Changing the PDFs viewer]]
+- [[#description][Description]]
+  - [[#module-flags][Module Flags]]
+  - [[#plugins][Plugins]]
+- [[#features][Features]]
+- [[#customization][Customization]]
+  - [[#specifying-the-location-of-a-bibtex-file--corresponding-pdfs][Specifying the location of a bibtex file & corresponding PDFs]]
+  - [[#changing-the-pdfs-viewer][Changing the PDFs viewer]]
 
 * Description
 Provide a helping hand when working with LaTeX documents.
@@ -56,8 +56,10 @@ PDFs:
 This module provides integration for four supported pdf viewers. They are
 
 + [[https://skim-app.sourceforge.io/][Skim.app]] (MacOS only)
-+ Okular
++ Evince
++ Sumatra PDF
 + Zathura
++ Okular
 + pdf-tools (requires =:tools pdf= module)
 
 They are searched for in this order. See ~+latex-viewers~ to change the order,

--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -13,8 +13,8 @@ package to be installed.")
 
 (defvar +latex-viewers '(skim evince sumatrapdf zathura okular pdf-tools)
   "A list of enabled latex viewers to use, in this order. If they don't exist,
-they will be ignored. Recognized viewers are skim, zathura, okular and
-pdf-tools.
+they will be ignored. Recognized viewers are skim, evince, sumatrapdf, zathura,
+okular and pdf-tools.
 
 If no viewers are found, `latex-preview-pane' is used.")
 


### PR DESCRIPTION
The user documentation of +latex-viewers did not keep up with changes to
the variable. This commit realigns its documentation.