### PR TITLE
irc: turn off smartparens mode for circe buffers

### DIFF
--- a/modules/app/irc/config.el
+++ b/modules/app/irc/config.el
@@ -93,6 +93,7 @@ playback.")
   (add-hook 'doom-real-buffer-functions #'+circe-buffer-p)
   (add-hook 'circe-channel-mode-hook #'turn-on-visual-line-mode)
   (add-hook 'circe-mode-hook #'+irc--add-circe-buffer-to-persp-h)
+  (add-hook 'circe-mode-hook #'turn-off-smartparens-mode)
 
   (defadvice! +irc--circe-run-disconnect-hook-a (&rest _)
     "Runs `+irc-disconnect-hook' after circe disconnects."


### PR DESCRIPTION
Users probably don't want ":-(" to be autocompleted as ":-()" so let's
turn of smartparens for chatting.