### PR TITLE
prevent rustic from checking lsp setup, enable lsp

### DIFF
--- a/modules/lang/rust/config.el
+++ b/modules/lang/rust/config.el
@@ -44,6 +44,7 @@
   :preface
   (setq rustic-rls-pkg (if (featurep! +lsp) 'lsp-mode))
   :config
+  (setq rustic-lsp-setup-p nil)
   (setq rustic-indent-method-chain t
         rustic-flycheck-setup-mode-line-p nil
         ;; use :editor format instead
@@ -55,6 +56,7 @@
         rustic-match-angle-brackets (not (featurep! :editor evil)))
 
   (add-hook 'rustic-mode-hook #'rainbow-delimiters-mode)
+  (when (featurep! +lsp) (add-hook 'rustic-mode-hook #'lsp!))
 
   (defadvice! +rust--dont-install-packages-p (orig-fn &rest args)
     :around #'rustic-setup-rls


### PR DESCRIPTION
Hi there! 

First of all, thank you for this wonderful project! I guess I'm a stubborn martian vimmer after all!

After a fresh install with `lsp` and `(rust +lsp)` in `init.el`, I had problems getting `lsp-mode` to start properly when opening a `.rs` file. I had a message complaining about `package` not being loaded... 

I found a block that seems to address this problem, but for some reason the it was still here on my machine. Maybe it's because `rustic` had some changes breaking this. Pardon my elisp ignorance.

I found a way to disable `rustic-lsp-setup` call just setting a custom var, then enabling `lsp-mode` via a hook. 

Hope that helps!