### PR TITLE
Cargo package never gets loaded

### DIFF
--- a/modules/lang/rust/config.el
+++ b/modules/lang/rust/config.el
@@ -48,7 +48,7 @@
 ;;; Tools
 
 (use-package! cargo
-  :after rustic-mode
+  :after rustic
   :config
   (map! :map rustic-mode-map
         :localleader


### PR DESCRIPTION
The cargo package is configured to load after `rustic-mode` but the package name is just `rustic`. Perhaps the cargo mode should not be used at all? It seems rustic has some functions of it's own to run cargo.

> To ensure that this PR is processed as quickly as possible, please ensure the
> following steps have been taken:
> - [ ] This PR targets the develop branch and not master
> - [ ] If your PR is a work in progress, include [WIP] in its title
> - [ ] Its commits' summaries are reasonably descriptive
> - [ ] You've described what this PR addresses below
> - [ ] You've included links to relevant issues, if any
> - [ ] You've deleted this template
>
> Thank you for contributing to Doom Emacs! <3

Your description here...
