### PR TITLE
lang/org: Bind org-agenda-show-and-scroll-up

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -691,6 +691,7 @@ between the two."
 
   (map! :after org-agenda
         :map org-agenda-mode-map
+        :m "C-SPC" #'org-agenda-show-and-scroll-up
         :localleader
         "d" #'org-agenda-deadline
         (:prefix ("c" . "clock")


### PR DESCRIPTION
Default Org binds 'SPC' to `org-agenda-show-and-scroll-up`, which
displays the original location of the Agenda item in another window
without moving focus from the Agenda window.

This is useful to preview items while staying in the Agenda window.
Since we can't use 'SPC', bind it to 'localleader SPC'.

See https://orgmode.org/manual/Agenda-commands.html