### PR TITLE
Add rst module to init.example.el

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -143,6 +143,7 @@
        ;;qt                ; the 'cutest' gui framework ever
        ;;racket            ; a DSL for DSLs
        ;;rest              ; Emacs as a REST client
+       ;;rst               ; ReST in peace
        ;;ruby              ; 1.step {|i| p "Ruby is #{i.even? ? 'love' : 'life'}"}
        ;;rust              ; Fe2O3.unwrap().unwrap().unwrap().unwrap()
        ;;scala             ; java, but good


### PR DESCRIPTION
PR #2020 adds support for a `lang/rst` module, but it wasn't added to the example `init.el`, which I believe is the one that's placed in `~/.doom.d/init.el` during a new installation ?

I think this greatly improves discoverability :)
