### PR TITLE
ivy-posframe: ignore counsel-rg

### DIFF
--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -333,7 +333,7 @@ evil-ex-specific constructs, so we disable it solely in evil-ex."
         #'+ivy-display-at-frame-center-near-bottom-fn)
 
   ;; posframe doesn't work well with async sources
-  (dolist (fn '(swiper counsel-ag counsel-grep counsel-git-grep))
+  (dolist (fn '(swiper counsel-rg counsel-grep counsel-git-grep))
     (setf (alist-get fn ivy-posframe-display-functions-alist)
           #'ivy-display-function-fallback)))
 


### PR DESCRIPTION
Before https://github.com/hlissner/doom-emacs/commit/a66872fe259ee6a99b6f4fae63ac4854102dc2b7  `counsel-ag` was disabled for ivy-posframe. Now it makes sense to disable `counsel-rg` for ivy-posframe.