### PR TITLE
+eval: do not trim when send-region-to-repl

### DIFF
--- a/modules/tools/eval/autoload/repl.el
+++ b/modules/tools/eval/autoload/repl.el
@@ -118,7 +118,7 @@ immediately after."
     (with-selected-window (get-buffer-window buffer)
       (when (bound-and-true-p evil-local-mode)
         (call-interactively #'evil-append-line))
-      (insert (string-trim selection))
+      (insert selection)
       (unless inhibit-auto-execute-p
         ;; `comint-send-input' isn't enough because some REPLs may not use
         ;; comint, so just emulate the keypress.


### PR DESCRIPTION
Remove string-trim in +eval/send-region-to-repl. The trim operation would negatively affect languages like python where spaces are used for defining code blocks.

Just accept whatever users decide to send to the repl.