### PR TITLE
email/mu4e: fix refile target

### DIFF
--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -166,9 +166,9 @@
                 :action #'+mu4e--mark-seen)
           ;; Refile will be my "archive" function.
           (alist-get 'refile mu4e-marks)
-          (list :char '("d" . "▼")
-                :prompt "dtrash"
-                :dyn-target (lambda (_target msg) (mu4e-get-trash-folder msg))
+          (list :char '("r" . "▼")
+                :prompt "rrefile"
+                :dyn-target (lambda (_target msg) (mu4e-get-refile-folder msg))
                 :action #'+mu4e--mark-seen))
 
     ;; This hook correctly modifies gmail flags on emails when they are marked.


### PR DESCRIPTION
- before this change: refile would use mu4e-trash-folder as the target
- after this change: refile would use mu4e-refile-folder as expected

Question: 
- Is a fancy icon needed for refile `:char`?
- What does `prompt` mean here? Do I need to change it to something else?