### PR TITLE
Improvements to notmuch module

### DIFF
--- a/modules/email/notmuch/autoload.el
+++ b/modules/email/notmuch/autoload.el
@@ -87,12 +87,13 @@
   (notmuch-tree-next-message))
 
 ;;;###autoload
-(defun +notmuch/ivy-compose ()
+(defun +notmuch/compose ()
   "Compose new mail"
   (interactive)
-  (ivy-read "From: "
-            (notmuch-user-emails)
-            :action (lambda (selection) (notmuch-mua-mail nil nil (list (cons 'From selection))))))
+  (notmuch-mua-mail
+   nil
+   nil
+   (list (cons 'From  (completing-read "From: " (notmuch-user-emails))))))
 
 ;;;###autoload
 (defun +notmuch/open-message-with-mail-app-notmuch-tree ()

--- a/modules/email/notmuch/autoload.el
+++ b/modules/email/notmuch/autoload.el
@@ -57,6 +57,13 @@
   (notmuch-tree-next-message))
 
 ;;;###autoload
+(defun +notmuch/show-delete ()
+  "Mark email for deletion in notmuch-show"
+  (interactive)
+  (notmuch-show-add-tag (list "+trash" "-inbox" "-unread"))
+  (notmuch-show-next-thread-show))
+
+;;;###autoload
 (defun +notmuch/search-spam ()
   (interactive)
   (notmuch-search-add-tag (list "+spam" "-inbox" "-unread"))

--- a/modules/email/notmuch/autoload.el
+++ b/modules/email/notmuch/autoload.el
@@ -119,7 +119,7 @@
   (notmuch-show-refresh-view t))
 
 ;;;###autoload
-(defun +notmuch-expand-only-unread-h ()
+(defun +notmuch-show-expand-only-unread-h ()
   (interactive)
   (let ((unread nil)
         (open (notmuch-show-get-message-ids-for-open-messages)))
@@ -127,7 +127,7 @@
                          (when (member "unread" (notmuch-show-get-tags))
                            (setq unread t))))
     (when unread
-      (let ((notmuch-show-hook (remove '+notmuch/expand-only-unread-hook notmuch-show-hook)))
+      (let ((notmuch-show-hook (remove '+notmuch-show-expand-only-unread-h notmuch-show-hook)))
         (notmuch-show-filter-thread "tag:unread")))))
 
 ;;

--- a/modules/email/notmuch/autoload.el
+++ b/modules/email/notmuch/autoload.el
@@ -92,6 +92,25 @@
     (start-process-shell-command "email" nil (format "xdg-open '%s'" temp))))
 
 
+;;;###autoload
+(defun +notmuch/show-filter-thread ()
+  "Show the current thread with a different filter"
+  (interactive)
+  (setq notmuch-show-query-context (notmuch-read-query "Filter thread: "))
+  (notmuch-show-refresh-view t))
+
+;;;###autoload
+(defun +notmuch-expand-only-unread-h ()
+  (interactive)
+  (let ((unread nil)
+        (open (notmuch-show-get-message-ids-for-open-messages)))
+    (notmuch-show-mapc (lambda ()
+                         (when (member "unread" (notmuch-show-get-tags))
+                           (setq unread t))))
+    (when unread
+      (let ((notmuch-show-hook (remove '+notmuch/expand-only-unread-hook notmuch-show-hook)))
+        (notmuch-show-filter-thread "tag:unread")))))
+
 ;;
 ;; Advice
 

--- a/modules/email/notmuch/autoload.el
+++ b/modules/email/notmuch/autoload.el
@@ -87,6 +87,14 @@
   (notmuch-tree-next-message))
 
 ;;;###autoload
+(defun +notmuch/ivy-compose ()
+  "Compose new mail"
+  (interactive)
+  (ivy-read "From: "
+            (notmuch-user-emails)
+            :action (lambda (selection) (notmuch-mua-mail nil nil (list (cons 'From selection))))))
+
+;;;###autoload
 (defun +notmuch/open-message-with-mail-app-notmuch-tree ()
   (interactive)
   (let* ((msg-path (car (plist-get (notmuch-tree-get-message-properties) :filename)))

--- a/modules/email/notmuch/config.el
+++ b/modules/email/notmuch/config.el
@@ -46,7 +46,7 @@
   ;; (setq-hook! 'notmuch-show-mode-hook line-spacing 0)
 
   ;; only unfold unread messages in thread by default
-  (add-hook 'notmuch-show-hook '+notmuch-show-expand-only-unread-h)
+  (add-hook 'notmuch-show-hook #'+notmuch-show-expand-only-unread-h)
 
   (add-hook 'doom-real-buffer-functions #'notmuch-interesting-buffer)
 

--- a/modules/email/notmuch/config.el
+++ b/modules/email/notmuch/config.el
@@ -66,10 +66,10 @@
    :desc "quit notmuch" "q" #'+notmuch/quit
    :map notmuch-search-mode-map
    :desc "mark as deleted" "d" #'+notmuch/search-delete
-   :desc "mark as spam" "d" #'+notmuch/search-spam
+   :desc "mark as spam" "s" #'+notmuch/search-spam
    :map notmuch-tree-mode-map
    :desc "mark as deleted" "d" #'+notmuch/tree-delete
-   :desc "mark as spam" "d" #'+notmuch/tree-spam))
+   :desc "mark as spam" "s" #'+notmuch/tree-spam))
 
 
 (use-package! org-mime

--- a/modules/email/notmuch/config.el
+++ b/modules/email/notmuch/config.el
@@ -5,6 +5,9 @@
 (defvar +notmuch-sync-backend 'gmi
   "Which backend to use. Can be either gmi, mbsync, offlineimap or nil (manual).")
 
+(defvar +notmuch-sync-command nil
+  "Command for custom notmuch sync")
+
 (defvar +notmuch-mail-folder "~/.mail/account.gmail"
   "Where your email folder is located (for use with gmailieer).")
 

--- a/modules/email/notmuch/config.el
+++ b/modules/email/notmuch/config.el
@@ -42,6 +42,9 @@
 
   ;; (setq-hook! 'notmuch-show-mode-hook line-spacing 0)
 
+  ;; only unfold unread messages in thread by default
+  (add-hook 'notmuch-show-hook '+notmuch-expand-only-unread-h)
+
   (add-hook 'doom-real-buffer-functions #'notmuch-interesting-buffer)
 
   (advice-add #'notmuch-start-notmuch-sentinel :around #'+notmuch-dont-confirm-on-kill-process-a)

--- a/modules/email/notmuch/config.el
+++ b/modules/email/notmuch/config.el
@@ -56,7 +56,20 @@
   (add-hook! '(notmuch-show-mode-hook
                notmuch-tree-mode-hook
                notmuch-search-mode-hook)
-             #'hide-mode-line-mode))
+             #'hide-mode-line-mode)
+ 
+  (map!
+   :localleader
+   :map (notmuch-search-mode-map notmuch-tree-mode-map notmuch-show-mode-map)
+   :desc "compose email" "c" #'+notmuch/compose
+   :desc "fetch new email" "u" #'+notmuch/update
+   :desc "quit notmuch" "q" #'+notmuch/quit
+   :map notmuch-search-mode-map
+   :desc "mark as deleted" "d" #'+notmuch/search-delete
+   :desc "mark as spam" "d" #'+notmuch/search-spam
+   :map notmuch-tree-mode-map
+   :desc "mark as deleted" "d" #'+notmuch/tree-delete
+   :desc "mark as spam" "d" #'+notmuch/tree-spam))
 
 
 (use-package! org-mime
@@ -73,4 +86,3 @@
   :when (featurep! :completion helm)
   :commands helm-notmuch
   :after notmuch)
-

--- a/modules/email/notmuch/config.el
+++ b/modules/email/notmuch/config.el
@@ -46,7 +46,7 @@
   ;; (setq-hook! 'notmuch-show-mode-hook line-spacing 0)
 
   ;; only unfold unread messages in thread by default
-  (add-hook 'notmuch-show-hook '+notmuch-expand-only-unread-h)
+  (add-hook 'notmuch-show-hook '+notmuch-show-expand-only-unread-h)
 
   (add-hook 'doom-real-buffer-functions #'notmuch-interesting-buffer)
 


### PR DESCRIPTION
This PR adds various features to the notmuch module

- Filter read messages in notmuch show (by folding them automatically)
- Refresh all notmuch buffers after sync (via process sentinel)
- Support custom sync commands (introduces an additional defvar)
- Add command to select From email prior to composing via ivy

I wasn't sure if you prefer separate diff or one big diff. Please let me know if you want me to split this into separate PRs.
