### PR TITLE
lang/latex: Support forward search with Skim

### DIFF
--- a/modules/lang/latex/+viewers.el
+++ b/modules/lang/latex/+viewers.el
@@ -10,7 +10,10 @@
      (when (and IS-MAC
                 (file-exists-p! (or "/Applications/Skim.app"
                                     "~/Applications/Skim.app")))
-       (add-to-list 'TeX-view-program-selection '(output-pdf "Skim"))))
+       (add-to-list 'TeX-view-program-selection '(output-pdf "Skim"))
+       (if (file-exists-p! "~/Applications/Skim.app")
+           (add-to-list 'TeX-view-program-list '("Skim" "~/Applications/Skim.app/Contents/SharedSupport/displayline -b -g %n %o %b"))
+         (add-to-list 'TeX-view-program-list '("Skim" "/Applications/Skim.app/Contents/SharedSupport/displayline -b -g %n %o %b")))))
 
     (`sumatrapdf
      (when (and IS-WINDOWS

--- a/modules/lang/latex/+viewers.el
+++ b/modules/lang/latex/+viewers.el
@@ -7,13 +7,15 @@
 (dolist (viewer (reverse +latex-viewers))
   (pcase viewer
     (`skim
-     (when (and IS-MAC
-                (file-exists-p! (or "/Applications/Skim.app"
-                                    "~/Applications/Skim.app")))
+     (when-let
+         (app-path
+          (and IS-MAC
+               (file-exists-p! (or "/Applications/Skim.app"
+                                   "~/Applications/Skim.app"))))
        (add-to-list 'TeX-view-program-selection '(output-pdf "Skim"))
-       (if (file-exists-p! "~/Applications/Skim.app")
-           (add-to-list 'TeX-view-program-list '("Skim" "~/Applications/Skim.app/Contents/SharedSupport/displayline -b -g %n %o %b"))
-         (add-to-list 'TeX-view-program-list '("Skim" "/Applications/Skim.app/Contents/SharedSupport/displayline -b -g %n %o %b")))))
+       (add-to-list 'TeX-view-program-list
+                    (list "Skim" (format "%s/Contents/SharedSupport/displayline -b -g %%n %%o %%b"
+                                         app-path))))
 
     (`sumatrapdf
      (when (and IS-WINDOWS


### PR DESCRIPTION
In LaTeX forward search doesn't work for me with the Skim PDF-reader. This fix appears to be necessary.

The format string for opening Skim is taken from [Skim's documentation](https://sourceforge.net/p/skim-app/wiki/TeX_and_PDF_Synchronization/).