### PR TITLE
Add emr to emacs lisp mode

### DIFF
--- a/modules/lang/emacs-lisp/config.el
+++ b/modules/lang/emacs-lisp/config.el
@@ -78,6 +78,20 @@ This marks a foldable marker for `outline-minor-mode' in elisp buffers.")
   (map! :localleader
         :map emacs-lisp-mode-map
         :desc "Expand macro" "m" #'macrostep-expand
+        (:prefix ("r" . "refactor")
+          :desc "refactor menu" "r" #'emr-show-refactor-menu
+          (:prefix ("i" . "inline")
+            :desc "Variable" "v" #'emr-el-inline-variable
+            :desc "Let variable" "l" #'emr-el-inline-let-variable
+            :desc "Function" "f" #'emr-el-inline-function)
+          (:prefix ("e" . "extract")
+            :desc "Function" "f" #'emr-el-extract-function
+            :desc "Variable" "v" #'emr-el-extract-variable
+            :desc "Constant" "c" #'emr-el-extract-constant
+            :desc "To let" "l" #'emr-el-extract-to-let)
+          (:prefix ("d" . "delete")
+            :desc "Let binding" "l" #'emr-el-delete-let-binding-form
+            :desc "Unused definition" "d" #'emr-el-delete-unused-definition))
         (:prefix ("d" . "debug")
           "f" #'+emacs-lisp/edebug-instrument-defun-on
           "F" #'+emacs-lisp/edebug-instrument-defun-off)

--- a/modules/lang/emacs-lisp/packages.el
+++ b/modules/lang/emacs-lisp/packages.el
@@ -8,6 +8,7 @@
 (package! overseer)
 (package! elisp-def)
 (package! elisp-demos)
+(package! emr)
 
 (when (featurep! :tools flycheck)
   (package! flycheck-cask))


### PR DESCRIPTION
While emr is sometimes buggy, it's basically the only choice for elisp.

I'm not a fan of this menu thing for common refactorings, so I've added some proper keybindings.