### PR TITLE
Allow +literate-config-file to be a symbolic link

### DIFF
--- a/modules/config/literate/init.el
+++ b/modules/config/literate/init.el
@@ -19,7 +19,7 @@ byte-compiled from.")
               force-p)
       (message "Compiling your literate config...")
       (let* ((org (file-truename +literate-config-file))
-             (dest (concat (file-name-sans-extension org) ".el"))
+             (dest (concat (file-name-sans-extension +literate-config-file) ".el"))
              (output (get-buffer-create "*org-tangle*")))
         (unwind-protect
             ;; We tangle in a separate, blank process because loading it here


### PR DESCRIPTION
If the literate config file is a symbolic link, the tangled file is with the
target of the link, not with the literate config file.

**What is wrong**
If `~/.doom.d/config.org` is a file symbolic linked to some other file, then it is not loaded when doom start.

**What is the problem**
In `modules/config/literate/init.el`, the function `+literate-tangle` is defined as:
```emacs-lisp
(defun +literate-tangle (&optional force-p)
  "Tangles `+literate-config-file' if it has changed."
  (let ((default-directory doom-private-dir))
    (when (or (file-newer-than-file-p +literate-config-file
                                      +literate-config-cache-file)
              force-p)
      (message "Compiling your literate config...")
      (let* ((org (file-truename +literate-config-file))
             (dest (concat (file-name-sans-extension org) ".el"))
             (output (get-buffer-create "*org-tangle*")))
        (unwind-protect
            ;; We tangle in a separate, blank process because loading it here
            ;; would load all of :lang org (very expensive!).
            (or (and (zerop (call-process
                             "emacs" nil output nil
                             "-q" "--batch"
                             "-l" "ob-tangle"
                             "--eval" (format "(org-babel-tangle-file %S %S)"
                                              org dest)))
                     (with-current-buffer output
                       (message "%s" (buffer-string))
                       t)
                     ;; Write the cache file to serve as our mtime cache
                     (with-temp-file +literate-config-cache-file
                       (message "Done!")))
                (warn "There was a problem tangling your literate config!"))
          (kill-buffer output))))))
```
Therefore, the tangled literate config file is saved in the same directory as the destination of the symbolic linked file, not in `~/.doom.d/`, and therefore not loaded. This bug was introduced in commit 132ad7d I am not sure about the reason for using `file-truename` when deciding the destination file of tangling.

**Steps to reproduce**
1. Make some configuration in a literate config file,
2. Symbolic link it to `~/.doom.d/config.org`
3. `doom refresh`
4. Start `doom` by running `emacs`