### PR TITLE
[coq] disable electric proof terminators

### DIFF
--- a/modules/lang/coq/config.el
+++ b/modules/lang/coq/config.el
@@ -13,8 +13,6 @@
 
 
 ;;;###package coq
-(setq proof-electric-terminator-enable t)
-
 ;; Doom syncs other indent variables with `tab-width'; we are trusting major
 ;; modes to set it -- which most of them do -- but coq-mode doesn't, so...
 (setq-hook! 'coq-mode-hook tab-width proof-indent)


### PR DESCRIPTION
These send input to coq too agressively. It's often the case that this
causes delays in coq.