### PR TITLE
Improve +word-wrap in non-code buffers

### DIFF
--- a/modules/editor/word-wrap/README.org
+++ b/modules/editor/word-wrap/README.org
@@ -12,10 +12,10 @@
 This module adds a minor-mode ~+word-wrap-mode~, which intelligently wraps long
 lines in the buffer without modifying the buffer content.
 
-Wrapped lines will be indented to match the preceding line. Lines which are not
-inside a comment will have extra indentation as determined by
-~+word-wrap-extra-indent~. The default is to increase the indent by twice the
-major-mode indent.
+Wrapped lines will be indented to match the preceding line. In code buffers,
+lines which are not inside a string or comment will have extra indentation as
+determined by ~+word-wrap-extra-indent~. The default is to increase the indent
+by twice the major-mode indent.
 
 The ~+word-wrap-extra-indent~ variable supports the following values:
 - ~double~: indent by twice the major-mode indentation
@@ -28,6 +28,14 @@ This module also includes a global minor-mode ~+global-word-wrap-mode~ to
 automatically enable wrapping in most buffers. Wrapping will not be enabled in
 buffers whose major mode is marked "special", or are listed in
 ~+word-wrap-disabled-modes~.
+
+The ~+word-wrap-text-modes~ variable lists modes which shouldn't have any extra
+indentation, regardless of the ~+word-wrap-extra-indent~ setting. This is useful
+for modes which are primarily text, such as ~text-mode~ and ~markdown-mode~.
+
+The ~+word-wrap-visual-modes~ variable lists modes which should only enable
+~visual-line-mode~ and not provide any prefix indentation. This is useful for
+modes like ~org-mode~ which handle prefix indentation themselves.
 
 ** Module Flags
 This module provides no flags.
@@ -49,12 +57,12 @@ To enable wrapping in a specific mode, add it to the appropriate hook in your
 (add-hook 'c-mode-common-hook #'+word-wrap-mode)
 #+END_SRC
 
-To customize the extra indent for a specific mode:
+To customize the behaviour in a specific mode:
 
 #+BEGIN_SRC emacs-lisp
-;; enable word-wrap with fixed extra 2 spaces in org-mode
-(add-hook! 'org-mode-hook
-  (setq-local +word-wrap-extra-indent 2)
+;; use a single indent in json-mode
+(add-hook! 'json-mode-hook
+  (setq-local +word-wrap-extra-indent 'single)
   (+word-wrap-mode +1))
 #+END_SRC
 

--- a/modules/editor/word-wrap/config.el
+++ b/modules/editor/word-wrap/config.el
@@ -1,15 +1,26 @@
 ;;; editor/word-wrap/config.el -*- lexical-binding: t; -*-
 
 (defvar +word-wrap-extra-indent 'double
-  "The amount of extra indentation for wrapped non-comment lines.
+  "The amount of extra indentation for wrapped code lines.
 
 When 'double, indent by twice the major-mode indentation.
 When 'single, indent by the major-mode indentation.
 When a positive integer, indent by this fixed amount.
 When a negative integer, dedent by this fixed amount.
+
 Otherwise no extra indentation will be used.")
 
 (defvar +word-wrap-disabled-modes
   '(fundamental-mode so-long-mode)
   "Major-modes where `+global-word-wrap-mode' should not enable
-  `+word-wrap-mode'.")
+`+word-wrap-mode'.")
+
+(defvar +word-wrap-visual-modes
+  '(org-mode)
+  "Major-modes where `+word-wrap-mode' should not use
+`adaptive-wrap-prefix-mode'.")
+
+(defvar +word-wrap-text-modes
+  '(text-mode markdown-mode markdown-view-mode gfm-mode gfm-view-mode rst-mode
+    latex-mode LaTeX-mode)
+  "Major-modes where `+word-wrap-mode' should not provide extra indentation.")


### PR DESCRIPTION
Adds `+word-wrap-text-modes`, a list of modes which shouldn't get any extra indentation. This is used for text and markdown modes, which should just indent to the parent depth.

Adds `+word-wrap-visual-modes`, a list of modes which shouldn't enable `adaptive-wrap-prefix-mode`. This is used to fix the prefix indentation in `org-mode`, which provides its own implementation.

Tweaks the indent behaviour to treat strings the same as comments so they don't receive additional indentation.