### PR TITLE
Fix #2177

### DIFF
--- a/modules/ui/popup/autoload/popup.el
+++ b/modules/ui/popup/autoload/popup.el
@@ -415,8 +415,9 @@ the message buffer in a popup window."
 
 ;;;###autoload
 (defun +popup/raise (window &optional arg)
-  "Raise the current popup window into a regular window.
-If prefix ARG, raise the current popup into a new window."
+  "Raise the current popup window into a regular window and
+return it. If prefix ARG, raise the current popup into a new
+window and return that window."
   (interactive
    (list (selected-window) current-prefix-arg))
   (cl-check-type window window)
@@ -428,7 +429,8 @@ If prefix ARG, raise the current popup into a new window."
     (+popup/close window 'force)
     (if arg
         (pop-to-buffer buffer)
-      (switch-to-buffer buffer))))
+      (switch-to-buffer buffer))
+    (selected-window)))
 
 ;;;###autoload
 (defun +popup/diagnose ()


### PR DESCRIPTION
Hi Henrik,

this PR addresses [2177](https://github.com/hlissner/doom-emacs/issues/2177).

The code to select a target directory for a copy/move operation was not executed because of an error. That error was due to `+popup--delete-other-windows` expecting `+popup/raise` to return a window, whereas it returned a buffer instead.