### PR TITLE
Remove lispy from evil-collections

### DIFF
--- a/modules/editor/evil/+everywhere.el
+++ b/modules/editor/evil/+everywhere.el
@@ -35,7 +35,8 @@
     package-menu
     ruby-mode
     simple
-    slime)
+    slime
+    lispy)
   "A list of `evil-collection' modules to ignore. See the definition of this
 variable for an explanation of the defaults (in comments). See
 `evil-collection-mode-list' for a list of available options.")


### PR DESCRIPTION
The bindings that it creates are weird and conflict with lispyville's
own bindings.