### PR TITLE
Fixed keybindings to org-attach commands

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -644,10 +644,10 @@ between the two."
           "O" #'+org/refile-to-other-buffers
           "r" #'org-refile) ; to all `org-refile-targets'
         (:prefix ("a" . "attachments")
-          "a" #'org-attach/file
-          "u" #'org-attach/uri
-          "f" #'org-attach/find-file
-          "s" #'org-attach/sync)
+          "a" #'+org-attach/file
+          "u" #'+org-attach/uri
+          "f" #'+org-attach/find-file
+          "s" #'+org-attach/sync)
         (:prefix ("c" . "clock")
           "c" #'org-clock-in
           "C" #'org-clock-out


### PR DESCRIPTION
Invoking the org-attach commands under the SPC-m-a prefix resulted in errors. It seems there was a plus sign omitted in the commands' names.