### PR TITLE
Reformat ui/doom-dashboard/README.org to match __doom-readme template

### DIFF
--- a/modules/ui/doom-dashboard/README.org
+++ b/modules/ui/doom-dashboard/README.org
@@ -1,17 +1,20 @@
-#+TITLE: :ui doom-dashboard
+#+TITLE:   ui/doom-dashboard
+#+DATE:    October 9, 2019
+#+SINCE:   v2.0.9
+#+STARTUP: inlineimages
 
+* Table of Contents :TOC_3:noexport:
+- [[#description][Description]]
+  - [[#module-flags][Module Flags]]
+- [[#prerequisites][Prerequisites]]
+
+* Description
 This module gives Doom Emacs a dashboard buffer.
 
 It is loosely inspired by Atom's dashboard.
 
-* Table of Contents :TOC:
-- [[#install][Install]]
-- [[#keybindings][Keybindings]]
-- [[#customization][Customization]]
+** Module Flags
+This module provides no flags.
 
-* Install
+* Prerequisites
 This module only requires that ~all-the-icons~'s icon fonts are installed. Use ~M-x all-the-icons-install-fonts~ to do so.
-
-* Keybindings
-
-* Customization


### PR DESCRIPTION
----

Reformats ui/doom-dashboard/README.org to match __doom-readme template as per #1166