### PR TITLE
[org +gnuplot] Warn if gnuplot is not installed

### DIFF
--- a/modules/lang/org/doctor.el
+++ b/modules/lang/org/doctor.el
@@ -1,0 +1,6 @@
+;; -*- lexical-binding: t; no-byte-compile: t; -*-
+;;; lang/org/doctor.el
+
+(when (featurep! +gnuplot)
+  (unless (executable-find "gnuplot")
+    (warn! "Couldn't find gnuplot. org-plot/gnuplot will not work")))


### PR DESCRIPTION
`doom doctor` should catch `gnuplot` not being installed when the `+gnuplot` feature is enabled.