### PR TITLE
Add py-isort feature to the python module

### DIFF
--- a/modules/lang/python/README.org
+++ b/modules/lang/python/README.org
@@ -31,7 +31,7 @@ Adds Python support to Doom Emacs.
 ** Plugins
 + [[https://github.com/pythonic-emacs/anaconda-mode][anaconda-mode]]*
 + [[https://github.com/Wilfred/pyimport][pyimport]]*
-+ [[https://github.com/emacs-pe/pyimpsort.el][pyimpsort]]*
++ [[https://github.com/paetzke/py-isort.el][py-isort]]*
 + [[https://melpa.org/#/nose][nose]]*
 + [[https://github.com/wbolster/emacs-python-pytest][python-pytest]]*
 + [[https://github.com/Wilfred/pip-requirements.el][pip-requirements]]*

--- a/modules/lang/python/README.org
+++ b/modules/lang/python/README.org
@@ -67,6 +67,9 @@ This module has no direct prerequisites. Here are some of its soft dependencies.
 + ~pyimport~ requires Python's module ~pyflakes~:
   + ~pip install pyflakes~
 
++ ~py-isort~ requires [[https://github.com/timothycrosley/isort][isort]] to be installed:
+  + ~pip install isort~
+
 + Python virtual environments install instructions at:
   + [[https://github.com/pyenv/pyenv][pyenv]]
   + [[https://conda.io/en/latest/][Conda]]

--- a/modules/lang/python/autoload/python.el
+++ b/modules/lang/python/autoload/python.el
@@ -59,4 +59,4 @@
   "organize imports"
   (interactive)
   (pyimport-remove-unused)
-  (pyimpsort-buffer))
+  (py-isort-buffer))

--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -139,7 +139,6 @@ called.")
         (:prefix ("i" . "imports")
           :desc "Insert missing imports" "i" #'pyimport-insert-missing
           :desc "Remove unused imports"  "r" #'pyimport-remove-unused
-          :desc "Sort imports"           "s" #'pyimpsort-buffer
           :desc "Optimize imports"       "o" #'+python/optimize-imports)))
 
 

--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -143,6 +143,16 @@ called.")
           :desc "Optimize imports"       "o" #'+python/optimize-imports)))
 
 
+(use-package! py-isort
+  :defer t
+  :init
+  (map! :after python
+        :map python-mode-map
+        :localleader
+        (:prefix ("i" . "imports")
+          :desc "Sort imports"      "s" #'py-isort-buffer
+          :desc "Sort region"       "r" #'py-isort-region)))
+
 (use-package! nose
   :commands nose-mode
   :preface (defvar nose-mode-map (make-sparse-keymap))

--- a/modules/lang/python/packages.el
+++ b/modules/lang/python/packages.el
@@ -31,7 +31,4 @@
 
 ;; Import managements
 (package! pyimport)
-(package! pyimpsort)
-
-(when (featurep! +isort)
-  (package! py-isort))
+(package! py-isort)

--- a/modules/lang/python/packages.el
+++ b/modules/lang/python/packages.el
@@ -32,3 +32,6 @@
 ;; Import managements
 (package! pyimport)
 (package! pyimpsort)
+
+(when (featurep! +isort)
+  (package! py-isort))


### PR DESCRIPTION
This PR introduces a new feature to the python module for `isort`. 

`isort` is a python tool which sorts imports which is actively maintained and used extensively by the python community. Emacs integration for this tool is done using the py-isort emacs package available on melpa.

The only thing that is missing from this PR is registering the hook to sort on save but i think this can be left to user-config rather than having it done automatically by doom.