### PR TITLE
added company-files support for file links in org mode

### DIFF
--- a/modules/completion/company/config.el
+++ b/modules/completion/company/config.el
@@ -51,6 +51,11 @@
 ;;
 ;; Packages
 
+(after! company-files
+  (pushnew! company-files--regexps
+            "file:\\(\\(?:\\.\\{1,2\\}/\\|~/\\|/\\)[^\]\n]*\\)"))
+
+
 (use-package! company-prescient
   :hook (company-mode . company-prescient-mode)
   :config

--- a/modules/completion/company/config.el
+++ b/modules/completion/company/config.el
@@ -31,7 +31,9 @@
       :before #'company-begin-backend
       (company-abort)))
 
-  (add-hook 'company-mode-hook #'+company-init-backends-h)
+  (add-hook 'company-mode-hook #'(lambda ()
+    (+company-init-backends-h)
+    (setq company-files--regexps (cons "file\:\\(\\(?:\\.\\{1,2\\}/\\|~/\\|/\\)[^\]\n]*\\)" company-files--regexps))))
   (global-company-mode +1))
 
 

--- a/modules/completion/company/config.el
+++ b/modules/completion/company/config.el
@@ -31,9 +31,7 @@
       :before #'company-begin-backend
       (company-abort)))
 
-  (add-hook 'company-mode-hook #'(lambda ()
-    (+company-init-backends-h)
-    (setq company-files--regexps (cons "file\:\\(\\(?:\\.\\{1,2\\}/\\|~/\\|/\\)[^\]\n]*\\)" company-files--regexps))))
+  (add-hook 'company-mode-hook #'+company-init-backends-h)
   (global-company-mode +1))
 
 

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -814,6 +814,17 @@ compelling reason, so..."
       (sp-local-pair "~" "~" :unless '(:add sp-point-before-word-p +org-sp-in-src-block-p))
       (sp-local-pair "=" "=" :unless '(:add sp-point-before-word-p sp-in-math-p +org-sp-in-src-block-p)))))
 
+(defun +org-init-company-h()
+  (after! company
+    (setq company-files--regexps
+      (let* ((root (if (eq system-type 'windows-nt)
+              "[a-zA-Z]:/"
+              "/"))
+              (begin (concat "\\(?:\\.\\{1,2\\}/\\|~/\\|" root "\\)")))
+        (list (concat "\"\\(" begin "[^\"\n]*\\)")
+              (concat "\'\\(" begin "[^\'\n]*\\)")
+              (concat "file:\\(" begin "[^\]\n]*\\)")
+              (concat "\\(?:[ \t=]\\|^\\)\\(" begin "[^ \t\n]*\\)"))))))
 
 ;;
 ;;; Bootstrap
@@ -859,12 +870,6 @@ compelling reason, so..."
              #'+org-enable-auto-update-cookies-h
              #'+org-unfold-to-2nd-level-or-point-h)
 
-  (if (featurep! :completion company)
-      (add-hook 'org-mode-hook
-            #'(lambda ()
-            (require 'company-files)
-            (setq company-files--regexps (cons "file:\\(\\(?:\\.\\{1,2\\}/\\|~/\\|/\\)[^\]\n]*\\)"
-                                        company-files--regexps)))))
 
 
   (add-hook! 'org-load-hook
@@ -885,7 +890,8 @@ compelling reason, so..."
              #'+org-init-popup-rules-h
              #'+org-init-protocol-h
              #'+org-init-protocol-lazy-loader-h
-             #'+org-init-smartparens-h)
+             #'+org-init-smartparens-h
+             #'+org-init-company-h)
 
   ;; In case the user has eagerly loaded org from their configs
   (when (and (featurep 'org)

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -814,18 +814,11 @@ compelling reason, so..."
       (sp-local-pair "~" "~" :unless '(:add sp-point-before-word-p +org-sp-in-src-block-p))
       (sp-local-pair "=" "=" :unless '(:add sp-point-before-word-p sp-in-math-p +org-sp-in-src-block-p)))))
 
-(defun +org-init-company-h()
-  (after! company
-    (setq company-files--regexps
-      (let* ((root (if (eq system-type 'windows-nt)
-              "[a-zA-Z]:/"
-              "/"))
-              (begin (concat "\\(?:\\.\\{1,2\\}/\\|~/\\|" root "\\)")))
-        (list (concat "\"\\(" begin "[^\"\n]*\\)")
-              (concat "\'\\(" begin "[^\'\n]*\\)")
-              (concat "file:\\(" begin "[^\]\n]*\\)")
-              (concat "\\(?:[ \t=]\\|^\\)\\(" begin "[^ \t\n]*\\)"))))))
-
+(defun +org-init-company-h ()
+  (after! company-files
+    (setq-local company-files--regexps
+                (cons "file:\\(\\(?:\\.\\{1,2\\}/\\|~/\\|/\\)[^\]\n]*\\)"
+                      company-files--regexps))))
 ;;
 ;;; Bootstrap
 

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -814,11 +814,7 @@ compelling reason, so..."
       (sp-local-pair "~" "~" :unless '(:add sp-point-before-word-p +org-sp-in-src-block-p))
       (sp-local-pair "=" "=" :unless '(:add sp-point-before-word-p sp-in-math-p +org-sp-in-src-block-p)))))
 
-(defun +org-init-company-h ()
-  (after! company-files
-    (setq-local company-files--regexps
-                (cons "file:\\(\\(?:\\.\\{1,2\\}/\\|~/\\|/\\)[^\]\n]*\\)"
-                      company-files--regexps))))
+
 ;;
 ;;; Bootstrap
 
@@ -881,8 +877,7 @@ compelling reason, so..."
              #'+org-init-popup-rules-h
              #'+org-init-protocol-h
              #'+org-init-protocol-lazy-loader-h
-             #'+org-init-smartparens-h
-             #'+org-init-company-h)
+             #'+org-init-smartparens-h)
 
   ;; In case the user has eagerly loaded org from their configs
   (when (and (featurep 'org)

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -859,6 +859,14 @@ compelling reason, so..."
              #'+org-enable-auto-update-cookies-h
              #'+org-unfold-to-2nd-level-or-point-h)
 
+  (if (featurep! :completion company)
+      (add-hook 'org-mode-hook
+            #'(lambda ()
+            (require 'company-files)
+            (setq company-files--regexps (cons "file:\\(\\(?:\\.\\{1,2\\}/\\|~/\\|/\\)[^\]\n]*\\)"
+                                        company-files--regexps)))))
+
+
   (add-hook! 'org-load-hook
              #'+org-init-appearance-h
              #'+org-init-agenda-h

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -870,8 +870,6 @@ compelling reason, so..."
              #'+org-enable-auto-update-cookies-h
              #'+org-unfold-to-2nd-level-or-point-h)
 
-
-
   (add-hook! 'org-load-hook
              #'+org-init-appearance-h
              #'+org-init-agenda-h


### PR DESCRIPTION
Added regex for company-files to recognize file links in org-mode.
I can move changing `company-files-regexps` if there is better place to modify it.