### PR TITLE
Handle "'" local pair in python mode only when smartparens enabled

### DIFF
--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -74,10 +74,11 @@ called.")
         (setq-local flycheck-python-flake8-executable "flake8"))))
 
   (define-key python-mode-map (kbd "DEL") nil) ; interferes with smartparens
-  (sp-local-pair 'python-mode "'" nil
-                 :unless '(sp-point-before-word-p
-                           sp-point-after-word-p
-                           sp-point-before-same-p))
+  (when (featurep! +smartparens)
+    (sp-local-pair 'python-mode "'" nil
+                   :unless '(sp-point-before-word-p
+                             sp-point-after-word-p
+                             sp-point-before-same-p)))
 
   ;; Affects pyenv and conda
   (when (featurep! :ui modeline)


### PR DESCRIPTION
Otherwise, python-mode fails to start with "Symbol's value as variable is void": sp-local-pair