### PR TITLE
Put mu4e-org behind a feature flag

### DIFF
--- a/docs/index.org
+++ b/docs/index.org
@@ -154,7 +154,7 @@ Modules that reconfigure or augment packages or features built into Emacs.
 + vc - TODO
 
 ** :email
-+ [[file:../modules/email/mu4e/README.org][mu4e]] =+gmail= - TODO
++ [[file:../modules/email/mu4e/README.org][mu4e]] =+gmail= =+mu4e-org= - TODO
 + notmuch - TODO
 + wanderlust =+gmail= - TODO
 

--- a/init.example.el
+++ b/init.example.el
@@ -154,7 +154,7 @@
        ;;web               ; the tubes
 
        :email
-       ;;(mu4e +gmail)
+       ;;(mu4e +gmail +mu4e-org)
        ;;notmuch
        ;;(wanderlust +gmail)
 

--- a/modules/email/mu4e/README.org
+++ b/modules/email/mu4e/README.org
@@ -31,6 +31,7 @@ via IMAP) and ~mu~ (to index my mail into a format ~mu4e~ can understand).
 
 ** Module Flags
 + ~+gmail~ Enables gmail-specific configuration.
++ ~+mu4e-org~ Enables mu4e org compose mode.
 
 ** Plugins
 + [[https://github.com/agpchil/mu4e-maildirs-extension][mu4e-maildirs-extension]]

--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -124,6 +124,7 @@
 
 
 (use-package! org-mu4e
+  :when (featurep! :email mu4e +org-mu4e)
   :hook (mu4e-compose-mode . org-mu4e-compose-org-mode)
   :config
   (setq org-mu4e-link-query-in-headers-mode nil


### PR DESCRIPTION
This PR puts `mu4e-org` behind a feature flag.

I think it should be optional to compose mails with org mode, so I would like to put it behind a feature flag.