### PR TITLE
fix flyspell-correct

### DIFF
--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -509,7 +509,7 @@ To change these keys see `+evil-repeat-keys'."
           :n "gr" #'elfeed-search-update--force
           :n "gR" #'elfeed-search-fetch))
 
-      :nv "z="    #'flyspell-correct-word-generic
+      :nv "z="    #'flyspell-correct-at-point
       ;; custom evil keybinds
       :nv "zn"    #'+evil:narrow-buffer
       :n  "zN"    #'doom/widen-indirectly-narrowed-buffer

--- a/modules/tools/flyspell/config.el
+++ b/modules/tools/flyspell/config.el
@@ -68,13 +68,13 @@ e.g. proselint and langtool."
   (add-hook 'flyspell-mode-hook #'+flyspell-init-predicate-h)
 
   (map! :map flyspell-mouse-map
-        "RET"     #'flyspell-correct-word-generic
-        [return]  #'flyspell-correct-word-generic
-        [mouse-1] #'flyspell-correct-word-generic))
+        "RET"     #'flyspell-correct-at-point
+        [return]  #'flyspell-correct-at-point
+        [mouse-1] #'flyspell-correct-at-point))
 
 
 (use-package! flyspell-correct
-  :commands flyspell-correct-word-generic flyspell-correct-previous-word-generic
+  :commands flyspell-correct-at-point flyspell-correct-previous
   :config
   (cond ((and (featurep! :completion helm)
               (require 'flyspell-correct-helm nil t)))


### PR DESCRIPTION
Yesterday, flyspell-correct had a new release, version 0.6.1 which removed aliases used in modules/tool/flyspell/config.el and modules/editor/evil/config.el

  https://github.com/d12frosted/flyspell-correct/commit/7b4cf8c9ba5ac65e3bb2b62f5b72d45f4c9cf7b6

This patch updates those calls.