### PR TITLE
Avoid nav-flash after each hydra action

### DIFF
--- a/modules/ui/hydra/config.el
+++ b/modules/ui/hydra/config.el
@@ -9,8 +9,7 @@
 ;;;###package hydra
 (setq lv-use-separator t)
 
-(after! hydra
-  (defadvice! +hydra/inhibit-window-switch-hooks-a (orig-fn)
-    :around #'lv-window
-    (let ((doom-inhibit-switch-window-hooks t))
-      (funcall orig-fn))))
+(defadvice! +hydra--inhibit-window-switch-hooks-a (orig-fn)
+  :around #'lv-window
+  (let ((doom-inhibit-switch-window-hooks t))
+    (funcall orig-fn)))

--- a/modules/ui/hydra/config.el
+++ b/modules/ui/hydra/config.el
@@ -8,3 +8,9 @@
 
 ;;;###package hydra
 (setq lv-use-separator t)
+
+(after! hydra
+  (defadvice! +hydra/inhibit-window-switch-hooks-a (orig-fn)
+    :around #'lv-window
+    (let ((doom-inhibit-switch-window-hooks t))
+      (funcall orig-fn))))


### PR DESCRIPTION
Hydra displays the hints in a buffer created by lv-window, which
triggers nav-flash. By advicing lv-window, we can inhibit the nav-flash
hook.