### PR TITLE
Popup rules for more builtin types

### DIFF
--- a/modules/ui/popup/config.el
+++ b/modules/ui/popup/config.el
@@ -158,13 +158,7 @@ prevent the popup(s) from messing up the UI (or vice versa)."
     ("^\\*Backtrace" :vslot 99 :size 0.4 :quit nil)
     ("^\\*CPU-Profiler-Report "    :side bottom :vslot 100 :slot 1 :height 0.4 :width 0.5 :quit nil)
     ("^\\*Memory-Profiler-Report " :side bottom :vslot 100 :slot 2 :height 0.4 :width 0.5 :quit nil)
-    ("^\\*Proced*" :ignore t)
-    ("^\\*timer-list*" :ignore t)
-    ("^\\*Process-List*" :ignore t)
-    ("^\\*Abbrevs*" :ignore t)
-    ("^\\*Output*" :ignore t)
-    ("^\\*Occur*" :ignore t)
-    ("^\\*unsent mail*" :ignore t)))
+    ("^\\*\\(?:Proced\\|timer-list\\|Process List\\|Abbrevs\\|Output\\|Occur\\|unsent mail\\)\\*" :ignore t)))
 
 (add-hook 'doom-init-ui-hook #'+popup-mode 'append)
 

--- a/modules/ui/popup/config.el
+++ b/modules/ui/popup/config.el
@@ -158,6 +158,12 @@ prevent the popup(s) from messing up the UI (or vice versa)."
     ("^\\*Backtrace" :vslot 99 :size 0.4 :quit nil)
     ("^\\*CPU-Profiler-Report "    :side bottom :vslot 100 :slot 1 :height 0.4 :width 0.5 :quit nil)
     ("^\\*Memory-Profiler-Report " :side bottom :vslot 100 :slot 2 :height 0.4 :width 0.5 :quit nil)
+    ("^\\*Proced*" :ignore t)
+    ("^\\*timer-list*" :ignore t)
+    ("^\\*Process-List*" :ignore t)
+    ("^\\*Abbrevs*" :ignore t)
+    ("^\\*Output*" :ignore t)
+    ("^\\*Occur*" :ignore t)
     ("^\\*unsent mail*" :ignore t)))
 
 (add-hook 'doom-init-ui-hook #'+popup-mode 'append)


### PR DESCRIPTION
process, timer, abbreviations, output, occur buffers are all better
displayed in a maximized fashion. Otherwise, they aren't really useful.
