### PR TITLE
[doctor] Ignore files that don't exist

### DIFF
--- a/core/cli/doctor.el
+++ b/core/cli/doctor.el
@@ -100,7 +100,7 @@ in."
         (dolist (file (list "savehist"
                             "projectile.cache"))
           (let* ((path (expand-file-name file doom-cache-dir))
-                 (size (/ (doom-file-size path) 1024)))
+                 (size (/ (or (doom-file-size path) 0) 1024)))
             (when (and (numberp size) (> size 1000))
               (warn! "%s is too large (%.02fmb). This may cause freezes or odd startup delays"
                      (relpath path)


### PR DESCRIPTION
Minor fix to ignore files that don't exist.
Without this change, the following error occurs on running `bin/doom doctor` if `savehist` or `projectile.cache` are not present.

```
! Attempt to load DOOM failed
  (number-or-marker-p nil)
```