### PR TITLE
Add an FAQ action to doom-dashboard

### DIFF
--- a/modules/ui/doom-dashboard/config.el
+++ b/modules/ui/doom-dashboard/config.el
@@ -69,8 +69,6 @@ Possible values:
      :action doom/open-private-config)
     ("Search Documentation"
      :icon (all-the-icons-octicon "book" :face 'font-lock-keyword-face)
-     :when (or (file-exists-p (expand-file-name "faq.org" doom-docs-dir))
-               (file-exists-p (expand-file-name "index.org" doom-docs-dir)))
      :action doom/help-search))
   "An alist of menu buttons used by `doom-dashboard-widget-shortmenu'. Each
 element is a cons cell (LABEL . PLIST). LABEL is a string to display after the

--- a/modules/ui/doom-dashboard/config.el
+++ b/modules/ui/doom-dashboard/config.el
@@ -69,10 +69,13 @@ Possible values:
      :action doom/open-private-config)
     ("Search Documentation"
      :icon (all-the-icons-octicon "book" :face 'font-lock-keyword-face)
-     :when (or (file-exists-p (expand-file-name "faq.org" doom-docs-dir))
-               (file-exists-p (expand-file-name "index.org" doom-docs-dir)))
-     :action (if (file-exists-p (expand-file-name "index.org" doom-docs-dir))
-                 doom/help-search doom/help-faq)))
+     :when (and (file-exists-p (expand-file-name "faq.org" doom-docs-dir))
+                (not (file-exists-p (expand-file-name "index.org" doom-docs-dir))))
+     :action doom/help-faq)
+    ("Search Documentation"
+     :icon (all-the-icons-octicon "book" :face 'font-lock-keyword-face)
+     :when (file-exists-p (expand-file-name "index.org" doom-docs-dir))
+     :action doom/help-search))
   "An alist of menu buttons used by `doom-dashboard-widget-shortmenu'. Each
 element is a cons cell (LABEL . PLIST). LABEL is a string to display after the
 icon and before the key string.

--- a/modules/ui/doom-dashboard/config.el
+++ b/modules/ui/doom-dashboard/config.el
@@ -67,10 +67,12 @@ Possible values:
      :icon (all-the-icons-octicon "tools" :face 'font-lock-keyword-face)
      :when (file-directory-p doom-private-dir)
      :action doom/open-private-config)
-    ("Open user manual"
+    ("Search Documentation"
      :icon (all-the-icons-octicon "book" :face 'font-lock-keyword-face)
-     :when (file-exists-p (expand-file-name "index.org" doom-docs-dir))
-     :action doom/help-search))
+     :when (or (file-exists-p (expand-file-name "faq.org" doom-docs-dir))
+               (file-exists-p (expand-file-name "index.org" doom-docs-dir)))
+     :action (if (file-exists-p (expand-file-name "index.org" doom-docs-dir))
+                 doom/help-search doom/help-faq)))
   "An alist of menu buttons used by `doom-dashboard-widget-shortmenu'. Each
 element is a cons cell (LABEL . PLIST). LABEL is a string to display after the
 icon and before the key string.

--- a/modules/ui/doom-dashboard/config.el
+++ b/modules/ui/doom-dashboard/config.el
@@ -69,12 +69,8 @@ Possible values:
      :action doom/open-private-config)
     ("Search Documentation"
      :icon (all-the-icons-octicon "book" :face 'font-lock-keyword-face)
-     :when (and (file-exists-p (expand-file-name "faq.org" doom-docs-dir))
-                (not (file-exists-p (expand-file-name "index.org" doom-docs-dir))))
-     :action doom/help-faq)
-    ("Search Documentation"
-     :icon (all-the-icons-octicon "book" :face 'font-lock-keyword-face)
-     :when (file-exists-p (expand-file-name "index.org" doom-docs-dir))
+     :when (or (file-exists-p (expand-file-name "faq.org" doom-docs-dir))
+               (file-exists-p (expand-file-name "index.org" doom-docs-dir)))
      :action doom/help-search))
   "An alist of menu buttons used by `doom-dashboard-widget-shortmenu'. Each
 element is a cons cell (LABEL . PLIST). LABEL is a string to display after the


### PR DESCRIPTION
# Add FAQ to doom-dashboard

I keep forgetting that there's a searchable FAQ, and I thought that having it on the dashboard was the best place : first screen someone sees when opening Doom. Especially until the user manual is not done, I discovered that while adding the menu item

Feel free to change the wording/icon if you think something else should be used
