### PR TITLE
Fixed sudo edit on remote files

### DIFF
--- a/core/autoload/files.el
+++ b/core/autoload/files.el
@@ -313,26 +313,26 @@ file if it exists, without confirmation."
     (`aborted (message "Aborted"))
     (_ t)))
 
+(defun doom--sudo-file (file)
+  (let ((host (or (file-remote-p file 'host) "localhost")))
+    (concat "/" (when (file-remote-p file)
+                  (concat (file-remote-p file 'method) ":"
+                          (if-let (user (file-remote-p file 'user))
+                              (concat user "@" host)
+                            host)
+                          "|"))
+            "sudo:root@" host
+            ":" (or (file-remote-p file 'localname)
+                    file))))
+
 ;;;###autoload
 (defun doom/sudo-find-file (file)
   "Open FILE as root."
   (interactive "FOpen file as root: ")
-  (let* ((host (or (file-remote-p file 'host) "localhost"))
-         (f (concat "/" (when (file-remote-p file)
-                          (concat (file-remote-p file 'method) ":"
-                                  (if-let (user (file-remote-p file 'user))
-                                      (concat user "@" host)
-                                    host)
-                                  "|"))
-                    "sudo:root@" host
-                    ":" (or (file-remote-p file 'localname)
-                            file))))
-    (if (and buffer-file-name (equal file (file-truename buffer-file-name)))
-        (find-alternate-file f)
-      (find-file f))))
+  (find-file (doom--sudo-file file)))
 
 ;;;###autoload
 (defun doom/sudo-this-file ()
   "Open the current file as root."
   (interactive)
-  (doom/sudo-find-file (file-truename buffer-file-name)))
+  (find-alternate-file (doom--sudo-file buffer-file-name)))


### PR DESCRIPTION
Hi there,

this pull request addresses a minor issue when sudo-editing remote files: The implementation of `doom/sudo-find-file` was adjusted in such a way, that the correct file is found, if the remote user is not given explicitely, i.e. if the file passed to the function is of the form:

`/ssh:otherhost:myfile`

instead of

`/ssh:alice@otherhost:myfile`

In that case, the previous implementation invoked `find-file` with a file name that contained an extra @ character.

 
Hope the code is not to obtuse or convoluted. I don't code much in elisp :-) 