### PR TITLE
Fix nil error in +ivy/jump-list for empty buffers

### DIFF
--- a/modules/completion/ivy/autoload/ivy.el
+++ b/modules/completion/ivy/autoload/ivy.el
@@ -513,7 +513,7 @@ If ALL-FILES-P, search compressed and hidden files as well."
                                        (cons (format "%s:%d: %s"
                                                      (buffer-name)
                                                      (line-number-at-pos)
-                                                     (string-trim-right (or (thing-at-point 'line) "<EMPTY BUFFER>")))
+                                                     (string-trim-right (or (thing-at-point 'line) "")))
                                              (point-marker)))))))
                              (cddr (better-jumper-jump-list-struct-ring
                                     (better-jumper-get-jumps (better-jumper--get-current-context))))))))

--- a/modules/completion/ivy/autoload/ivy.el
+++ b/modules/completion/ivy/autoload/ivy.el
@@ -513,7 +513,7 @@ If ALL-FILES-P, search compressed and hidden files as well."
                                        (cons (format "%s:%d: %s"
                                                      (buffer-name)
                                                      (line-number-at-pos)
-                                                     (string-trim-right (thing-at-point 'line)))
+                                                     (string-trim-right (or (thing-at-point 'line) "<EMPTY BUFFER>")))
                                              (point-marker)))))))
                              (cddr (better-jumper-jump-list-struct-ring
                                     (better-jumper-get-jumps (better-jumper--get-current-context))))))))


### PR DESCRIPTION
For empty buffers which don't have any lines, `(thing-at-point 'line)`
will return `nil`. This broke `+ivy/jump-list`.