### PR TITLE
Fix completion of doom-help-modules in doom! macro

### DIFF
--- a/core/autoload/help.el
+++ b/core/autoload/help.el
@@ -340,7 +340,9 @@ without needing to check if they are available."
               (file-in-directory-p buffer-file-name doom-private-dir)
               (save-excursion (goto-char (point-min))
                               (re-search-forward "^\\s-*(doom! " nil t))
-              (thing-at-point 'sexp t)))
+              (save-excursion (re-search-backward "\\(:\\w*\\)" nil t))
+              (concat (match-string 0) " "
+                      (thing-at-point 'sexp t))))
         ((save-excursion
            (require 'smartparens)
            (ignore-errors


### PR DESCRIPTION
The default completion in doom! macro used only the name of thing at
point instead of also pulling the category to give a valid candidate.