### PR TITLE
Add cython-specific flag and packages

### DIFF
--- a/modules/lang/python/README.org
+++ b/modules/lang/python/README.org
@@ -25,6 +25,7 @@ Adds Python support to Doom Emacs.
 + ~+lsp~ Language Server Protocol support
 + ~+pyenv~ Python virtual environment support via [[https://github.com/pyenv/pyenv][pyenv]]
 + ~+conda~ Python virtual environment support via [[https://conda.io/en/latest/][Conda]]
++ ~+cython~ Cython files support via [[https://github.com/cython/cython/blob/master/Tools/cython-mode.el][Cython-mode]]
 
 ** Plugins
 + [[https://github.com/pythonic-emacs/anaconda-mode][anaconda-mode]]*
@@ -43,6 +44,9 @@ Adds Python support to Doom Emacs.
 + ~+lsp~ and ~:tools lsp~
   + [[https://github.com/emacs-lsp/lsp-mode][lsp]]
   + [[https://github.com/emacs-lsp/lsp-python-ms][lsp-python-ms]]*
++ ~+cython~
+  + [[https://github.com/cython/cython/blob/master/Tools/cython-mode.el][Cython-mode]]
+  + ~:tools flycheck~ [[https://github.com/lbolla/emacs-flycheck-cython/tree/master][Flycheck-cython]]
 
 * Prerequisites
 This module has no direct prerequisites. Here are some of its soft dependencies.
@@ -62,6 +66,8 @@ This module has no direct prerequisites. Here are some of its soft dependencies.
   + [[https://conda.io/en/latest/][Conda]]
 
 + ~pipenv~ requires [[https://pipenv.readthedocs.io/en/latest/][pipenv]]
+
++ ~cython~ requires [[https://cython.org/][Cython]]
 
 ** Language Server Protocol Support
 Requires the ~+lsp~ flag and ~:tools lsp~ module to be enabled.
@@ -86,6 +92,7 @@ To enable support for auto-formatting with black enable ~:editor format-all~ in
 
 | Binding             | Description                      |
 |---------------------+----------------------------------|
+| ~<localleader> c c~ | ~Compile Cython buffer~          |
 | ~<localleader> i i~ | ~Insert mising imports~          |
 | ~<localleader> i r~ | ~Remove unused imports~          |
 | ~<localleader> i s~ | ~Sort imports~                   |

--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -277,18 +277,17 @@ called.")
     :override #'lsp-python-ms--command-string
     lsp-python-ms-executable))
 
+
 (use-package! cython-mode
   :when (featurep! +cython)
-  :mode (("\\.pyx\\'" . cython-mode)
-         ("\\.pxd\\'" . cython-mode)
-         ("\\.pxi\\'" . cython-mode))
+  :mode "\\.p\\(yx\\|x[di]\\)\\'"
   :config
   (setq cython-default-compile-format "cython -a %s")
   (map! :map cython-mode-map
         :localleader
         :prefix "c"
-        :desc "Cython compile buffer"    "c" #'cython-compile)
-  )
+        :desc "Cython compile buffer"    "c" #'cython-compile))
+
 
 (use-package! flycheck-cython
   :when (featurep! :tools flycheck)

--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -276,3 +276,20 @@ called.")
   (defadvice! +python--dont-auto-install-server-a ()
     :override #'lsp-python-ms--command-string
     lsp-python-ms-executable))
+
+(use-package! cython-mode
+  :when (featurep! +cython)
+  :mode (("\\.pyx\\'" . cython-mode)
+         ("\\.pxd\\'" . cython-mode)
+         ("\\.pxi\\'" . cython-mode))
+  :config
+  (setq cython-default-compile-format "cython -a %s")
+  (map! :map cython-mode-map
+        :localleader
+        :prefix "c"
+        :desc "Cython compile buffer"    "c" #'cython-compile)
+  )
+
+(use-package! flycheck-cython
+  :when (featurep! :tools flycheck)
+  :after cython-mode)

--- a/modules/lang/python/packages.el
+++ b/modules/lang/python/packages.el
@@ -3,6 +3,10 @@
 
 ;; Major modes
 (package! pip-requirements)
+(when (featurep! +cython)
+  (package! cython-mode)
+  (when (featurep! :tools flycheck)
+    (package! flycheck-cython)))
 
 ;; LSP
 (when (featurep! +lsp)


### PR DESCRIPTION
# Cython flag for Python mode

- [x] Ensure cython-mode is installed with`+cython` 
- [x] Ensure flycheck-cython is installed with `:tools flycheck`
- [x] Bindings for `cython-compile`
- [x] Add documentation about the flag and dependencies

Enable optional cython support in Python module