### PR TITLE
Add grip-mode for live markdown previews

### DIFF
--- a/modules/lang/markdown/README.org
+++ b/modules/lang/markdown/README.org
@@ -122,6 +122,8 @@ installed through your OS's package manager:
 non-evil users). This will open a preview of your compiled markdown document in
 your browser.
 
+Alternatively, you can use ~grip-mode~ through =+grip=.
+
 * Configuration
 ** Changing how markdown is compiled
 When ~markdown-preview~ is invoked (=SPC m b= or =C-c l b=), it consults

--- a/modules/lang/markdown/README.org
+++ b/modules/lang/markdown/README.org
@@ -118,7 +118,7 @@ installed through your OS's package manager:
 
 * Features
 ** Markdown preview
-~markdown-preview~ is bound to =SPC m b= (for Evil users) and =C-c l b= (for
+~markdown-preview~ is bound to =SPC m p= (for Evil users) and =C-c l p= (for
 non-evil users). This will open a preview of your compiled markdown document in
 your browser.
 

--- a/modules/lang/markdown/config.el
+++ b/modules/lang/markdown/config.el
@@ -69,6 +69,8 @@ capture, the end position, and the output buffer.")
           "o" #'markdown-open
           "p" #'markdown-preview
           "e" #'markdown-export
+          (:when (featurep! +grip)
+            "p" #'grip-mode)
           (:prefix ("i" . "insert")
             "t" #'markdown-toc-generate-toc
             "i" #'markdown-insert-image

--- a/modules/lang/markdown/doctor.el
+++ b/modules/lang/markdown/doctor.el
@@ -16,3 +16,7 @@
            (unless (executable-find cmd)
              (warn! "Couldn't find %S. markdown-preview command won't work"
                     cmd))))))
+
+(when (featurep! +grip)
+  (unless (executable-find "grip")
+    (warn! "Couldn't find grip. grip-mode will not work")))

--- a/modules/lang/markdown/packages.el
+++ b/modules/lang/markdown/packages.el
@@ -4,3 +4,6 @@
 (package! markdown-mode)
 (package! markdown-toc)
 (package! edit-indirect)
+
+(when (featurep! +grip)
+  (package! grip-mode))


### PR DESCRIPTION
This adds support for [grip-mode](https://github.com/seagle0128/grip-mode) through `+grip`.
Also, fixing up some stale documentation for markdown here.

Happy to make any changes!