### PR TITLE
Don't bind nav-flash keybind unless enabled

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -554,7 +554,8 @@
       :desc "Search for symbol in project" "*" #'+default/search-project-for-symbol-at-point
 
       :desc "Find file in project"  "SPC"  #'projectile-find-file
-      :desc "Blink cursor line"     "DEL"  #'+nav-flash/blink-cursor
+      (:when (featurep! :ui nav-flash)
+        :desc "Blink cursor line"   "DEL"  #'+nav-flash/blink-cursor)
       :desc "Jump to bookmark"      "RET"  #'bookmark-jump
 
       ;;; <leader> / --- search


### PR DESCRIPTION
The nav-flash keybind is enabled regardless of whether or not the module is enabled. This just adds a check to the map! in the default keybindings.