### PR TITLE
lang/clojure: Update to cider-clojuredocs

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -94,9 +94,10 @@
             (:prefix ("h" . "help")
               "n" #'cider-find-ns
               "a" #'cider-apropos
+              "c" #'cider-clojuredocs
               "d" #'cider-doc
-              "g" #'cider-grimoire-web
-              "j" #'cider-javadoc)
+              "j" #'cider-javadoc
+              "w" #'cider-clojuredocs-web)
             (:prefix ("i" . "inspect")
               "e" #'cider-enlighten-mode
               "i" #'cider-inspect


### PR DESCRIPTION
CIDER removed `cider-grimoire-web` as Grimoire is no longer available. Now it uses ClojureDocs:
- https://metaredux.com/posts/2019/06/29/farewell-grimoire.html
- https://github.com/clojure-emacs/cider/issues/2663

For reference, taken from [cider_mode.adoc](https://github.com/clojure-emacs/cider/blob/master/doc/modules/ROOT/pages/usage/cider_mode.adoc#key-reference): 

Command | Keyboard shortcut | Description
-- | -- | --
`cider-clojuredocs` | `C-c C-d c` or `C-c C-d C-c` | Lookup symbol in ClojureDocs.
`cider-clojuredocs-web` | `C-c C-d w` or `C-c C-d C-w` | Open the ClojureDocs documentation for symbol in a web browser.

