### PR TITLE
Fixes Emacs crashing in MacOS cause of ligatures

### DIFF
--- a/modules/ui/pretty-code/+hasklig.el
+++ b/modules/ui/pretty-code/+hasklig.el
@@ -49,7 +49,8 @@
 
 
 (defun +pretty-code-setup-hasklig-ligatures-h ()
-  (set-fontset-font t '(#Xe100 . #Xe129) +pretty-code-hasklig-font-name)
+  (set-fontset-font t (cons (decode-char 'ucs #Xe100)
+                            (decode-char 'ucs #Xe129)) +pretty-code-hasklig-font-name)
   (setq-default prettify-symbols-alist
                 (append prettify-symbols-alist
                         (mapcar #'+pretty-code--correct-symbol-bounds


### PR DESCRIPTION
This fixes the issue I reported in #2169 , it's my first type coding in elisp.
