### PR TITLE
Expand notmuch features

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,16 +63,21 @@ to learn more about our favorite OS.
 ## Doom's mantras
 
 - **Gotta go fast.** Startup and run-time performance are high priorities.
-  Expensive plugins and functionality is modified and optimized toward this end,
-  otherwise, they must be opt-in.
+  Expensive functionality (built-in or in plugins) is modified and optimized
+  toward this end, otherwise, they must be opt-in.
 - **Close to metal.** There's less between you and vanilla Emacs, by design.
   There's less to grok. Modules should be syntactically sweet and backend logic
   explicit and abstraction-light. The code itself ought to be designed as if
-  reading it were part of the user experience; and it is!
+  grokking it were part of the user experience; and it is!
 - **Opinionated, but not stubborn.** Doom is a bundle of reasonable defaults
   and curated opinions, but you aren't stuck with it. Use as little or as much
   of it as you like. Use it as-is as a complete Emacs distribution; disable
   everything and use it as a baseline for your own; or anywhere in between.
+- **Your system, your rules.** There are more ways to set up your programming
+  environment than there are dislikes on Youtube Rewind '18, so Doom and its
+  plugins promise not to *automatically* (and definitely not *silently*) install
+  system dependencies. This means fonts, packages and programs. `doom doctor`
+  will tell you what's missing though!
 
 ## Features
 

--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -63,8 +63,6 @@ immediately runs it on the current candidate (ending the ivy session)."
         ivy-wrap t
         ivy-fixed-height-minibuffer t
         projectile-completion-system 'ivy
-        ;; Remove ./ and ../ from file commands
-        ivy-extra-directories nil
         ;; disable magic slash on non-match
         ivy-magic-slash-non-match-action nil
         ;; don't show recent files in switch-buffer

