### PR TITLE
ui/modeline: fix ligature advice for hlissner#1216

### DIFF
--- a/modules/ui/modeline/config.el
+++ b/modules/ui/modeline/config.el
@@ -41,7 +41,7 @@
             (featurep! :ui pretty-code +iosevka))
     ;; Fix #1216 and seagle0128/doom-modeline#69: wrong icon displayed for
     ;; 'save' icon in modeline.
-    (defadvice! +modeline-fix-font-conflict-with-ligatures-a (icon-name &rest args)
+    (defadvice! +modeline-fix-font-conflict-with-ligatures-a (&rest args)
       :override #'doom-modeline-icon-material
       (when doom-modeline-icon
         (pcase (car args)


### PR DESCRIPTION
The advice was pulling in an `icon-name` in the args list but the whole body considers `args` as containing everything. So now `args` contains everything.
