### PR TITLE
Fix example to change org-directory in org README

### DIFF
--- a/modules/lang/org/README.org
+++ b/modules/lang/org/README.org
@@ -205,6 +205,6 @@ They are (with examples):
 To modify ~org-directory~ it must be set /before/ =org= has loaded:
 
 #+BEGIN_SRC emacs-lisp
-;; ~/.doom.d/config.el
+;; ~/.doom.d/init.el
 (setq org-directory "~/new/org/location/")
 #+END_SRC


### PR DESCRIPTION
org-directory must be set in `init.el` to make sure it is set before org
is loaded.