### PR TITLE
Add ibuffer filter group for the workspace

### DIFF
--- a/modules/emacs/ibuffer/config.el
+++ b/modules/emacs/ibuffer/config.el
@@ -39,6 +39,23 @@
      :header-mouse-map ibuffer-size-header-map)
     (file-size-human-readable (buffer-size)))
 
+  (when (featurep! :ui workspaces)
+    (define-ibuffer-filter workspace-buffers
+        "Filter for workspace buffers"
+      (:reader
+       (+workspace-get (read-string "workspace name: ")) :description "workspace")
+      (memq buf (+workspace-buffer-list qualifier)))
+
+    (defun +ibuffer/workspace (workspace-name)
+      "Open an ibuffer window for a workspace"
+      (ibuffer nil (format "%s buffers" workspace-name)
+               (list (cons 'workspace-buffers (+workspace-get workspace-name)))))
+
+    (defun +ibuffer-current-workspace ()
+      "Open an ibuffer window for the current workspace"
+      (interactive)
+      (+ibuffer/workspace (+workspace-current-name))))
+
   (when (featurep! :completion ivy)
     (defadvice! +ibuffer-use-counsel-maybe-a (_file &optional _wildcards)
       "Use `counsel-find-file' instead of `find-file'."


### PR DESCRIPTION
This introduces the +ibuffer-current-workspace function which open an
ibuffer with only buffers from the current workspace.

This proof of concept already works and is proving to be quite useful for me, but there are still some imperfections:

* The workspace filter is displayed in an ugly way in the ibuffer window. (it's pretty printed as an emacs lisp struct)

* We should be using something like `ivy-read` to read the workspace in `:reader`.