### PR TITLE
Changed to correct default location

### DIFF
--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -27,13 +27,13 @@
     (projectile-invalidate-cache nil))
 
   ;; The default location for git-credential-cache is in
-  ;; ~/.config/git/credential. However, if ~/.git-credential-cache/ exists, then
+  ;; ~/.cache/git/credential. However, if ~/.git-credential-cache/ exists, then
   ;; it is used instead. Magit seems to be hardcoded to use the latter, so here
   ;; we override it to have more correct behavior.
   (unless (file-exists-p "~/.git-credential-cache/")
     (setq magit-credential-cache-daemon-socket
-          (doom-glob (or (getenv "XDG_CONFIG_HOME")
-                         "~/.config/")
+          (doom-glob (or (getenv "XDG_CACHE_HOME")
+                         "~/.cache/")
                      "git/credential/socket")))
 
   ;; Magit uses `magit-display-buffer-traditional' to display windows, by


### PR DESCRIPTION
https://git-scm.com/docs/git-credential-cache

I believe that the default location for git-credential-cache should be
$XDG_CACHE_HOME/git/credential/socket

Which is where I found it running git from the command line.





