### PR TITLE
lang/ruby: auto enter inf-ruby when breakpoint detected

### DIFF
--- a/modules/lang/ruby/config.el
+++ b/modules/lang/ruby/config.el
@@ -30,6 +30,10 @@
     (add-to-list 'company-dabbrev-code-modes 'enh-ruby-mode nil #'eq)
     (add-to-list 'company-dabbrev-code-modes 'ruby-mode nil #'eq))
 
+  (after! inf-ruby
+    ;; switch to inf-ruby from compile if we detect a breakpoint has been hit
+    (add-hook 'compilation-filter-hook 'inf-ruby-auto-enter))
+
   ;; so class and module pairs work
   (setq-hook! (ruby-mode enh-ruby-mode) sp-max-pair-length 6))
 


### PR DESCRIPTION
This PR add a hook that auto switches to inf-ruby when the compilation buffer matches the `inf-ruby-breakpoint-pattern`.
