### PR TITLE
Rename ivy-dispatching-done{-hydra,}

### DIFF
--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -148,10 +148,10 @@ evil-ex-specific constructs, so we disable it solely in evil-ex."
   (ivy-mode +1)
 
   (use-package! ivy-hydra
-    :commands (ivy-dispatching-done-hydra ivy--matcher-desc ivy-hydra/body)
+    :commands (ivy-dispatching-done ivy--matcher-desc ivy-hydra/body)
     :init
     (define-key! ivy-minibuffer-map
-      "C-o" #'ivy-dispatching-done-hydra
+      "C-o" #'ivy-dispatching-done
       "M-o" #'hydra-ivy/body)
     :config
     ;; ivy-hydra rebinds this, so we have to do so again


### PR DESCRIPTION
The Ivy command `ivy-dispatching-done-hydra` has been renamed to `ivy-dispatching-done` in this commit:

https://github.com/abo-abo/swiper/commit/1ad457d8e76c431783d2efb866ef51b8c14e7c82#diff-59c8f3240a0249f3809ead0286a450b7
