### PR TITLE
lang/org: add support for org-cliplink

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -672,6 +672,7 @@ between the two."
           "r" #'org-refile-goto-last-stored
           "x" #'org-capture-goto-last-stored)
         (:prefix ("l" . "links")
+          "c" 'org-cliplink
           "l" #'org-insert-link
           "L" #'org-insert-all-links
           "s" #'org-store-link

--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -30,6 +30,7 @@
 (package! org-yt :recipe (:host github :repo "TobiasZawada/org-yt"))
 (package! ox-clip)
 (package! toc-org)
+(package! org-cliplink)
 
 (when (featurep! :editor evil +everywhere)
   (package! evil-org :recipe (:host github :repo "hlissner/evil-org-mode")))


### PR DESCRIPTION
This PR adds support for [org-cliplink](https://github.com/rexim/org-cliplink). org-cliplink takes a URL from the clipboard and inserts an org-mode link with a title of a page found by the URL into the current buffer.
