### PR TITLE
Restore save file binding on SPC f s

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -647,7 +647,8 @@
         :desc "Browse private config"       "P"   #'doom/open-private-config
         :desc "Recent files"                "r"   #'recentf-open-files
         :desc "Recent project files"        "R"   #'projectile-recentf
-        :desc "Save file"                   "s"   #'write-file
+        :desc "Save file"                   "s"   #'save-buffer
+        :desc "Save file as..."             "S"   #'write-file
         :desc "Sudo find file"              "u"   #'doom/sudo-find-file
         :desc "Yank filename"               "y"   #'+default/yank-buffer-filename)
 


### PR DESCRIPTION
Put `save-buffer` back on `SPC f s` to save without prompt, and add `write-file` as `SPC f S` for saving with prompt for filename.

Fixes #1923