### PR TITLE
re-search-forward to search-forward when no re

### DIFF
--- a/bin/doom-doctor
+++ b/bin/doom-doctor
@@ -107,7 +107,7 @@
                    (with-temp-buffer
                      (insert-file-contents-literally core-file)
                      (goto-char (point-min))
-                     (when (re-search-forward "doom-version" nil t)
+                     (when (search-forward "doom-version" nil t)
                        (forward-char)
                        (sexp-at-point))))))
           "???")

--- a/core/autoload/debug.el
+++ b/core/autoload/debug.el
@@ -137,7 +137,7 @@ markdown and copies it to your clipboard, ready to be pasted into bug reports!"
           (progn
             (save-excursion
               (pp info (current-buffer)))
-            (when (re-search-forward "(modules " nil t)
+            (when (search-forward "(modules " nil t)
               (goto-char (match-beginning 0))
               (cl-destructuring-bind (beg . end)
                   (bounds-of-thing-at-point 'sexp)

--- a/core/autoload/help.el
+++ b/core/autoload/help.el
@@ -424,7 +424,7 @@ If prefix arg is present, refresh the cache."
             (progn
               (end-of-line)
               (insert "\n"))
-          (re-search-forward "\n\n" nil t))
+          (search-forward "\n\n" nil t))
 
         (package--print-help-section "Package")
         (insert (symbol-name package) "\n")

--- a/core/autoload/packages.el
+++ b/core/autoload/packages.el
@@ -139,7 +139,7 @@ was installed with."
           (when (file-readable-p file)
             (insert-file-contents file)
             (delay-mode-hooks (emacs-lisp-mode))
-            (while (re-search-forward "(package! " nil t)
+            (while (search-forward "(package! " nil t)
               (save-excursion
                 (goto-char (match-beginning 0))
                 (unless (let ((ppss (syntax-ppss)))


### PR DESCRIPTION
When no regular expression is present, it's faster and simpler to use
search-forward