### PR TITLE
[FEATURE] Add flycheck-golangci-lint

### DIFF
--- a/modules/lang/go/README.org
+++ b/modules/lang/go/README.org
@@ -27,6 +27,7 @@ This module adds [[https://golang.org][Go]] support.
 + [[../../editor/file-templates/templates/go-mode][File templates]]
 + [[https://github.com/hlissner/doom-snippets/tree/master/go-mode][Snippets]]
 + Generate testing code (~go-gen-test~)
++ Code checking (~flycheck-golangci-lint~)
 
 ** Module Flags
 This module provides no flags.
@@ -39,6 +40,7 @@ This module provides no flags.
 + [[https://github.com/syohex/emacs-go-add-tags][go-add-tags]]
 + [[https://github.com/mdempsky/gocode][company-go]]*
 + [[https://github.com/s-kostyaev/go-gen-test][go-gen-test]]
++ [[https://github.com/weijiangan/flycheck-golangci-lint][flycheck-golangci-lint]] (if =:tools flycheck= is enabled)
 
 * Prerequisites
 ** Go
@@ -81,6 +83,10 @@ go get -u golang.org/x/tools/cmd/gorename
 go get -u golang.org/x/tools/cmd/guru
 go get -u github.com/cweill/gotests/...
 #+END_SRC
+
++ ~golangci-lint~ (optional: for flycheck to integrate golangci-lint results)
+  it is recommended to *not* use go get to install this one, check the
+  [[https://github.com/golangci/golangci-lint#binary-release][documentation]].
 
 * TODO Features
 

--- a/modules/lang/go/config.el
+++ b/modules/lang/go/config.el
@@ -68,3 +68,8 @@
   :config
   (set-company-backend! 'go-mode 'company-go)
   (setq company-go-show-annotation t))
+
+(use-package! flycheck-golangci-lint
+  :when (featurep! :tools flycheck)
+  :hook (go-mode . flycheck-golangci-lint-setup)
+  :config (setenv "GO111MODULE" "on"))

--- a/modules/lang/go/packages.el
+++ b/modules/lang/go/packages.el
@@ -10,3 +10,6 @@
 
 (when (featurep! :completion company)
   (package! company-go))
+
+(when (featurep! :tools flycheck)
+  (package! flycheck-golangci-lint))


### PR DESCRIPTION
The added plugin runs
[golangci-lint](https://github.com/golangci/golangci-lint) in the
background and gathers the results in a checker.

I don't know if there's a macro already to add a checker to flycheck, I don't know which hook to aim for if I want to run `(flycheck-add-next-checker 'lsp-ui 'golangci-lint)` only in `go-mode` buffers (without the lsp-ui setup destroying the flycheck checkers priority list just after)