### PR TITLE
add key binding for commenting code

### DIFF
--- a/core/autoload/text.el
+++ b/core/autoload/text.el
@@ -245,6 +245,16 @@ editorconfig or dtrt-indent installed."
            (set var width))))
   (message "Changed indentation to %d" width))
 
+;;;###autoload
+(defun toggle-comment-region-or-line ()
+  "Comments or uncomments the region or the current line if there's no active region."
+  (interactive)
+  (let (beg end)
+    (if (region-active-p)
+        (setq beg (region-beginning) end (region-end))
+      (setq beg (line-beginning-position) end (line-end-position)))
+    (comment-or-uncomment-region beg end)
+    ))
 
 ;;
 ;;; Hooks

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -347,6 +347,7 @@
 
       ;;; <leader> c --- code
       (:prefix-map ("c" . "code")
+        :desc "Toggle comment"              "/"   #'toggle-comment-region-or-line
         :desc "Compile"                     "c"   #'compile
         :desc "Recompile"                   "C"   #'recompile
         :desc "Jump to definition"          "d"   #'+lookup/definition


### PR DESCRIPTION
This PR adds a bindig to `<leader> c /` for comment/uncommenting code. I use this quite frequently so I thought it can be beneficial to others too.