### PR TITLE
Remove detection for .merlin files

### DIFF
--- a/modules/lang/ocaml/config.el
+++ b/modules/lang/ocaml/config.el
@@ -65,12 +65,11 @@
     :hook (merlin-mode . +ocaml-init-flycheck-h)
     :config
     (defun +ocaml-init-flycheck-h ()
-      "Activate `flycheck-ocaml` if the current project possesses a .merlin file."
-      (when (projectile-locate-dominating-file default-directory ".merlin")
-        ;; Disable Merlin's own error checking
-        (setq merlin-error-after-save nil)
-        ;; Enable Flycheck checker
-        (flycheck-ocaml-setup))))
+      "Activate `flycheck-ocaml`"
+      ;; Disable Merlin's own error checking
+      (setq merlin-error-after-save nil)
+      ;; Enable Flycheck checker
+      (flycheck-ocaml-setup)))
 
   (use-package! merlin-eldoc
     :hook (merlin-mode . merlin-eldoc-setup))


### PR DESCRIPTION
These files are generated and hence this detection fails if they haven't
been generated yet. Merlin is essential for basically all OCaml
development so there's no need for this extra check.