### PR TITLE
[clojure] Check for nrepl-server-buffer in advice

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -57,11 +57,12 @@
   (add-hook! 'cider-connected-hook
     (defun +clojure--cider-dump-nrepl-server-log-h ()
       "Copy contents of *nrepl-server* to beginning of *cider-repl*."
-      (save-excursion
-        (goto-char (point-min))
-        (insert
-         (with-current-buffer nrepl-server-buffer
-           (buffer-string))))))
+      (when (buffer-live-p nrepl-server-buffer)
+        (save-excursion
+          (goto-char (point-min))
+          (insert
+           (with-current-buffer nrepl-server-buffer
+             (buffer-string)))))))
 
   ;; The CIDER welcome message obscures error messages that the above code is
   ;; supposed to be make visible.


### PR DESCRIPTION
When using `cider-connect` to an external server, this function would throw
an exception because nrepl-server-buffer is nil