### PR TITLE
replace go-add-tags with go-tag

### DIFF
--- a/modules/lang/go/README.org
+++ b/modules/lang/go/README.org
@@ -36,7 +36,7 @@ This module adds [[https://golang.org][Go]] support.
 + [[https://github.com/syohex/emacs-go-eldoc][go-eldoc]]
 + [[https://github.com/dominikh/go-mode.el][go-guru]]
 + [[https://github.com/manute/gorepl-mode][gorepl-mode]]
-+ [[https://github.com/syohex/emacs-go-add-tags][go-add-tags]]
++ [[https://github.com/brantou/emacs-go-tag][go-tag]]
 + [[https://github.com/mdempsky/gocode][company-go]]*
 + [[https://github.com/s-kostyaev/go-gen-test][go-gen-test]]
 
@@ -69,6 +69,7 @@ This module requires a valid ~GOPATH~, and the following Go packages:
 + ~guru~ (for code navigation & refactoring commands)
 + ~goimports~ (optional: for auto-formatting code on save & fixing imports)
 + ~gotests~ (for generate test code)
++ ~gomodifytags~ (for manipulating tags)
 
 #+BEGIN_SRC sh
 export GOPATH=~/work/go
@@ -80,6 +81,7 @@ go get -u golang.org/x/tools/cmd/goimports
 go get -u golang.org/x/tools/cmd/gorename
 go get -u golang.org/x/tools/cmd/guru
 go get -u github.com/cweill/gotests/...
+go get -u github.com/fatih/gomodifytags
 #+END_SRC
 
 * TODO Features

--- a/modules/lang/go/config.el
+++ b/modules/lang/go/config.el
@@ -25,7 +25,8 @@
 
   (map! :map go-mode-map
         :localleader
-        "a" #'go-add-tags
+        "a" #'go-tag-add
+        "d" #'go-tag-remove
         "e" #'+go/play-buffer-or-region
         "i" #'go-goto-imports      ; Go to imports
         (:prefix ("h" . "help")

--- a/modules/lang/go/doctor.el
+++ b/modules/lang/go/doctor.el
@@ -14,6 +14,9 @@
 (unless (executable-find "gotests")
   (warn! "Couldn't find gotests. Generating tests will not work"))
 
+(unless (executable-find "gomodifytags")
+  (warn! "Couldn't find gomodifytags. Manipulating struct tags will not work"))
+
 (when (featurep! :completion company)
   (require 'company-go)
   (unless (executable-find company-go-gocode-command)

--- a/modules/lang/go/packages.el
+++ b/modules/lang/go/packages.el
@@ -5,7 +5,7 @@
 (package! go-guru)
 (package! go-mode)
 (package! gorepl-mode)
-(package! go-add-tags)
+(package! go-tag)
 (package! go-gen-test)
 
 (when (featurep! :completion company)


### PR DESCRIPTION
go-add-tags isn't maintained and has a few issues.
This library will fix those issues by using a binary intended for this.
