### PR TITLE
Faster prompt eshell

### DIFF
--- a/core/core-cli.el
+++ b/core/core-cli.el
@@ -33,6 +33,19 @@ STATUS is a boolean"
                 (string-trim (buffer-string))))
       (kill-buffer output))))
 
+(defun doom-sh-ignore-stderr (command &rest args)
+  "Execute COMMAND with ARGS in the shell and return (STATUS . OUTPUT). Discards
+  the stderr of the command.
+
+STATUS is a boolean"
+  (let ((output (get-buffer-create "*doom-sh-ignore-stdderr-output*")))
+    (unwind-protect
+        (cons (or (apply #'call-process command nil `(,output nil) nil args)
+                  -1)
+              (with-current-buffer output
+                (string-trim (buffer-string))))
+      (kill-buffer output))))
+
 (defun doom--dispatch-command (command)
   (when (symbolp command)
     (setq command (symbol-name command)))

--- a/modules/term/eshell/autoload/prompts.el
+++ b/modules/term/eshell/autoload/prompts.el
@@ -12,7 +12,7 @@
 
 
 (defun +eshell--current-git-branch ()
-  (let ((branch (car (cl-loop for match in (split-string (shell-command-to-string "git branch") "\n")
+  (let ((branch (car (cl-loop for match in (split-string (doom-sh-ignore-stderr "git branch") "\n")
                               if (string-match-p "^\*" match)
                               collect match))))
     (if (eq branch nil)

--- a/modules/term/eshell/autoload/prompts.el
+++ b/modules/term/eshell/autoload/prompts.el
@@ -12,7 +12,7 @@
 
 
 (defun +eshell--current-git-branch ()
-  (let ((branch (car (cl-loop for match in (split-string (doom-sh-ignore-stderr "git branch") "\n")
+  (let ((branch (car (cl-loop for match in (split-string (cdr (doom-sh-ignore-stderr "git" "branch")) "\n")
                               if (string-match-p "^\*" match)
                               collect match))))
     (if (eq branch nil)

--- a/modules/term/eshell/autoload/prompts.el
+++ b/modules/term/eshell/autoload/prompts.el
@@ -15,9 +15,9 @@
   (let ((branch (car (cl-loop for match in (split-string (shell-command-to-string "git branch") "\n")
                               if (string-match-p "^\*" match)
                               collect match))))
-    (if (not (eq branch nil))
-        (format " [%s]" (substring branch 2))
-      "")))
+    (if (eq branch nil)
+        ""
+      (format " [%s]" (substring branch 2)))))
 
 ;;;###autoload
 (defun +eshell-default-prompt-fn ()


### PR DESCRIPTION
There's no need for a shell or for any complex output parsing. So this is simpler and more efficient.

Copy pasting `doom-sh-ignore-stderr` like that is ugly of course. I'm open to suggestions on how to refactor things.

The whole `sh` thing is confusing btw. Avoiding the shell seems like the whole point of using `doom-sh`.