### PR TITLE
doc - fix instruction on removing +org-cycle-only-current-subtree-h

### DIFF
--- a/modules/lang/org/README.org
+++ b/modules/lang/org/README.org
@@ -119,8 +119,8 @@ https://www.mfoot.com/blog/2015/11/22/literate-emacs-configuration-with-org-mode
   rather than cycle through it recursively. This can be reversed with:
 
   #+BEGIN_SRC emacs-lisp
-  (after! org
-    (remove-hook 'org-tab-first-hook #'+org-cycle-only-current-subtree-h t))
+  (after! evil-org
+    (remove-hook 'org-tab-first-hook #'+org-cycle-only-current-subtree-h))
   #+END_SRC
 + (Evil users) Nearby tables are formatted when exiting insert or replace mode
   (see ~+org-enable-auto-reformat-tables-h~).


### PR DESCRIPTION
`+org-cycle-only-current-subtree-h` is being added to hook in `evil-org`  config, not in `org`'s one.
Also snippet wouldn't work with `local` flag (last arg of  `remove-hook`).