### PR TITLE
Correct a requirement in README.org

### DIFF
--- a/modules/lang/python/README.org
+++ b/modules/lang/python/README.org
@@ -54,8 +54,8 @@ This module has no direct prerequisites. Here are some of its soft dependencies.
 + The ~:editor format~ module uses [[https://github.com/psf/black][Black]] for python files
   + ~pip install black~
 
-+ ~pyimport~ requires Python's module ~pyimport~:
-  + ~pip install pyimport~
++ ~pyimport~ requires Python's module ~pyflakes~:
+  + ~pip install pyflakes~
 
 + Python virtual environments install instructions at:
   + [[https://github.com/pyenv/pyenv][pyenv]]


### PR DESCRIPTION
Quick fix to the README for python language module to correct the required python package for `pyimport.el` to `pyflakes` as mentioned in its own [README](https://github.com/Wilfred/pyimport).