### PR TITLE
[popup] ignore send mail buffers

### DIFF
--- a/modules/ui/popup/config.el
+++ b/modules/ui/popup/config.el
@@ -159,7 +159,8 @@ prevent the popup(s) from messing up the UI (or vice versa)."
   '(("^\\*Warnings" :vslot 99 :size 0.25)
     ("^\\*Backtrace" :vslot 99 :size 0.4 :quit nil)
     ("^\\*CPU-Profiler-Report "    :side bottom :vslot 100 :slot 1 :height 0.4 :width 0.5 :quit nil)
-    ("^\\*Memory-Profiler-Report " :side bottom :vslot 100 :slot 2 :height 0.4 :width 0.5 :quit nil)))
+    ("^\\*Memory-Profiler-Report " :side bottom :vslot 100 :slot 2 :height 0.4 :width 0.5 :quit nil)
+    ("^\\*unsent mail*" :ignore t)))
 
 (add-hook 'doom-init-ui-hook #'+popup-mode 'append)
 


### PR DESCRIPTION
[C-x m] should not appear in a popup.

In fact, I think this rule should be applied to all `message-mode` buffers.