### PR TITLE
dap-mode: set extensions variable to doom-cache

### DIFF
--- a/modules/tools/debugger/config.el
+++ b/modules/tools/debugger/config.el
@@ -23,8 +23,10 @@
 (use-package! dap-mode
   :when (featurep! :tools lsp)
   :after lsp-mode
-  :preface (setq dap--breakpoints-file (concat doom-etc-dir "dap-breakpoints"))
-  :init (add-hook 'dap-mode-hook #'dap-ui-mode) ; use a hook so users can remove it
+  :preface
+  (add-hook 'dap-mode-hook #'dap-ui-mode) ; use a hook so users can remove it
+  (setq dap--breakpoints-file (concat doom-etc-dir "dap-breakpoints")
+        dap-utils-extension-path (concat doom-etc-dir "dap-extension/"))
   :config
   (dap-mode 1)
   (dolist (module '(((:lang . cc) ccls dap-lldb dap-gdb-lldb)


### PR DESCRIPTION
Previously, this would put the .extension directory in
`user-emacs-directory' which in doom's case will be in the root of the
doom directory.

So, we move the directory to doom's cache dir and also name it something
descriptive instead of 'extension'.