### PR TITLE
Reformats ui/doom/README.org to match __doom-readme template

### DIFF
--- a/modules/ui/doom/README.org
+++ b/modules/ui/doom/README.org
@@ -1,5 +1,19 @@
-#+TITLE: :ui doom
+#+TITLE:   ui/doom
+#+DATE:    October 9, 2019
+#+SINCE:   v2.0.9
+#+STARTUP: inlineimages
 
+* Table of Contents :TOC_3:noexport:
+- [[#description][Description]]
+  - [[#module-flags][Module Flags]]
+- [[#prerequisites][Prerequisites]]
+- [[#configuration][Configuration]]
+  - [[#changing-theme][Changing theme]]
+  - [[#changing-fonts][Changing fonts]]
+- [[#troubleshooting][Troubleshooting]]
+  - [[#strange-font-symbols][Strange font symbols]]
+
+* Description
 This module modifies Emacs' user interface.
 
 Doom's look is loosely inspired by Atom's One Dark theme, and is largely contained in the] plugin.
@@ -9,12 +23,11 @@ Doom's look is loosely inspired by Atom's One Dark theme, and is largely contain
 + "Thin bar" fringe bitmaps for ~git-gutter-fringe~
 + File-visiting buffers are slightly brighter (powered by solaire-mode)
 
-* Table of Contents :TOC:
-- [[#configuration][Configuration]]
-  - [[#changing-theme][Changing theme]]
-  - [[#changing-fonts][Changing fonts]]
-- [[#troubleshooting][Troubleshooting]]
-  - [[#strange-font-symbols][Strange font symbols]]
+** Module Flags
+This module provides no flags.
+
+* Prerequisites
+This module has no prereqisites.
 
 * Configuration
 ** Changing theme

--- a/modules/ui/doom/README.org
+++ b/modules/ui/doom/README.org
@@ -1,6 +1,6 @@
 #+TITLE:   ui/doom
 #+DATE:    October 9, 2019
-#+SINCE:   v2.0.9
+#+SINCE:   v1.3
 #+STARTUP: inlineimages
 
 * Table of Contents :TOC_3:noexport:


### PR DESCRIPTION
Reformats ui/doom/README.org to match __doom-readme template as per #1166