### PR TITLE
Add: evil bindings for 2 evil-mc functions

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -397,7 +397,9 @@
           :nv "q" #'evil-mc-undo-all-cursors
           :nv "t" #'+multiple-cursors/evil-mc-toggle-cursors
           :nv "u" #'evil-mc-undo-last-added-cursor
-          :nv "z" #'+multiple-cursors/evil-mc-make-cursor-here)
+          :nv "z" #'+multiple-cursors/evil-mc-make-cursor-here
+          :v  "I" #'evil-mc-make-cursor-in-visual-selection-beg
+          :v  "A" #'evil-mc-make-cursor-in-visual-selection-end)
         (:after evil-mc
           :map evil-mc-key-map
           :nv "C-n" #'evil-mc-make-and-goto-next-cursor

--- a/modules/editor/multiple-cursors/config.el
+++ b/modules/editor/multiple-cursors/config.el
@@ -9,6 +9,8 @@
              evil-mc-resume-cursors
              evil-mc-make-and-goto-first-cursor
              evil-mc-make-and-goto-last-cursor
+             evil-mc-make-cursor-in-visual-selection-beg
+             evil-mc-make-cursor-in-visual-selection-end
              evil-mc-make-cursor-move-next-line
              evil-mc-make-cursor-move-prev-line
              evil-mc-make-cursor-at-pos


### PR DESCRIPTION
Two useful functions added for evil-mc

`evil-mc-make-cursor-in-visual-selection-beg`
Create cursors at the beginning of every visually selected line.

`evil-mc-make-cursor-in-visual-selection-end`
Create cursors at the end of every visually selected line.
