### PR TITLE
Update plantuml doctor prescription

### DIFF
--- a/modules/lang/plantuml/doctor.el
+++ b/modules/lang/plantuml/doctor.el
@@ -7,4 +7,4 @@
     (warn! "Couldn't find java. PlantUML preview or syntax checking won't work"))
   ;; plantuml.jar
   (unless (file-exists-p plantuml-jar-path)
-    (warn! "Couldn't find plantuml.jar. Install it with-x +plantuml/install")))
+    (warn! "Couldn't find plantuml.jar. Install it with M-x plantuml-download-jar")))


### PR DESCRIPTION
This patch changes the recommendation from +plantuml/install to
plantuml-dowload-jar, when the plantuml.jar can't be found. The command
+plantuml/install has been removed in a previous patch.


----

# 

When running bin/doom doctor and plantuml.jar is not found the recommendation is
to use the +plantuml/install command. But this command has been removed some
time ago. Instead it works to run the commnand plantuml-dowload-jar. This commit
updates the subscription by the doctor.