### PR TITLE
Fix interactive call of doom/narrow-buffer-indirectly

### DIFF
--- a/core/autoload/ui.el
+++ b/core/autoload/ui.el
@@ -179,8 +179,7 @@ narrowing doesn't affect other windows displaying the same buffer. Call
 Inspired from http://demonastery.org/2013/04/emacs-evil-narrow-region/"
   (interactive
    (list (or (bound-and-true-p evil-visual-beginning) (region-beginning))
-         (or (bound-and-true-p evil-visual-end)       (region-end))
-         current-prefix-arg))
+         (or (bound-and-true-p evil-visual-end)       (region-end))))
   (unless (region-active-p)
     (setq beg (line-beginning-position)
           end (line-end-position)))


### PR DESCRIPTION
The optional 3rd arg to the function was removed in f9190c08bfb908df1df3cc49ee2ecec4b360d42c