--- a/modules/editor/multiple-cursors/autoload/evil-mc.el
+++ b/modules/editor/multiple-cursors/autoload/evil-mc.el
@@ -32,7 +32,8 @@ pauses cursors."
            (save-excursion
              (evil-apply-on-block
               (lambda (ibeg _)
-                (unless (= line-at-pt (line-number-at-pos ibeg))
+                (unless (or (= line-at-pt (line-number-at-pos ibeg))
+                            (invisible-p ibeg))
                   (goto-char ibeg)
                   (move-to-column col)
                   (when (= (current-column) col)

--- a/modules/email/notmuch/autoload.el
+++ b/modules/email/notmuch/autoload.el
@@ -57,6 +57,13 @@
   (notmuch-tree-next-message))
 
 ;;;###autoload
+(defun +notmuch/show-delete ()
+  "Mark email for deletion in notmuch-show"
+  (interactive)
+  (notmuch-show-add-tag (list "+trash" "-inbox" "-unread"))
+  (notmuch-show-next-thread-show))
+
+;;;###autoload
 (defun +notmuch/search-spam ()
   (interactive)
   (notmuch-search-add-tag (list "+spam" "-inbox" "-unread"))

--- a/modules/email/notmuch/autoload.el
+++ b/modules/email/notmuch/autoload.el
@@ -119,7 +119,7 @@
   (notmuch-show-refresh-view t))
 
 ;;;###autoload
-(defun +notmuch-expand-only-unread-h ()
+(defun +notmuch-show-expand-only-unread-h ()
   (interactive)
   (let ((unread nil)
         (open (notmuch-show-get-message-ids-for-open-messages)))
@@ -127,7 +127,7 @@
                          (when (member "unread" (notmuch-show-get-tags))
                            (setq unread t))))
     (when unread
-      (let ((notmuch-show-hook (remove '+notmuch/expand-only-unread-hook notmuch-show-hook)))
+      (let ((notmuch-show-hook (remove '+notmuch-show-expand-only-unread-h notmuch-show-hook)))
         (notmuch-show-filter-thread "tag:unread")))))
 
 ;;

--- a/modules/email/notmuch/autoload.el
+++ b/modules/email/notmuch/autoload.el
@@ -92,6 +92,25 @@
     (start-process-shell-command "email" nil (format "xdg-open '%s'" temp))))
 
 
+;;;###autoload
+(defun +notmuch/show-filter-thread ()
+  "Show the current thread with a different filter"
+  (interactive)
+  (setq notmuch-show-query-context (notmuch-read-query "Filter thread: "))
+  (notmuch-show-refresh-view t))
+
+;;;###autoload
+(defun +notmuch-expand-only-unread-h ()
+  (interactive)
+  (let ((unread nil)
+        (open (notmuch-show-get-message-ids-for-open-messages)))
+    (notmuch-show-mapc (lambda ()
+                         (when (member "unread" (notmuch-show-get-tags))
+                           (setq unread t))))
+    (when unread
+      (let ((notmuch-show-hook (remove '+notmuch/expand-only-unread-hook notmuch-show-hook)))
+        (notmuch-show-filter-thread "tag:unread")))))
+
 ;;
 ;; Advice
 

--- a/modules/email/notmuch/autoload.el
+++ b/modules/email/notmuch/autoload.el
@@ -87,6 +87,14 @@
   (notmuch-tree-next-message))
 
 ;;;###autoload
+(defun +notmuch/ivy-compose ()
+  "Compose new mail"
+  (interactive)
+  (ivy-read "From: "
+            (notmuch-user-emails)
+            :action (lambda (selection) (notmuch-mua-mail nil nil (list (cons 'From selection))))))
+
+;;;###autoload
 (defun +notmuch/open-message-with-mail-app-notmuch-tree ()
   (interactive)
   (let* ((msg-path (car (plist-get (notmuch-tree-get-message-properties) :filename)))

--- a/modules/email/notmuch/config.el
+++ b/modules/email/notmuch/config.el
@@ -5,6 +5,9 @@
 (defvar +notmuch-sync-backend 'gmi
   "Which backend to use. Can be either gmi, mbsync, offlineimap or nil (manual).")
 
+(defvar +notmuch-sync-command nil
+  "Command for custom notmuch sync")
+
 (defvar +notmuch-mail-folder "~/.mail/account.gmail"
   "Where your email folder is located (for use with gmailieer).")
 

--- a/modules/email/notmuch/config.el
+++ b/modules/email/notmuch/config.el
@@ -42,6 +42,9 @@
 
   ;; (setq-hook! 'notmuch-show-mode-hook line-spacing 0)
 
+  ;; only unfold unread messages in thread by default
+  (add-hook 'notmuch-show-hook '+notmuch-expand-only-unread-h)
+
   (add-hook 'doom-real-buffer-functions #'notmuch-interesting-buffer)
 
   (advice-add #'notmuch-start-notmuch-sentinel :around #'+notmuch-dont-confirm-on-kill-process-a)

--- a/modules/email/notmuch/config.el
+++ b/modules/email/notmuch/config.el
@@ -46,7 +46,7 @@
   ;; (setq-hook! 'notmuch-show-mode-hook line-spacing 0)
 
   ;; only unfold unread messages in thread by default
-  (add-hook 'notmuch-show-hook '+notmuch-expand-only-unread-h)
+  (add-hook 'notmuch-show-hook '+notmuch-show-expand-only-unread-h)
 
   (add-hook 'doom-real-buffer-functions #'notmuch-interesting-buffer)
 

--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -58,7 +58,6 @@ If no viewers are found, `latex-preview-pane' is used.")
   (add-hook 'TeX-update-style-hook #'rainbow-delimiters-mode)
   ;; display output of latex commands in popup
   (set-popup-rule! " output\\*$" :size 15)
-  (add-hook 'latex-mode-local-vars-hook #'flyspell-mode!)
   (after! smartparens-latex
     (let ((modes '(tex-mode plain-tex-mode latex-mode LaTeX-mode)))
       ;; All these excess pairs dramatically slow down typing in latex buffers,

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -883,9 +883,7 @@ compelling reason, so..."
     :init
     (setq org-clock-persist t
           ;; Resume when clocking into task with open clock
-          org-clock-in-resume t
-          ;; Remove log if task ends up with 0:00 on the clock
-          org-clock-out-remove-zero-time-clocks t)
+          org-clock-in-resume t)
 
     (defadvice! +org--clock-load-a (&rest _)
       "Lazy load org-clock until its commands are used."

--- a/modules/tools/lsp/config.el
+++ b/modules/tools/lsp/config.el
@@ -21,6 +21,11 @@ This can be a single company backend or a list thereof. It can be anything
   ;; project.
   (setq lsp-keep-workspace-alive nil)
 
+  ;; For `lsp-clients'
+  (setq lsp-fsharp-server-install-dir (concat doom-etc-dir "lsp-fsharp/")
+        lsp-groovy-server-install-dir (concat doom-etc-dir "lsp-groovy/")
+        lsp-intelephense-storage-path (concat doom-cache-dir "lsp-intelephense/"))
+
   :config
   (set-lookup-handlers! 'lsp-mode :async t
     :documentation 'lsp-describe-thing-at-point
@@ -141,19 +146,3 @@ Also logs the resolved project root, if found."
         (remove-hook 'company-mode-hook #'+lsp-init-company-h t))))
   :config
   (setq company-lsp-cache-candidates 'auto)) ;; cache candidates for better performance
-
-
-(after! lsp-clients
-  (setq lsp-fsharp-server-install-dir (concat doom-etc-dir "lsp-fsharp/")
-        lsp-groovy-server-install-dir (concat doom-etc-dir "lsp-groovy/")
-        lsp-intelephense-storage-path (concat doom-cache-dir "lsp-intelephense/"))
-
-  (defadvice! +lsp-activate-for-js-shell-scripts-a (filename &optional _)
-    :after-until #'lsp-typescript-javascript-tsx-jsx-activate-p
-    (when (file-readable-p filename)
-      (with-temp-buffer
-        (insert-file-contents filename nil 0 64)
-        (save-match-data
-          (goto-char (point-min))
-          (and (looking-at "#![ \t]?\\([^ \t\n]*/bin/env[ \t]\\)?\\([^ \t\n]+\\)")
-               (member (match-string 2) '("node" "rhino" "gjs" "nodejs"))))))))

--- a/modules/ui/modeline/config.el
+++ b/modules/ui/modeline/config.el
@@ -66,7 +66,7 @@
 
   (doom-modeline-def-modeline 'project
     '(bar window-number buffer-default-directory)
-    '(misc-info mu4e github debug fancy-battery " " major-mode process))
+    '(misc-info mu4e github debug battery " " major-mode process))
 
   ;; Some functions modify the buffer, causing the modeline to show a false
   ;; modified state, so force them to behave.

--- a/modules/ui/modeline/config.el
+++ b/modules/ui/modeline/config.el
@@ -42,6 +42,7 @@
     ;; Fix #1216 and seagle0128/doom-modeline#69: wrong icon displayed for
     ;; 'save' icon in modeline.
     (defadvice! +modeline-fix-font-conflict-with-ligatures-a (icon-name &rest args)
+      :override #'doom-modeline-icon-material
       (when doom-modeline-icon
         (pcase (car args)
           ("save" (apply 'all-the-icons-faicon (cons "floppy-o" (plist-put (cdr args) :v-adjust -0.0575))))


### PR DESCRIPTION
This PR adds various features to the notmuch module

- Filter read messages in notmuch show (by folding them automatically)
- Refresh all notmuch buffers after sync (via process sentinel)
- Support custom sync commands (introduces an additional defvar)
- Add command to select From email prior to composing via ivy

I wasn't sure if you prefer separate diff or one big diff. Please let me know if you want me to split this into separate PRs.
