### PR TITLE
Remove envvar setter in golangci-lint checker

### DIFF
--- a/modules/lang/go/config.el
+++ b/modules/lang/go/config.el
@@ -72,5 +72,4 @@
 
 (use-package! flycheck-golangci-lint
   :when (featurep! :tools flycheck)
-  :hook (go-mode . flycheck-golangci-lint-setup)
-  :config (setenv "GO111MODULE" "on"))
+  :hook (go-mode . flycheck-golangci-lint-setup))


### PR DESCRIPTION
This allows users to be responsible for their use of the feature. I definitely misread the documentation about the checker.
