### PR TITLE
Add org archive keybinding

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -633,6 +633,7 @@ between the two."
         (:when (featurep! :completion helm)
           "." #'helm-org-in-buffer-headings
           "/" #'helm-org-agenda-files-headings)
+        "A" #'org-archive-subtree
         "d" #'org-deadline
         "e" #'org-export-dispatch
         "f" #'org-footnote-new


### PR DESCRIPTION
I frequently find myself using the native keybinding which has recently become more verbose: [`C-c C-x C-a`](https://orgmode.org/manual/Archiving.html).