### PR TITLE
modeline: add irc-buffers back

### DIFF
--- a/modules/ui/modeline/config.el
+++ b/modules/ui/modeline/config.el
@@ -62,7 +62,7 @@
 
   (doom-modeline-def-modeline 'special
     '(bar window-number matches buffer-info-simple buffer-position selection-info)
-    '(objed-state misc-info persp-name debug input-method irc buffer-encoding lsp major-mode process checker))
+    '(objed-state misc-info persp-name debug input-method irc-buffers buffer-encoding lsp major-mode process checker))
 
   (doom-modeline-def-modeline 'project
     '(bar window-number buffer-default-directory)


### PR DESCRIPTION
Now that doom-modeline #260 is resolved, `irc-buffers' is back so let's
add it back to the `special' modeline definition.