### PR TITLE
Fix typos

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -78,7 +78,7 @@
        ;;ein               ; tame Jupyter notebooks with emacs
        (eval +overlay)     ; run code, run (also, repls)
        flycheck          ; tasing you for every semicolon you forget
-       ;;flyspell          ; tasing you for misspelling mispelling
+       ;;flyspell          ; tasing you for misspelling misspelling
        ;;gist              ; interacting with github gists
        (lookup           ; helps you navigate your code and documentation
         +docsets)        ; ...or in Dash docsets locally

--- a/init.example.el
+++ b/init.example.el
@@ -78,7 +78,7 @@
        ;;ein               ; tame Jupyter notebooks with emacs
        (eval +overlay)     ; run code, run (also, repls)
        flycheck          ; tasing you for every semicolon you forget
-       ;;flyspell          ; tasing you for misspelling misspelling
+       ;;flyspell          ; tasing you for misspelling mispelling
        ;;gist              ; interacting with github gists
        (lookup           ; helps you navigate your code and documentation
         +docsets)        ; ...or in Dash docsets locally

--- a/modules/config/default/config.el
+++ b/modules/config/default/config.el
@@ -347,7 +347,7 @@
   "n"    #'doom/help-news
   ;; replaces `help-with-tutorial', b/c it's less useful than `load-theme'
   "t"    #'load-theme
-  ;; replaces `finder-by-keyword' b/c not usefull
+  ;; replaces `finder-by-keyword' b/c not useful
   "p"    #'doom/help-packages
   ;; replaces `describe-package' b/c redundant w/ `doom/describe-package'
   "P"    #'find-library)

--- a/modules/editor/evil/autoload/ex.el
+++ b/modules/editor/evil/autoload/ex.el
@@ -168,7 +168,7 @@ function and open its documentation with `helpful-function'. Otherwise, it will
 search for it with `apropos'.
 
 If QUERY is empty, this runs the equivalent of 'M-x apropos'. If BANG is
-non-nil, a search is preformed against Doom's manual (wiht `doom/help-search')."
+non-nil, a search is preformed against Doom's manual (with `doom/help-search')."
   (interactive "<!><a>")
   (if bang
       (doom/help-search query)

--- a/modules/lang/haskell/+dante.el
+++ b/modules/lang/haskell/+dante.el
@@ -8,7 +8,7 @@
                            "+c"
                            "-Wwarn=missing-home-modules"
                            "-fno-diagnostics-show-caret"
-                           ;; neccessary to make attrap-attrap useful:
+                           ;; necessary to make attrap-attrap useful:
                            "-Wall"
                            ;; necessary to make company completion useful:
                            "-fdefer-typed-holes"

--- a/modules/lang/haskell/README.org
+++ b/modules/lang/haskell/README.org
@@ -30,7 +30,7 @@ This module adds [[https://www.haskell.org/][Haskell]] support, powered by eithe
 + [[https://github.com/hlissner/doom-snippets/tree/master/haskell-mode][Snippets]]
 
 ** External resources
-Here are a few resources I've found indespensible in my Haskell adventures:
+Here are a few resources I've found indispensable in my Haskell adventures:
 
 + [[http://learnyouahaskell.com/][Learn you a haskell for great good]]
 + [[http://haskellbook.com/][Haskell Programming from first principles]]

--- a/modules/lang/org/README.org
+++ b/modules/lang/org/README.org
@@ -127,7 +127,7 @@ https://www.mfoot.com/blog/2015/11/22/literate-emacs-configuration-with-org-mode
 + Statistics cookies are updated when saving the buffer of exiting insert mode
   (see ~+org-enable-auto-update-cookies-h~).
 + Org-protocol has been lazy loaded (see ~+org-init-protocol-lazy-loader-h~);
-  loaded when the server recieves a request for an org-protocol:// url.
+  loaded when the server receives a request for an org-protocol:// url.
 + Babel and babel plugins are now lazy loaded (see
   ~+org-init-babel-lazy-loader-h~); loaded when a src block is executed. No need
   to use ~org-babel-do-load-languages~ in your config, just install your babel

--- a/modules/ui/unicode/autoload.el
+++ b/modules/ui/unicode/autoload.el
@@ -3,7 +3,7 @@
 ;;;###autoload
 (add-hook! 'doom-init-ui-hook
   (defun +unicode-init-fonts-h ()
-    "Set up `unicode-fonts' to eventually run; accomodating the daemon, if
+    "Set up `unicode-fonts' to eventually run; accommodating the daemon, if
 necessary."
     (setq-default bidi-display-reordering t
                   doom-unicode-font nil)


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos.