### PR TITLE
Add support for go-gen-test for go-mode

### DIFF
--- a/modules/lang/go/README.org
+++ b/modules/lang/go/README.org
@@ -26,6 +26,7 @@ This module adds [[https://golang.org][Go]] support.
 + Code navigation & refactoring (~go-guru~)
 + [[../../editor/file-templates/templates/go-mode][File templates]]
 + [[https://github.com/hlissner/doom-snippets/tree/master/go-mode][Snippets]]
++ Generate testing code (~go-gen-test~)
 
 ** Module Flags
 This module provides no flags.
@@ -37,6 +38,7 @@ This module provides no flags.
 + [[https://github.com/manute/gorepl-mode][gorepl-mode]]
 + [[https://github.com/syohex/emacs-go-add-tags][go-add-tags]]
 + [[https://github.com/mdempsky/gocode][company-go]]*
++ [[https://github.com/s-kostyaev/go-gen-test][go-gen-test]]
 
 * Prerequisites
 ** Go
@@ -66,6 +68,7 @@ This module requires a valid ~GOPATH~, and the following Go packages:
 + ~gore~ (for the REPL)
 + ~guru~ (for code navigation & refactoring commands)
 + ~goimports~ (optional: for auto-formatting code on save & fixing imports)
++ ~gotests~ (for generate test code)
 
 #+BEGIN_SRC sh
 export GOPATH=~/work/go
@@ -76,6 +79,7 @@ go get -u golang.org/x/tools/cmd/godoc
 go get -u golang.org/x/tools/cmd/goimports
 go get -u golang.org/x/tools/cmd/gorename
 go get -u golang.org/x/tools/cmd/guru
+go get -u github.com/cweill/gotests/...
 #+END_SRC
 
 * TODO Features

--- a/modules/lang/go/config.el
+++ b/modules/lang/go/config.el
@@ -51,11 +51,10 @@
           "t" #'+go/test-rerun
           "a" #'+go/test-all
           "s" #'+go/test-single
-          "n" #'+go/test-nested)
-        (:prefix ("gt" . "gen-test")
-          "d" #'go-gen-test-dwim         ; Generate tests for functions you want to.
-          "a" #'go-gen-test-all          ; Generate tests for all functions.
-          "e" #'go-gen-test-exported)))  ; Generate tests for all exported functions.
+          "n" #'+go/test-nested
+          "g" #'go-gen-test-dwim
+          "G" #'go-gen-test-all
+          "e" #'go-gen-test-exported)))
 
 
 (use-package! gorepl-mode

--- a/modules/lang/go/config.el
+++ b/modules/lang/go/config.el
@@ -51,7 +51,11 @@
           "t" #'+go/test-rerun
           "a" #'+go/test-all
           "s" #'+go/test-single
-          "n" #'+go/test-nested)))
+          "n" #'+go/test-nested)
+        (:prefix ("gt" . "gen-test")
+          "d" #'go-gen-test-dwim         ; Generate tests for functions you want to.
+          "a" #'go-gen-test-all          ; Generate tests for all functions.
+          "e" #'go-gen-test-exported)))  ; Generate tests for all exported functions.
 
 
 (use-package! gorepl-mode

--- a/modules/lang/go/doctor.el
+++ b/modules/lang/go/doctor.el
@@ -11,6 +11,9 @@
 (unless (executable-find "gore")
   (warn! "Couldn't find gore. REPL will not work"))
 
+(unless (executable-find "gotests")
+  (warn! "Couldn't find gotests. Generating tests will not work"))
+
 (when (featurep! :completion company)
   (require 'company-go)
   (unless (executable-find company-go-gocode-command)

--- a/modules/lang/go/packages.el
+++ b/modules/lang/go/packages.el
@@ -6,6 +6,7 @@
 (package! go-mode)
 (package! gorepl-mode)
 (package! go-add-tags)
+(package! go-gen-test)
 
 (when (featurep! :completion company)
   (package! company-go))


### PR DESCRIPTION
Hello. This pull request add the package [go-gen-test](https://github.com/s-kostyaev/go-gen-test) to :lang go module.
I customized doom config for this feature, but I thought it would be more useful if it was supported by default, so I created this PR.