### PR TITLE
Add support for mu4e links in org

### DIFF
--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -125,6 +125,7 @@
 (defun +mu4e--org-mu4e-open (&rest args)
   "Rebind mu4e~main-view to a no-op so we don't get sent to the
 mu4e main view after exiting the headers view."
+  ;; http://endlessparentheses.com/understanding-letf-and-how-it-replaces-flet.html
   (cl-letf (((symbol-function 'mu4e~main-view) #'ignore))
     (apply 'org-mu4e-open args)))
 

--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -125,6 +125,15 @@
 
 (use-package! org-mu4e
   :hook (mu4e-compose-mode . org-mu4e-compose-org-mode)
+  :commands org-mu4e-open org-mu4e-store-link org-mu4e-store-and-capture
+  :init
+  (after! org
+    (if (fboundp 'org-link-set-parameters)
+        (org-link-set-parameters "mu4e"
+        :follow 'org-mu4e-open
+        :store 'org-mu4e-store-link)
+      (org-add-link-type "mu4e" 'org-mu4e-open)
+      (add-hook 'org-store-link-functions 'org-mu4e-store-link)))
   :config
   (setq org-mu4e-link-query-in-headers-mode nil
         org-mu4e-convert-to-html t)

--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -122,6 +122,11 @@
   (mu4e-maildirs-extension)
   (setq mu4e-maildirs-extension-title nil))
 
+(defun +mu4e--org-mu4e-open (&rest args)
+  "Rebind mu4e~main-view to a no-op so we don't get sent to the
+mu4e main view after exiting the headers view."
+  (cl-letf (((symbol-function 'mu4e~main-view) #'ignore))
+    (apply 'org-mu4e-open args)))
 
 (use-package! org-mu4e
   :hook (mu4e-compose-mode . org-mu4e-compose-org-mode)
@@ -130,9 +135,9 @@
   (after! org
     (if (fboundp 'org-link-set-parameters)
         (org-link-set-parameters "mu4e"
-        :follow 'org-mu4e-open
-        :store 'org-mu4e-store-link)
-      (org-add-link-type "mu4e" 'org-mu4e-open)
+                                 :follow '+mu4e--org-mu4e-open
+                                 :store 'org-mu4e-store-link)
+      (org-add-link-type "mu4e" '+mu4e--org-mu4e-open)
       (add-hook 'org-store-link-functions 'org-mu4e-store-link)))
   :config
   (setq org-mu4e-link-query-in-headers-mode nil


### PR DESCRIPTION
This PR makes `mu4e:` links work in org-mode.

There's one remaining annoyance. Quitting the mu4e header view gives you this message: “`mu4e~headers-quit-buffer: Symbol’s function definition is void: mu4e~main-view`”. I'm still figuring out why this is, but, if anybody else likes to link to emails from their todo list like I do, this PR should improve their workflow regardless.