### PR TITLE
Add openSUSE prerequisite instructions

### DIFF
--- a/modules/completion/ivy/README.org
+++ b/modules/completion/ivy/README.org
@@ -12,6 +12,7 @@
   - [[#install][Install]]
     - [[#macos][MacOS]]
     - [[#arch-linux][Arch Linux]]
+    - [[#opensuse][openSUSE]]
 - [[#features][Features]]
   - [[#jump-to-file-project-navigation][Jump-to-file project navigation]]
   - [[#project-search--replace][Project search & replace]]
@@ -88,6 +89,11 @@ brew install ripgrep the_silver_searcher
 *** Arch Linux
 #+BEGIN_SRC sh :dir /sudo::
 sudo pacman --needed --noconfirm -S ripgrep the_silver_searcher
+#+END_SRC
+
+*** openSUSE
+#+BEGIN_SRC sh :dir /sudo::
+sudo zypper install ripgrep the_silver_searcher
 #+END_SRC
 
 * Features

--- a/modules/email/mu4e/README.org
+++ b/modules/email/mu4e/README.org
@@ -4,16 +4,18 @@
 #+STARTUP: inlineimages
 
 * Table of Contents :TOC:
-- [[Description][Description]]
-  - [[Module Flags][Module Flags]]
-  - [[Plugins][Plugins]]
-- [[Prerequisites][Prerequisites]]
-  - [[MacOS][MacOS]]
-  - [[Arch Linux][Arch Linux]]
-- [[Features][Features]]
-- [[Configuration][Configuration]]
-  - [[offlineimap][offlineimap]]
-  - [[mbsync][mbsync]]
+- [[#description][Description]]
+  - [[#module-flags][Module Flags]]
+  - [[#plugins][Plugins]]
+- [[#prerequisites][Prerequisites]]
+  - [[#macos][MacOS]]
+  - [[#arch-linux][Arch Linux]]
+  - [[#nixos][NixOS]]
+  - [[#opensuse][openSUSE]]
+- [[#features][Features]]
+- [[#configuration][Configuration]]
+  - [[#offlineimap][offlineimap]]
+  - [[#mbsync][mbsync]]
 
 * Description
 This module makes Emacs an email client, using ~mu4e~.
@@ -65,6 +67,15 @@ environment.systemPackages = with pkgs; [
 #+END_SRC
 
 [[https://github.com/Emiller88/dotfiles/blob/master/modules/shell/mail.nix][An example of setting up mbsync with home-manager]]
+
+** openSUSE
+
+Remove ~#~ in ~#sync_program=offlineimap~ to choose ~offlineimap~ instead of ~mbsync~.
+#+BEGIN_SRC sh :dir /sudo::
+sync_program=isync # mbsync
+#sync_program=offlineimap
+sudo zypper install maildir-utils $sync_programm
+#+END_SRC
 
 * TODO Features
 

--- a/modules/lang/cc/README.org
+++ b/modules/lang/cc/README.org
@@ -11,6 +11,7 @@
   - [[#irony-server][irony-server]]
     - [[#macos][MacOS]]
     - [[#arch-linux][Arch Linux]]
+    - [[#opensuse][openSUSE]]
   - [[#rtags][rtags]]
 - [[#configure][Configure]]
   - [[#project-compile-settings][Project compile settings]]
@@ -91,6 +92,11 @@ rm -rf irony-mode
 *** Arch Linux
 #+BEGIN_SRC sh
 pacman -S clang cmake
+#+END_SRC
+
+*** openSUSE
+#+BEGIN_SRC sh :dir /sudo::
+sudo zypper install clang cmake
 #+END_SRC
 
 ** rtags

--- a/modules/lang/elixir/README.org
+++ b/modules/lang/elixir/README.org
@@ -11,6 +11,7 @@
     - [[#with-asdf][With ~asdf~]]
     - [[#arch-linux][Arch Linux]]
     - [[#gentoo-linux][Gentoo Linux]]
+    - [[#opensuse][openSUSE]]
 - [[#features][Features]]
 
 * Description
@@ -46,6 +47,11 @@ sudo pacman -S elixir
 *** Gentoo Linux
 #+BEGIN_SRC sh :dir /sudo::
 sudo emerge -v dev-lang/elixir
+#+END_SRC
+
+*** openSUSE
+#+BEGIN_SRC sh :dir /sudo::
+sudo zypper install elixir
 #+END_SRC
 * Features
 - Code completion (~:completion company~)

--- a/modules/lang/go/README.org
+++ b/modules/lang/go/README.org
@@ -4,15 +4,15 @@
 #+STARTUP: inlineimages
 
 * Table of Contents :TOC:
-- [[Description][Description]]
-  - [[Module Flags][Module Flags]]
-  - [[Plugins][Plugins]]
-- [[Prerequisites][Prerequisites]]
-  - [[Go][Go]]
-  - [[Dependencies][Dependencies]]
-- [[Features][Features]]
-- [[Configuration][Configuration]]
-- [[Troubleshooting][Troubleshooting]]
+- [[#description][Description]]
+  - [[#module-flags][Module Flags]]
+  - [[#plugins][Plugins]]
+- [[#prerequisites][Prerequisites]]
+  - [[#go][Go]]
+  - [[#dependencies][Dependencies]]
+- [[#features][Features]]
+- [[#configuration][Configuration]]
+- [[#troubleshooting][Troubleshooting]]
 
 * Description
 This module adds [[https://golang.org][Go]] support.
@@ -49,6 +49,11 @@ brew install go
 *** Arch Linux
 #+BEGIN_SRC bash
 sudo pacman -S go
+#+END_SRC
+
+*** openSUSE
+#+BEGIN_SRC sh :dir /sudo::
+sudo zypper install go
 #+END_SRC
 
 ** Dependencies

--- a/modules/lang/haskell/README.org
+++ b/modules/lang/haskell/README.org
@@ -72,12 +72,17 @@ To use Intero, you need =stack=:
 brew install haskell-stack
 stack setup
 #+END_SRC
-
 *** Arch Linux
 #+BEGIN_SRC sh
 sudo pacman -S stack
 # Replace pacaur with your AUR package manager of choice
 pacaur -S ncurses5-compat-lib
+stack setup
+#+END_SRC
+
+*** openSUSE
+#+BEGIN_SRC sh :dir /sudo::
+sudo zypper install stack
 stack setup
 #+END_SRC
 
@@ -93,6 +98,11 @@ brew install cabal-install ghc
 *** Arch Linux
 #+BEGIN_SRC sh
 sudo pacman -S cabal-install ghc
+#+END_SRC
+
+*** openSUSE
+#+BEGIN_SRC sh :dir /sudo::
+sudo zypper install cabal-install ghc
 #+END_SRC
 
 ** LSP

--- a/modules/lang/javascript/README.org
+++ b/modules/lang/javascript/README.org
@@ -10,6 +10,7 @@
 - [[#prerequisites][Prerequisites]]
   - [[#macos][MacOS]]
   - [[#arch-linux][Arch Linux]]
+  - [[#opensuse][openSUSE]]
 - [[#appendix][Appendix]]
   - [[#commands][Commands]]
 
@@ -54,6 +55,11 @@ brew install node
 ** Arch Linux
 #+BEGIN_SRC sh :dir /sudo:: :tangle (if (doom-system-os 'arch) "yes")
 sudo pacman --needed --noconfirm -S nodejs npm
+#+END_SRC
+
+** openSUSE
+#+BEGIN_SRC sh :dir /sudo::
+sudo zypper install nodejs npm
 #+END_SRC
 
 * Appendix

--- a/modules/lang/nim/README.org
+++ b/modules/lang/nim/README.org
@@ -11,10 +11,10 @@ This module adds [[https://nim-lang.org][Nim]] support to Emacs.
 + Babel support (~ob-nim~)
 
 * Table of Contents :TOC:
-- [[Module Flags][Module Flags]]
-- [[Prerequisites][Prerequisites]]
-  - [[Nim][Nim]]
-- [[Configuration][Configuration]]
+- [[#module-flags][Module Flags]]
+- [[#prerequisites][Prerequisites]]
+  - [[#nim][Nim]]
+- [[#configuration][Configuration]]
 
 * Module Flags
 This module provides no flags.
@@ -42,6 +42,11 @@ brew install nim
 *** Arch Linux
 #+BEGIN_SRC sh :dir /sudo:: :tangle (if (doom-system-os 'arch) "yes")
 sudo pacman --needed --noconfirm -S nim nimble
+#+END_SRC
+
+*** openSUSE
+#+BEGIN_SRC sh :dir /sudo::
+sudo zypper install nim
 #+END_SRC
 
 * Configuration

--- a/modules/lang/php/README.org
+++ b/modules/lang/php/README.org
@@ -40,6 +40,11 @@ brew install composer
 sudo pacman --needed --noconfirm -S php composer  # or php53, php54, php55
 #+END_SRC
 
+*** openSUSE
+#+BEGIN_SRC sh :dir /sudo::
+sudo zypper install php-composer
+#+END_SRC
+
 ** Dependencies
 The features in this module optionally depend on the following php packages:
 


### PR DESCRIPTION
These instructions were tested on openSUSE Tumbleweed and openSUSE Leap
15.1. There are some modules left that are not documented yet, but this
already improves the sitution for common openSUSE users.