### PR TITLE
[ocaml] disable more features with lsp

### DIFF
--- a/modules/lang/ocaml/packages.el
+++ b/modules/lang/ocaml/packages.el
@@ -9,7 +9,7 @@
 
 (package! ocp-indent)
 
-(when (and (featurep! :tools flycheck) (not (featurep :lsp)))
+(when (and (featurep! :tools flycheck) (not (featurep +lsp)))
   (package! flycheck-ocaml))
 
 (when (featurep! :tools eval)

--- a/modules/lang/ocaml/packages.el
+++ b/modules/lang/ocaml/packages.el
@@ -5,12 +5,11 @@
 
 (unless (featurep! +lsp)
   (package! merlin)
-  (package! merlin-eldoc))
+  (package! merlin-eldoc)
+  (when (featurep! :tools flycheck)
+    (package! flycheck-ocaml)))
 
 (package! ocp-indent)
-
-(when (and (featurep! :tools flycheck) (not (featurep +lsp)))
-  (package! flycheck-ocaml))
 
 (when (featurep! :tools eval)
   (package! utop))

--- a/modules/lang/ocaml/packages.el
+++ b/modules/lang/ocaml/packages.el
@@ -2,11 +2,14 @@
 ;;; lang/ocaml/packages.el
 
 (package! tuareg)
-(package! merlin)
-(package! merlin-eldoc)
+
+(unless (featurep! +lsp)
+  (package! merlin)
+  (package! merlin-eldoc))
+
 (package! ocp-indent)
 
-(when (featurep! :tools flycheck)
+(when (and (featurep! :tools flycheck) (not (featurep :lsp)))
   (package! flycheck-ocaml))
 
 (when (featurep! :tools eval)


### PR DESCRIPTION
merlin, merlin-eldoc, merlin-flycheck are all unnecessary when lsp is
turned on