### PR TITLE
Add support for org-pomodoro

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -129,9 +129,10 @@
        ;;ocaml             ; an objective camel
        (org              ; organize your plain life in plain text
         +dragndrop       ; drag & drop files/images into org buffers
-        ;+hugo           ; use Emacs for hugo blogging
+        ;+hugo            ; use Emacs for hugo blogging
         +ipython         ; ipython/jupyter support for babel
         +pandoc          ; export-with-pandoc support
+        ;+pomodoro        ; be fruitful with the tomato technique
         +present)        ; using org-mode for presentations
        ;;perl              ; write code no one else can comprehend
        ;;php               ; perl's insecure younger brother

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -855,6 +855,8 @@
         :desc "Word-wrap mode"               "w" #'+word-wrap-mode
         (:when (featurep! :lang org +present)
           :desc "org-tree-slide mode"          "p" #'+org-present/start)
+        (:when (featurep! :lang org +pomodoro)
+          :desc "Pomodoro timer"               "t" #'org-pomodoro)
         (:when (featurep! :tools flycheck)
           :desc "Flycheck"                     "f" #'flycheck-mode)
         (:when (featurep! :tools flyspell)

--- a/modules/lang/org/README.org
+++ b/modules/lang/org/README.org
@@ -59,6 +59,7 @@ https://www.mfoot.com/blog/2015/11/22/literate-emacs-configuration-with-org-mode
   =SPC m b p=, by default).
 + =+ipython= Enables ipython+babel integration.
 + =+pandoc= Enables pandoc integration into the Org exporter.
++ =+pomodoro= Enables a pomodoro timer for clocking time on tasks.
 + =+present= Enables integration with reveal.js, beamer and org-tree-slide, so
   Emacs can be used for presentations.
 + =+hugo= Enables integration with [[https://gohugo.io][hugo]] to export from Emacs well-formed
@@ -97,6 +98,8 @@ https://www.mfoot.com/blog/2015/11/22/literate-emacs-configuration-with-org-mode
   + [[https://github.com/gregsexton/ob-ipython][ob-ipython]]
 + =+pandoc=
   + [[https://github.com/kawabata/ox-pandoc][ox-pandoc]]
++ =+pomodoro=
+  + [[https://github.com/marcinkoziej/org-pomodoro][org-pomodoro]]
 + =+present=
   + [[https://github.com/anler/centered-window-mode][centered-window]]
   + [[https://github.com/takaxp/org-tree-slide][org-tree-slide]]

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -886,6 +886,7 @@ compelling reason, so..."
   ;;; Custom org modules
   (if (featurep! +dragndrop) (load! "contrib/dragndrop"))
   (if (featurep! +ipython)   (load! "contrib/ipython"))
+  (if (featurep! +pomodoro)  (load! "contrib/pomodoro"))
   (if (featurep! +present)   (load! "contrib/present"))
 
   :config

--- a/modules/lang/org/contrib/pomodoro.el
+++ b/modules/lang/org/contrib/pomodoro.el
@@ -1,0 +1,18 @@
+;;; lang/org/contrib/pomodoro.el -*- lexical-binding: t; -*-
+;;;###if (featurep! +pomodoro)
+
+(use-package! org-pomodoro
+  :defer t
+  :config
+
+  ;; prefer PulseAudio to ALSA in $current_year
+  (setq org-pomodoro-audio-player (or (executable-find "paplay")
+                                      org-pomodoro-audio-player))
+
+  ;; configure pomodoro alerts to use growl or libnotify
+  (alert-add-rule :category "org-pomodoro"
+                  :style (cond (alert-growl-command
+                                'growl)
+                               (alert-libnotify-command
+                                'libnotify)
+                               (alert-default-style))))

--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -45,6 +45,8 @@
   (package! ob-ipython))
 (when (featurep! +pandoc)
   (package! ox-pandoc))
+(when (featurep! +pomodoro)
+  (package! org-pomodoro))
 (when (featurep! +present)
   (package! centered-window :recipe (:host github :repo "anler/centered-window-mode"))
   (package! org-tree-slide)


### PR DESCRIPTION
This is a resurrection & review of #1484.

Adds `SPC t t` binding to toggle `org-pomodoro` (mnemonic "toggle timer").

Sends notifications using growl or libnotify if available.