### PR TITLE
Documentation: Make it clearer that JavaScript module also is for TypeScript

### DIFF
--- a/docs/index.org
+++ b/docs/index.org
@@ -186,7 +186,7 @@ Modules that bring support for a language or group of languages to Emacs.
 + hy - TODO
 + [[file:../modules/lang/idris/README.org][idris]] - TODO
 + java =+meghanada +lsp= - TODO
-+ [[file:../modules/lang/javascript/README.org][javascript]] =+lsp= - Javascript, typescript, and coffeescript support
++ [[file:../modules/lang/javascript/README.org][javascript]] =+lsp= - JavaScript, TypesCript, and CoffeeScript support
 + julia - TODO
 + kotlin - TODO
 + [[file:../modules/lang/latex/README.org][latex]] - TODO

--- a/docs/index.org
+++ b/docs/index.org
@@ -186,7 +186,7 @@ Modules that bring support for a language or group of languages to Emacs.
 + hy - TODO
 + [[file:../modules/lang/idris/README.org][idris]] - TODO
 + java =+meghanada +lsp= - TODO
-+ [[file:../modules/lang/javascript/README.org][javascript]] =+lsp= - JavaScript, TypesCript, and CoffeeScript support
++ [[file:../modules/lang/javascript/README.org][javascript]] =+lsp= - JavaScript, TypeScript, and CoffeeScript support
 + julia - TODO
 + kotlin - TODO
 + [[file:../modules/lang/latex/README.org][latex]] - TODO

--- a/modules/lang/javascript/README.org
+++ b/modules/lang/javascript/README.org
@@ -15,7 +15,7 @@
   - [[#commands][Commands]]
 
 * Description
-This module adds Javascript support.
+This module adds JavaScript and TypeScript support.
 
 + Code completion (tide)
 + REPL support (nodejs-repl)


### PR DESCRIPTION
Currently, it is a bit hard to figure out that Doom supports TypeScript.

I looked for a `typescript` module in `init.el` but couldn't find one. I then looked for a `typescript` directory in `modules/lang` but couldn't find one. It took me a while to realize that the JavaScript module also supports TypeScript. This PR improves discoverability of this fact by:

* Mentioning in the default user `init.el` that the JS module supports TS such that people can find it when searcing for "typescript".
* Make it clearer in the JavaScript module documentation that it also works for TypeScript.

If other people have additional ideas for improving discoveability I'll update the PR. One could also add a `modules/lang/typescript` directory with a readme that simply points to the JavaScript module. But, that may be more controversial so I didn't do that in this PR.