### PR TITLE
Add binding for setting effort

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -667,6 +667,7 @@ between the two."
           "C" #'org-clock-out
           "d" #'org-clock-mark-default-task
           "e" #'org-clock-modify-effort-estimate
+          "E" #'org-set-effort
           "l" #'org-clock-in-last
           "g" #'org-clock-goto
           "G" (λ! (org-clock-goto 'select))


### PR DESCRIPTION
The org-clock-modify-effort-estimate is only useful after we've clocked
in a task.
