### PR TITLE
[config] which-key descriptions for prefixes

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -627,3 +627,9 @@
         (:when (featurep! :lang org +pomodoro)
           :desc "Pomodoro timer"             "t" #'org-pomodoro)
         :desc "Word-wrap mode"               "w" #'+word-wrap-mode))
+
+(after! which-key
+  (let ((prefix-re (regexp-opt (list doom-leader-key doom-leader-alt-key))))
+    (cl-pushnew `((,(format "\\`\\(?:C-w\\|%s w\\) m\\'" prefix-re))
+                  nil . "maximize")
+                which-key-replacement-alist)))

--- a/modules/config/default/config.el
+++ b/modules/config/default/config.el
@@ -342,10 +342,10 @@
 
 (after! which-key
   (let ((prefix-re (regexp-opt (list doom-leader-key doom-leader-alt-key))))
-    (cl-pushnew `((,(format "\\`\\(?:<\\(?:\\(?:f1\\|help\\)>\\)\\|%s h\\) d\\'" prefix-re))
+    (cl-pushnew `((,(format "\\`\\(?:<\\(?:\\(?:f1\\|help\\)>\\)\\|C-h\\|%s h\\) d\\'" prefix-re))
                   nil . "doom")
                 which-key-replacement-alist)
-    (cl-pushnew `((,(format "\\`\\(?:<\\(?:\\(?:f1\\|help\\)>\\)\\|%s h\\) r\\'" prefix-re))
+    (cl-pushnew `((,(format "\\`\\(?:<\\(?:\\(?:f1\\|help\\)>\\)\\|C-h\\|%s h\\) r\\'" prefix-re))
                   nil . "reload")
                 which-key-replacement-alist)))
 


### PR DESCRIPTION
`SPC w m` did not have a prefix.
~~Neither did `SPC h d` and `SPC h r`~~

~~I used a variable to define the help key to avoid hard-coding to `h`. I don't know if it's the smartest choice.~~

~~(I also don't really know why the help-map is not mapped with `map!` but I left it like that)~~