### PR TITLE
[dired] add dired-git-info and hide dotfiles/details

### DIFF
--- a/modules/emacs/dired/autoload.el
+++ b/modules/emacs/dired/autoload.el
@@ -10,7 +10,9 @@
 
 ;;;###autoload
 (defun +dired-enable-git-info-h ()
-  (if (locate-dominating-file "." ".git")
+  (if (and
+       (not (file-remote-p default-directory))
+       (locate-dominating-file "." ".git"))
       (dired-git-info-mode 1)))
 
 ;;;###autoload

--- a/modules/emacs/dired/autoload.el
+++ b/modules/emacs/dired/autoload.el
@@ -9,12 +9,12 @@
 
 
 ;;;###autoload
-(defun +dired/enable-git-info-h ()
+(defun +dired-enable-git-info-h ()
   (if (locate-dominating-file "." ".git")
       (dired-git-info-mode 1)))
 
 ;;;###autoload
-(defun +dired/dotfiles-hide ()
+(defun +dired-dotfiles-hide ()
   (set (make-local-variable '+dired-dotfiles-show-p) nil)
   (dired-mark-files-regexp "^\\\.")
   (dired-do-kill-lines))
@@ -24,6 +24,6 @@
   (interactive)
   (when (equal major-mode 'dired-mode)
     (if (or (not (boundp '+dired-dotfiles-show-p)) +dired-dotfiles-show-p) ; if currently showing
-        (+dired/dotfiles-hide)
+        (+dired-dotfiles-hide)
       (progn (revert-buffer) ; otherwise just revert to re-show
              (set (make-local-variable '+dired-dotfiles-show-p) t)))))

--- a/modules/emacs/dired/autoload.el
+++ b/modules/emacs/dired/autoload.el
@@ -6,7 +6,24 @@
   (interactive)
   (mapc #'kill-buffer (doom-buffers-in-mode 'dired-mode))
   (message "Killed all dired buffers"))
+
+
 ;;;###autoload
 (defun +dired/enable-git-info-h ()
   (if (locate-dominating-file "." ".git")
       (dired-git-info-mode 1)))
+
+;;;###autoload
+(defun +dired/dotfiles-hide ()
+  (set (make-local-variable '+dired-dotfiles-show-p) nil)
+  (dired-mark-files-regexp "^\\\.")
+  (dired-do-kill-lines))
+
+;;;###autoload
+(defun +dired/dotfiles-toggle ()
+  (interactive)
+  (when (equal major-mode 'dired-mode)
+    (if (or (not (boundp '+dired-dotfiles-show-p)) +dired-dotfiles-show-p) ; if currently showing
+        (+dired/dotfiles-hide)
+      (progn (revert-buffer) ; otherwise just revert to re-show
+             (set (make-local-variable '+dired-dotfiles-show-p) t)))))

--- a/modules/emacs/dired/autoload.el
+++ b/modules/emacs/dired/autoload.el
@@ -6,3 +6,7 @@
   (interactive)
   (mapc #'kill-buffer (doom-buffers-in-mode 'dired-mode))
   (message "Killed all dired buffers"))
+;;;###autoload
+(defun +dired/enable-git-info-h ()
+  (if (locate-dominating-file "." ".git")
+      (dired-git-info-mode 1)))

--- a/modules/emacs/dired/autoload.el
+++ b/modules/emacs/dired/autoload.el
@@ -14,18 +14,3 @@
        (not (file-remote-p default-directory))
        (locate-dominating-file "." ".git"))
       (dired-git-info-mode 1)))
-
-;;;###autoload
-(defun +dired-dotfiles-hide ()
-  (set (make-local-variable '+dired-dotfiles-show-p) nil)
-  (dired-mark-files-regexp "^\\\.")
-  (dired-do-kill-lines))
-
-;;;###autoload
-(defun +dired/dotfiles-toggle ()
-  (interactive)
-  (when (equal major-mode 'dired-mode)
-    (if (or (not (boundp '+dired-dotfiles-show-p)) +dired-dotfiles-show-p) ; if currently showing
-        (+dired-dotfiles-hide)
-      (progn (revert-buffer) ; otherwise just revert to re-show
-             (set (make-local-variable '+dired-dotfiles-show-p) t)))))

--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -45,6 +45,11 @@ only variant that supports --group-directories-first."
                                    "--group-directories-first")
                      " ")))))
 
+  ;; hide details by default
+  (add-hook 'dired-mode-hook 'dired-hide-details-mode)
+  ;; hide dotfiles by default
+  (add-hook 'dired-after-readin-hook '+dired/dotfiles-hide)
+
   ;; Don't complain about this command being disabled when we use it
   (put 'dired-find-alternate-file 'disabled nil)
 

--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -168,3 +168,11 @@ we have to clean it up ourselves."
   :when (executable-find doom-projectile-fd-binary)
   :defer t
   :init (advice-add #'find-dired :override #'fd-dired))
+
+
+(use-package! dired-git-info
+  :bind (:map dired-mode-map (")" . dired-git-info-mode))
+  :after dired
+  :init
+  (progn
+    (add-hook 'dired-after-readin-hook '+dired/enable-git-info-h)))

--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -164,7 +164,11 @@ we have to clean it up ourselves."
             ("\\.\\(?:mp4\\|mkv\\|avi\\|flv\\|rm\\|rmvb\\|ogv\\)\\(?:\\.part\\)?\\'" ,cmd)
             ("\\.\\(?:mp3\\|flac\\)\\'" ,cmd)
             ("\\.html?\\'" ,cmd)
-            ("\\.md\\'" ,cmd)))))
+            ("\\.md\\'" ,cmd))))
+  (map!
+   :map dired-mode-map
+   :localleader
+   "h" #'dired-omit-mode))
 
 
 (use-package! fd-dired

--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -47,8 +47,6 @@ only variant that supports --group-directories-first."
 
   ;; hide details by default
   (add-hook 'dired-mode-hook 'dired-hide-details-mode)
-  ;; hide dotfiles by default
-  (add-hook 'dired-after-readin-hook '+dired-dotfiles-hide)
 
   ;; Don't complain about this command being disabled when we use it
   (put 'dired-find-alternate-file 'disabled nil)

--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -178,8 +178,11 @@ we have to clean it up ourselves."
 
 
 (use-package! dired-git-info
-  :bind (:map dired-mode-map (")" . dired-git-info-mode))
+  :unless (featurep! +ranger)
   :after dired
   :init
-  (progn
-    (add-hook 'dired-after-readin-hook '+dired-enable-git-info-h)))
+  (add-hook 'dired-after-readin-hook '+dired-enable-git-info-h)
+  :config
+  (map!
+   :map dired-mode-map
+   :ng ")" #'dired-git-info-mode))

--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -48,7 +48,7 @@ only variant that supports --group-directories-first."
   ;; hide details by default
   (add-hook 'dired-mode-hook 'dired-hide-details-mode)
   ;; hide dotfiles by default
-  (add-hook 'dired-after-readin-hook '+dired/dotfiles-hide)
+  (add-hook 'dired-after-readin-hook '+dired-dotfiles-hide)
 
   ;; Don't complain about this command being disabled when we use it
   (put 'dired-find-alternate-file 'disabled nil)
@@ -180,4 +180,4 @@ we have to clean it up ourselves."
   :after dired
   :init
   (progn
-    (add-hook 'dired-after-readin-hook '+dired/enable-git-info-h)))
+    (add-hook 'dired-after-readin-hook '+dired-enable-git-info-h)))

--- a/modules/emacs/dired/packages.el
+++ b/modules/emacs/dired/packages.el
@@ -2,6 +2,7 @@
 ;;; emacs/dired/packages.el
 
 (package! diredfl)
+(package! dired-git-info)
 (package! diff-hl)
 (package! dired-rsync)
 (when (featurep! +ranger)


### PR DESCRIPTION
This PR makes a couple of simple changes to the dired module which I find useful:

- Add dired-git-info package and enable it automatically in git (sub)dirs
- Add support for toggling dotfiles
- Hide dotfiles and dired details by default
