### PR TITLE
lang/ruby: add featurep for rspec and minitest

### DIFF
--- a/modules/lang/ruby/config.el
+++ b/modules/lang/ruby/config.el
@@ -127,6 +127,10 @@
   :init
   (when (featurep! :editor evil)
     (add-hook 'rspec-mode-hook #'evil-normalize-keymaps))
+  (advice-add 'rspec-enable-appropriate-mode :around
+              (lambda (orig-fun)
+                (when (file-exists-p (expand-file-name "spec/" (rspec-project-root)))
+                  (funcall orig-fun))))
   :config
   (setq rspec-use-rvm (executable-find "rvm"))
   (map! :localleader

--- a/modules/lang/ruby/packages.el
+++ b/modules/lang/ruby/packages.el
@@ -25,5 +25,7 @@
   (package! rvm))
 
 ;; Testing frameworks
-(package! rspec-mode)
-(package! minitest)
+(when (featurep! +rspec)
+  (package! rspec-mode))
+(when (featurep! +minitest)
+  (package! minitest))

--- a/modules/lang/ruby/packages.el
+++ b/modules/lang/ruby/packages.el
@@ -25,7 +25,5 @@
   (package! rvm))
 
 ;; Testing frameworks
-(when (featurep! +rspec)
-  (package! rspec-mode))
-(when (featurep! +minitest)
-  (package! minitest))
+(package! rspec-mode)
+(package! minitest)


### PR DESCRIPTION
The ruby's testing frameworks should be optional. When both are installed rspec's keybindings take precedence over minitest's.