### PR TITLE
Add evil-quick-diff

### DIFF
--- a/modules/editor/evil/README.org
+++ b/modules/editor/evil/README.org
@@ -42,6 +42,7 @@ This holy module brings the vim experience to Emacs.
 + [[https://github.com/bling/evil-visualstar][evil-visualstar]]
 + [[https://github.com/ninrod/exato][exato]]
 + [[https://github.com/emacs-evil/evil-collection][evil-collection]]*
++ [[https://www.github.com/rgrinberg/evil-quick-diff][evil-quick-diff]]
 
 ** Hacks
 + The o/O keys will respect and continue commented lines (can be disabled by

--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -283,6 +283,8 @@ directives. By default, this only recognizes C directives.")
         (evil-exchange-cancel)
         t))))
 
+(use-package! evil-quick-diff
+  :commands (evil-quick-diff evil-quick-diff-cancel))
 
 (use-package! evil-nerd-commenter
   :commands (evilnc-comment-operator

--- a/modules/editor/evil/packages.el
+++ b/modules/editor/evil/packages.el
@@ -16,6 +16,7 @@
 (package! evil-traces)
 (package! evil-visualstar)
 (package! exato)
+(package! evil-quick-diff :recipe (:host github :repo "rgrinberg/evil-quick-diff"))
 
 ;;
 (when (featurep! +everywhere)


### PR DESCRIPTION
This introduces the `g o d` text object for comparing regions. It works
like evil-exchange. Select two regions in sequence with `g o d` and an
ediff buffer of the selections will pop up.