### PR TITLE
email/mu4e: add featurep check for workspaces

### DIFF
--- a/modules/email/mu4e/autoload/email.el
+++ b/modules/email/mu4e/autoload/email.el
@@ -54,6 +54,8 @@ default/fallback account."
   (require 'mu4e)
   (if (featurep :ui 'workspaces)
       (+workspace-switch +mu4e-workspace-name t))
+  (delete-other-windows)
+  (switch-to-buffer (doom-fallback-buffer))
   (mu4e~start 'mu4e~main-view)
   ;; (save-selected-window
   ;;   (prolusion-mail-show))

--- a/modules/email/mu4e/autoload/email.el
+++ b/modules/email/mu4e/autoload/email.el
@@ -55,9 +55,9 @@ default/fallback account."
   (require 'mu4e)
   (if (featurep :ui 'workspaces)
       (+workspace-switch +mu4e-workspace-name t)
-    (setq +mu4e--old-wconf (current-window-configuration)))
-  (delete-other-windows)
-  (switch-to-buffer (doom-fallback-buffer))
+    (setq +mu4e--old-wconf (current-window-configuration))
+    (delete-other-windows)
+    (switch-to-buffer (doom-fallback-buffer)))
   (mu4e~start 'mu4e~main-view)
   ;; (save-selected-window
   ;;   (prolusion-mail-show))

--- a/modules/email/mu4e/autoload/email.el
+++ b/modules/email/mu4e/autoload/email.el
@@ -52,7 +52,8 @@ default/fallback account."
   "Start email client."
   (interactive)
   (require 'mu4e)
-  (+workspace-switch +mu4e-workspace-name t)
+  (if (featurep :ui 'workspaces)
+      (+workspace-switch +mu4e-workspace-name t))
   (mu4e~start 'mu4e~main-view)
   ;; (save-selected-window
   ;;   (prolusion-mail-show))
@@ -74,5 +75,6 @@ default/fallback account."
 
 (defun +mu4e-kill-mu4e-h ()
   ;; (prolusion-mail-hide)
-  (when (+workspace-exists-p +mu4e-workspace-name)
+  (when (and (featurep :ui 'workspaces)
+             (+workspace-exists-p +mu4e-workspace-name))
     (+workspace/delete +mu4e-workspace-name)))

--- a/modules/email/mu4e/autoload/email.el
+++ b/modules/email/mu4e/autoload/email.el
@@ -44,6 +44,7 @@ default/fallback account."
 
 (defvar +mu4e-workspace-name "*mu4e*"
   "TODO")
+(defvar +mu4e--old-wconf nil)
 
 (add-hook 'mu4e-main-mode-hook #'+mu4e-init-h)
 
@@ -53,7 +54,8 @@ default/fallback account."
   (interactive)
   (require 'mu4e)
   (if (featurep :ui 'workspaces)
-      (+workspace-switch +mu4e-workspace-name t))
+      (+workspace-switch +mu4e-workspace-name t)
+    (setq +mu4e--old-wconf (current-window-configuration)))
   (delete-other-windows)
   (switch-to-buffer (doom-fallback-buffer))
   (mu4e~start 'mu4e~main-view)
@@ -77,6 +79,10 @@ default/fallback account."
 
 (defun +mu4e-kill-mu4e-h ()
   ;; (prolusion-mail-hide)
-  (when (and (featurep :ui 'workspaces)
-             (+workspace-exists-p +mu4e-workspace-name))
-    (+workspace/delete +mu4e-workspace-name)))
+  (cond
+   ((and (featurep :ui 'workspaces) (+workspace-exists-p +mu4e-workspace-name))
+    (+workspace/delete +mu4e-workspace-name))
+
+   (+mu4e--old-wconf
+    (set-window-configuration +mu4e--old-wconf)
+    (setq +mu4e--old-wconf nil))))


### PR DESCRIPTION
- if module workspaces is not used, an error would be raised when calling `=mu4e`
  `=mu4e: Symbol’s function definition is void: +workspace-switch`
- if module workspaces is not used, an error would be raised when quiting mu4e
  `=mu4e: Symbol’s function definition is void: +workspace/delete`

This PR fixes these two issues.

I think there might be a better fix:
Like extracting these workspaces tweeks to a new file and adding a `;;;###if (featurep! :ui workspaces)` check at the beginning?