### PR TITLE
Fix tuareg-find-alternate-file binding

### DIFF
--- a/modules/lang/ocaml/config.el
+++ b/modules/lang/ocaml/config.el
@@ -25,6 +25,9 @@
   (setq-hook! 'tuareg-mode-hook
     comment-line-break-function #'+ocaml/comment-indent-new-line)
 
+  (map! :localleader
+        :map tuareg-mode-map
+        "a" #'tuareg-find-alternate-file)
 
   (use-package! utop
     :when (featurep! :tools eval)
@@ -57,8 +60,7 @@
 
   (map! :localleader
         :map tuareg-mode-map
-        "t" #'merlin-type-enclosing
-        "a" #'tuareg-find-alternate-file)
+        "t" #'merlin-type-enclosing)
 
   (use-package! flycheck-ocaml
     :when (featurep! :tools flycheck)


### PR DESCRIPTION
This binding should be available whenever tuareg is loaded. Previously,
it would loaded only after merlin.