### PR TITLE
Add LSP support to Kotlin

### DIFF
--- a/docs/index.org
+++ b/docs/index.org
@@ -188,7 +188,7 @@ Modules that bring support for a language or group of languages to Emacs.
 + java =+meghanada +lsp= - TODO
 + [[file:../modules/lang/javascript/README.org][javascript]] =+lsp= - JavaScript, TypeScript, and CoffeeScript support
 + julia - TODO
-+ kotlin - TODO
++ kotlin =+lsp+= - TODO
 + [[file:../modules/lang/latex/README.org][latex]] - TODO
 + lean - TODO
 + [[file:../modules/lang/ledger/README.org][ledger]] - TODO

--- a/modules/lang/kotlin/config.el
+++ b/modules/lang/kotlin/config.el
@@ -1,5 +1,10 @@
 ;;; lang/kotlin/config.el -*- lexical-binding: t; -*-
 
+(use-package! kotlin-mode
+  :init 
+  (when (featurep! +lsp)
+    (add-hook 'kotlin-mode-local-vars-hook #'lsp!)))
+
 (after! kotlin-mode
   (set-docsets! 'kotlin-mode "Kotlin")
 

--- a/modules/lang/kotlin/config.el
+++ b/modules/lang/kotlin/config.el
@@ -1,11 +1,8 @@
 ;;; lang/kotlin/config.el -*- lexical-binding: t; -*-
 
-(use-package! kotlin-mode
-  :init 
-  (when (featurep! +lsp)
-    (add-hook 'kotlin-mode-local-vars-hook #'lsp!)))
-
 (after! kotlin-mode
+  (when (featurep! +lsp)
+    (add-hook 'kotlin-mode-local-vars-hook #'lsp!))
   (set-docsets! 'kotlin-mode "Kotlin")
 
   (map! :map kotlin-mode-map

--- a/modules/lang/kotlin/doctor.el
+++ b/modules/lang/kotlin/doctor.el
@@ -2,3 +2,7 @@
 
 (unless (executable-find "ktlint")
   (warn! "ktlint not found. flycheck-kotlin won't work."))
+
+(assert! (or (not (featurep! +lsp))
+             (featurep! :tools lsp))
+         "This module requires (:tools lsp)")


### PR DESCRIPTION
`lsp-mode` has built in support for Kotlin. This makes it automatically used if you use the `+lsp` flag.