### PR TITLE
fix doc for enabling rust analyzer

### DIFF
--- a/modules/lang/rust/README.org
+++ b/modules/lang/rust/README.org
@@ -77,8 +77,7 @@ You'll need [[https://github.com/rust-analyzer/rust-analyzer][rust-analyzer]] in
 =$DOOMDIR/config.el=:
 
 #+BEGIN_SRC elisp
-(after! lsp-rust
-  (setq lsp-rust-server 'rust-analyzer))
+(setq lsp-rust-server 'rust-analyzer)
 #+END_SRC
 
 * TODO Troubleshooting


### PR DESCRIPTION
Using the previous config did not change the language server to rust analyzer for me. I think it is because setting it after lsp-rust has been initialized is too late.