### PR TITLE
Enable zen mode keybind only if zen module present

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -616,7 +616,8 @@
         (:when (featurep! :lang org +pomodoro)
           :desc "Pomodoro timer"             "t" #'org-pomodoro)
         :desc "Word-wrap mode"               "w" #'+word-wrap-mode
-        :desc "Zen mode"                     "z" #'writeroom-mode))
+        (:when (featurep! :ui zen)
+          :desc "Zen mode"                     "z" #'writeroom-mode)))
 
 (after! which-key
   (let ((prefix-re (regexp-opt (list doom-leader-key doom-leader-alt-key))))


### PR DESCRIPTION
Previously it would error with `command-execute: Wrong type argument: commandp, writeroom-mode`.