### PR TITLE
Mention $DOOMDIR/modules explictly in docs

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -694,6 +694,10 @@ modules/
       packages.el
       doctor.el
 #+end_example
+
+By default, doom looks for modules in two places: =.emacs.d/modules/= where doom's
+own modules are located and =$DOOMDIR/modules/= where you can define your
+own private modules.
 *** Structure of a module
 **** =init.el=
 This file is loaded first, before anything else, but after Doom core is loaded.


### PR DESCRIPTION
The docs already mention in in the load path, but I found that to be a little bit hidden. I think it makes sense to explictly mention it when explaining how to write your own modules?