### PR TITLE
Fix uses of projectile-locate-dominating-file

### DIFF
--- a/core/core-projects.el
+++ b/core/core-projects.el
@@ -27,6 +27,7 @@ Emacs.")
   :commands (projectile-project-root
              projectile-project-name
              projectile-project-p
+             projectile-locate-dominating-file
              projectile-add-known-project) ; TODO PR autoload upstream
   :init
   (setq projectile-cache-file (concat doom-cache-dir "projectile.cache")


### PR DESCRIPTION
This function isn't autoloaded so we should include it in the list of
commands like some other projectile functions.