### PR TITLE
fix: gruvbox theme with solaire-mode

### DIFF
--- a/modules/ui/doom/config.el
+++ b/modules/ui/doom/config.el
@@ -5,6 +5,7 @@
     (doom-city-lights . t)
     (doom-dracula . t)
     (doom-molokai)
+    (doom-gruvbox . t)
     (doom-nord . t)
     (doom-nord-light . t)
     (doom-nova)


### PR DESCRIPTION
I believe that `doom-gruvbox` supports solaire, which means that the background colors are swapped. This PR adds the `doom-gruvbox` theme to the list of supported solaire themes.