### PR TITLE
Easier creation of named workspaces

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -298,7 +298,8 @@
       (:when (featurep! :ui workspaces)
         (:prefix-map ("TAB" . "workspace")
           :desc "Display tab bar"           "TAB" #'+workspace/display
-          :desc "Switch workspace"          "."   #'+workspace/switch-to
+          :desc "Switch workspace"          "."
+          (if (featurep! :completion ivy) #'ivy/workspace/switch-to #'+workspace/switch-to)
           :desc "Switch to last workspace"  "`"   #'+workspace/other
           :desc "New workspace"             "n"   #'+workspace/new
           :desc "Load workspace from file"  "l"   #'+workspace/load

--- a/modules/ui/workspaces/autoload/workspaces.el
+++ b/modules/ui/workspaces/autoload/workspaces.el
@@ -299,13 +299,10 @@ workspace, otherwise the new workspace is blank."
              (+workspace/display)))
     ((debug error) (+workspace-error (cadr e) t))))
 
-;;;###autoload
-(defun +workspace/switch-to (index)
-  "Switch to a workspace at a given INDEX. A negative number will start from the
-end of the workspace list."
-  (interactive
-   (list (or current-prefix-arg
-             (completing-read "Switch to workspace: " (+workspace-list-names)))))
+
+(defun +workspace--switch-to (index &optional skip-warnings)
+  "Generic workspace switching action. It is used by both the ivy and normal
+command."
   (when (and (stringp index)
              (string-match-p "^[0-9]+$" index))
     (setq index (string-to-number index)))
@@ -322,10 +319,28 @@ end of the workspace list."
               (t
                (error "Not a valid index: %s" index)))
         (unless (called-interactively-p 'interactive)
-          (if (equal (+workspace-current-name) old-name)
+          (if (and (not skip-warnings) (equal (+workspace-current-name) old-name))
               (+workspace-message (format "Already in %s" old-name) 'warn)
             (+workspace/display))))
     ('error (+workspace-error (cadr ex) t))))
+
+;;;###autoload
+(defun +ivy/workspace/switch-to ()
+  (interactive)
+  (ivy-read "Switch to workspace: "
+            (+workspace-list-names)
+            :caller #'+ivy/workspace/switch-to
+            :preselect (+workspace-current-name)
+            :action (lambda (w) (+workspace--switch-to w t))))
+
+;;;###autoload
+(defun +workspace/switch-to (index)
+  "Switch to a workspace at a given INDEX. A negative number will start from the
+end of the workspace list."
+  (interactive
+   (list (or current-prefix-arg
+             (completing-read "Switch to workspace: " (+workspace-list-names)))))
+  (+workspace/switch-to index))
 
 ;;;###autoload
 (dotimes (i 9)

--- a/modules/ui/workspaces/autoload/workspaces.el
+++ b/modules/ui/workspaces/autoload/workspaces.el
@@ -318,9 +318,7 @@ end of the workspace list."
                    (error "No workspace at #%s" (1+ index)))
                  (+workspace-switch dest)))
               ((stringp index)
-               (unless (member index names)
-                 (error "No workspace named %s" index))
-               (+workspace-switch index))
+               (+workspace-switch index t))
               (t
                (error "Not a valid index: %s" index)))
         (unless (called-interactively-p 'interactive)


### PR DESCRIPTION
When a user tries to switch to a named workspace that doesn't exist,
create it, instead of just failing.

This is consistent with bookmarks for example