### PR TITLE
Correct some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,15 +108,15 @@ to learn more about our favorite OS.
   [the_silver_searcher][url:the_silver_searcher] or [ripgrep][url:ripgrep].
 - Isolated and persistent workspaces (also substitutes for vim tabs).
 - An environment variables file generator and loader, so that Emacs can
-  perfeclty inherit your shell configuration.
+  perfectly inherit your shell configuration.
 - Everything is optional!
-   
+
 # Getting Help
-  
+
 ## Community
 
 We have [a Discord server][url:discord]! Hop on and say hi!
-  
+
 ## Troubleshooting
 
 Encountered strange behavior or an error? Here are some things to try before you

--- a/docs/contributing.org
+++ b/docs/contributing.org
@@ -89,7 +89,7 @@ Please make sure of the following before you submit:
 
 * TODO Contributing code
 There's much to be done around here! We need bugfixes, new features, and
-documentation. If you'd like to convert some caffiene into Emacs Lisp, here are
+documentation. If you'd like to convert some caffeine into Emacs Lisp, here are
 a few considerations before starting that PR:
 
 ** TODO Conventions
@@ -128,7 +128,7 @@ public variables/functions (e.g. ~bookmark-default-file~ or
   ~doom--fix-broken-smie-modes-a~, ~+org--babel-lazy-load-library-a~
 + ~doom-[-]NAME-fn~ or ~+MODULE-[-]NAME-fn~ :: Indicates an [[https://en.wikipedia.org/wiki/Strategy_pattern][strategy]] function. A
   good rule of thumb for what makes a strategy function is: is it
-  interchangable? Can it be replaced with another function with a matching
+  interchangeable? Can it be replaced with another function with a matching
   signature? e.g. ~+lookup-dumb-jump-backend-fn~, ~+magit-display-buffer-fn~,
   ~+workspaces-set-project-action-fn~
 + ~abc!~ :: A public Doom "autodef" function or macro. An autodef should always

--- a/docs/faq.org
+++ b/docs/faq.org
@@ -134,11 +134,11 @@ Doom had ++four++ *five* goals for its package management system:
 4. *Organization:* an Emacs configuration grows so quickly, in complexity and
    size. A clear separation of concerns (configuration of packages from their
    installation) is more organized.
-5. *Reproducability:* /This goal hasn't been implemented yet/, but all our work
+5. *Reproducibility:* /This goal hasn't been implemented yet/, but all our work
    up until now is aimed at this goal. Emacs is a tumultuous ecosystem; packages
    break left and right, and we rely on hundreds of them. Eventually, we want
    package versions to be locked to versions of Doom so that Doom installs are
-   reproducable.
+   reproducible.
 
 ** How does Doom start up so quickly?
 Doom employs a number of techniques to cut down startup time. Here are its most
@@ -384,7 +384,7 @@ editing in the terminal (without ~-Q~). This also facilitates:
   for nix-shell users, or to isolate one instance for IRC from an instance for
   writing code, etc).
 - Quicker restarting of Emacs, to reload package settings or recover from
-  disasterous errors which can leave Emacs in a broken state.
+  disastrous errors which can leave Emacs in a broken state.
 - Faster integration with "edit in Emacs" solutions (like [[https://github.com/alpha22jp/atomic-chrome][atomic-chrome]]), and
   the potential to use them without a running daemon.
 
@@ -466,7 +466,7 @@ public variables/functions (e.g. ~bookmark-default-file~ or
   ~doom--fix-broken-smie-modes-a~, ~+org--babel-lazy-load-library-a~
 + ~doom-[-]NAME-fn~ or ~+MODULE-[-]NAME-fn~ :: Indicates an [[https://en.wikipedia.org/wiki/Strategy_pattern][strategy]] function. A
   good rule of thumb for what makes a strategy function is: is it
-  interchangable? Can it be replaced with another function with a matching
+  interchangeable? Can it be replaced with another function with a matching
   signature? e.g. ~+lookup-dumb-jump-backend-fn~, ~+magit-display-buffer-fn~,
   ~+workspaces-set-project-action-fn~
 + ~abc!~ :: A public Doom "autodef" function or macro. An autodef should always
@@ -746,7 +746,7 @@ consistent with other Emacs functions. For example, word characters are exactly
 those characters that are matched by the regular expression character class
 ~[:word:]~.
 
-If you want the underscore to be recognised as word character, you can modify
+If you want the underscore to be recognized as word character, you can modify
 its entry in the syntax-table:
 
 #+BEGIN_SRC emacs-lisp
@@ -1020,8 +1020,8 @@ TL;DR: =ws-butler= is less imposing.
 Don't be that guy who PRs 99 whitespace adjustments around his one-line
 contribution. Don't automate this aggressive behavior by attaching
 ~delete-trailing-whitespace~ (or ~whitespace-cleanup~) to ~before-save-hook~. If
-you have rambunctous colleagues peppering trailing whitespace into your project,
-you need to have a talk (with wiffle bats, preferrably) rather than play this
+you have rambunctious colleagues peppering trailing whitespace into your project,
+you need to have a talk (with wiffle bats, preferably) rather than play this
 passive-aggressive game of whack-a-mole.
 
 Here at Doom Inc we believe that operations that mutate entire files should
@@ -1138,7 +1138,7 @@ If neither of these solve your issue, try ~bin/doom doctor~. It will detect a
 variety of common issues, and may give you some clues as to what is wrong.
 
 ** The frame goes black on MacOS, while in full-screen mode
-There are known issues with childframes and MacOS's fullscreen mode. There is no
+There are known issues with childframes and macOS's fullscreen mode. There is no
 known fix for this. To work around it, you must either:
 
 1. Avoid MacOS native fullscreen by maximizing Emacs instead,

--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -8,7 +8,7 @@
       - [[#arch-linux][Arch Linux:]]
       - [[#ubuntu][Ubuntu:]]
       - [[#nixos][NixOS]]
-    - [[#on-macos][On MacOS]]
+    - [[#on-macos][On macOS]]
       - [[#where-not-to-install-emacs-from][Where *not* to install Emacs from]]
     - [[#on-windows][On Windows]]
       - [[#chocolatey--scoop][chocolatey / scoop]]
@@ -86,7 +86,7 @@ And then some optional dependencies that you will likely want, as the will
 optimize Doom's performance and stability.
 
 + [[https://github.com/sharkdp/fd][fd]]
-+ *GNU ls* (BSD ls on MacOS/BSD Linux has some limitations)
++ *GNU ls* (BSD ls on macOS/BSD Linux has some limitations)
 + *clang* -- with which to compile certain external dependencies, like the
   emacsqlite binary, irony server (requires clang), or vterm module
 
@@ -140,7 +140,7 @@ environment.systemPackages = with pkgs; [
 ];
 #+END_SRC
 
-*** On MacOS
+*** On macOS
 Mac users several options to install Emacs, but only a few of them are
 recommended for Doom Emacs (you'll need to [[http://brew.sh/][install Homebrew]] first). To start
 with:
@@ -167,7 +167,7 @@ options, in order from most to least recommended for Doom.
   #+END_SRC
 
 - [[https://bitbucket.org/mituharu/emacs-mac/overview][emacs-mac]] is also acceptable. It offers slightly better integration into
-  MacOS, with native emojis and better childframe support. However, at the time
+  macOS, with native emojis and better childframe support. However, at the time
   of writing, it [[https://github.com/railwaycat/homebrew-emacsmacport/issues/52][lacks multi-tty support]] (which impacts daemon usage). Use it if
   you experience crashing or performance issues with emacs-plus.
 
@@ -235,7 +235,7 @@ git clone https://github.com/hlissner/doom-emacs ~/.emacs.d
 3. Creates dummy config.el and packages.el files in ~$DOOMDIR~.
 4. Optionally generates an envvar file (equivalent to using ~doom env~), which
    stores your shell environment in an env file that Doom will load at startup.
-   *This is essential for MacOS users!*
+   *This is essential for macOS users!*
 5. Installs all dependencies for enabled modules (specified by
    =$DOOMDIR/init.el=),
 6. And prompts to install the icon fonts required by the [[https://github.com/domtronn/all-the-icons.el][all-the-icons]] package.
@@ -256,7 +256,7 @@ get to know these four commands:
 - ~doom upgrade~: Updates Doom Emacs (if available) and its packages.
 - ~doom env~: Generates an "envvar file", which scrapes your shell environment
   into a file that is loaded by Doom Emacs at startup. This is especially
-  necessary for MacOS users who open Emacs through an Emacs.app bundle.
+  necessary for macOS users who open Emacs through an Emacs.app bundle.
 - ~doom doctor~: If Doom misbehaves, the doc will diagnose common issues with
   your installation and environment. If all else fails, you'll find help on
   Doom's [[https://discord.gg/bcZ6P3y][Discord server]] and [[https://github.com/hlissner/doom-emacs/issues][issue tracker]].
@@ -300,7 +300,7 @@ git clone -b develop https://github.com/raxod502/straight.el ~/.emacs.d/.local/s
 doom install
 
 # If you know Emacs won't be launched from your shell environment (e.g. you're
-# on MacOS or use an app launcher that doesn't launch programs with the correct
+# on macOS or use an app launcher that doesn't launch programs with the correct
 # shell), then creating an envvar file is necessary to ensure Doom inherits your
 # shell environment.
 #
@@ -558,7 +558,7 @@ The ~package!~ macro possesses a ~:disable~ property.
 
 Once a package is disabled, ~use-packages!~ and ~after!~ blocks for it will be
 ignored, and the package will be removed the next time you run ~doom refresh~.
-Use this to disable undesireable packages included with the built-in modules.
+Use this to disable undesirable packages included with the built-in modules.
 
 Alternatively, the ~disable-packages!~ macro exists for more concisely disabling
 multiple packages:
@@ -655,7 +655,7 @@ modules or installed packages), you can evaluate Emacs Lisp code on-the-fly.
   enough to warrant one).
 
   =gr= works for most languages, but using it on Elisp is a special case; it's
-  executed within your current session of Emacs. You acn use this to modify
+  executed within your current session of Emacs. You can use this to modify
   Emacs' state on the fly.
 + Non-evil users can use =C-x C-e= to run ~eval-last-sexp~, as well as ~M-x
   +eval/buffer-or-region~ (on =SPC c e=).
@@ -787,7 +787,7 @@ You can also use this ~package!~ to disable other packages:
 Functions marked with an autoload cookie (~;;;###autoload~) in these files will
 be lazy loaded.
 
-When you run ~bin/doom autoloads~, Doom scans these files to popuplate autoload file
+When you run ~bin/doom autoloads~, Doom scans these files to populate autoload file
 in =~/.emacs.d/.local/autoloads.el=, which will tell Emacs where to find these
 functions when they are called.
 
@@ -824,7 +824,7 @@ installed:
 #+END_SRC
 
 **** Additional files
-Sometimes, it is preferrable that a module's config.el file be split up into
+Sometimes, it is preferable that a module's config.el file be split up into
 multiple files. The convention is to name these additional files with a leading
 =+=, e.g. =modules/feature/version-control/+git.el=.
 

--- a/init.example.el
+++ b/init.example.el
@@ -49,7 +49,7 @@
        fold              ; (nigh) universal code folding
        ;;(format +onsave)  ; automated prettiness
        ;;god               ; run Emacs commands without modifier keys
-       ;;lispy             ; vim for lisp, for people who dont like vim
+       ;;lispy             ; vim for lisp, for people who don't like vim
        multiple-cursors  ; editing in many places at once
        ;;objed             ; text object editing for the innocent
        ;;parinfer          ; turn lisp into python, sort of
@@ -130,10 +130,10 @@
        ;;ocaml             ; an objective camel
        (org              ; organize your plain life in plain text
         +dragndrop       ; drag & drop files/images into org buffers
-        ;+hugo            ; use Emacs for hugo blogging
+        ;;+hugo            ; use Emacs for hugo blogging
         +ipython         ; ipython/jupyter support for babel
         +pandoc          ; export-with-pandoc support
-        ;+pomodoro        ; be fruitful with the tomato technique
+        ;;+pomodoro        ; be fruitful with the tomato technique
         +present)        ; using org-mode for presentations
        ;;perl              ; write code no one else can comprehend
        ;;php               ; perl's insecure younger brother


### PR DESCRIPTION
Wed Oct 30 14:43:09 GMT 2019

This PR corrects some typos throughout the project - mainly in the `docs` directory.

There was one instance where the British spelling was used: `recognised`.  This was corrected to North American spelling: `recognized`.

Also, `MacOS` was changed to `macOS`.

Most of the others were for commonly misspelled words.  (Note - this was not corrected in init.example.el.) ;-)