### PR TITLE
vterm: adapt to new function signature

### DIFF
--- a/modules/term/vterm/config.el
+++ b/modules/term/vterm/config.el
@@ -10,7 +10,7 @@
   (add-hook 'vterm-mode-hook #'doom-mark-buffer-as-real-h)
   ;; Automatically kill buffer when vterm exits.
   (add-hook! 'vterm-exit-functions
-    (defun +vterm-kill-buffer-on-quit-fn (buffer)
+    (defun +vterm-kill-buffer-on-quit-fn (buffer event)
       (if buffer (kill-buffer buffer))))
   ;; Modeline serves no purpose in vterm
   (add-hook 'vterm-mode-hook #'hide-mode-line-mode)


### PR DESCRIPTION
emacs-libvterm@376db7cf416 had a breaking change for
`vterm-exit-functions` which sends the event as the second argument.