### PR TITLE
ui/doom-dashboard: De-hardcode dashboard faces

### DIFF
--- a/modules/ui/doom-dashboard/README.org
+++ b/modules/ui/doom-dashboard/README.org
@@ -10,6 +10,7 @@
 - [[#configuration][Configuration]]
   - [[#a-custom-banner][A custom banner]]
   - [[#adding-text-to-the-dashboard][Adding text to the dashboard]]
+  - [[#customizing-faces][Customizing Faces]]
 
 * Description
 This module adds a minimalistic, Atom-inspired dashboard to Emacs.
@@ -61,3 +62,27 @@ whatever you like to Doom's splash screen.
 Keep in mind that inserting text from expensive sources, e.g. your org agenda,
 will negate most of Doom's startup benefits.
 #+end_quote
+
+** Customizing Faces
+Doom's dashboard defaults to inheriting faces set by the current theme. If you wish
+to customize it independently of the theme (or just inherit a different color
+from the theme) you can make use of ~custom-set-faces!~ or  ~custom-theme-set-faces!~
+#+BEGIN_SRC elisp
+(custom-set-faces!
+  '(doom-dashboard-banner :foreground "red" :background "#000000" :weight bold)
+  '(doom-dashboard-footer :inherit font-lock-constant-face)
+  '(doom-dashboard-footer-icon :inherit all-the-icons-red)
+  '(doom-dashboard-loaded :inherit font-lock-warning-face)
+  '(doom-dashboard-menu-desc :inherit font-lock-string-face)
+  '(doom-dashboard-menu-title :inherit font-lock-function-name-face))
+#+END_SRC
+or for a per-theme setting
+#+BEGIN_SRC elisp
+(custom-theme-set-faces! 'doom-tomorrow-night
+  '(doom-dashboard-banner :foreground "red" :background "#000000" :weight bold)
+  '(doom-dashboard-footer :inherit font-lock-constant-face)
+  '(doom-dashboard-footer-icon :inherit all-the-icons-red)
+  '(doom-dashboard-loaded :inherit font-lock-warning-face)
+  '(doom-dashboard-menu-desc :inherit font-lock-string-face)
+  '(doom-dashboard-menu-title :inherit font-lock-function-name-face))
+#+END_SRC

--- a/modules/ui/doom-dashboard/config.el
+++ b/modules/ui/doom-dashboard/config.el
@@ -43,32 +43,32 @@ Possible values:
 
 (defvar +doom-dashboard-menu-sections
   '(("Reload last session"
-     :icon (all-the-icons-octicon "history" :face 'font-lock-keyword-face)
+     :icon (all-the-icons-octicon "history" :face 'doom-dashboard-menu-title)
      :when (cond ((require 'persp-mode nil t)
                   (file-exists-p (expand-file-name persp-auto-save-fname persp-save-dir)))
                  ((require 'desktop nil t)
                   (file-exists-p (desktop-full-file-name))))
-     :face (:inherit (font-lock-keyword-face bold))
+     :face (:inherit (doom-dashboard-menu-title bold))
      :action doom/quickload-session)
     ("Open org-agenda"
-     :icon (all-the-icons-octicon "calendar" :face 'font-lock-keyword-face)
+     :icon (all-the-icons-octicon "calendar" :face 'doom-dashboard-menu-title)
      :when (fboundp 'org-agenda)
      :action org-agenda)
     ("Recently opened files"
-     :icon (all-the-icons-octicon "file-text" :face 'font-lock-keyword-face)
+     :icon (all-the-icons-octicon "file-text" :face 'doom-dashboard-menu-title)
      :action recentf-open-files)
     ("Open project"
-     :icon (all-the-icons-octicon "briefcase" :face 'font-lock-keyword-face)
+     :icon (all-the-icons-octicon "briefcase" :face 'doom-dashboard-menu-title)
      :action projectile-switch-project)
     ("Jump to bookmark"
-     :icon (all-the-icons-octicon "bookmark" :face 'font-lock-keyword-face)
+     :icon (all-the-icons-octicon "bookmark" :face 'doom-dashboard-menu-title)
      :action bookmark-jump)
     ("Open private configuration"
-     :icon (all-the-icons-octicon "tools" :face 'font-lock-keyword-face)
+     :icon (all-the-icons-octicon "tools" :face 'doom-dashboard-menu-title)
      :when (file-directory-p doom-private-dir)
      :action doom/open-private-config)
     ("Open documentation"
-     :icon (all-the-icons-octicon "book" :face 'font-lock-keyword-face)
+     :icon (all-the-icons-octicon "book" :face 'doom-dashboard-menu-title)
      :action doom/help))
   "An alist of menu buttons used by `doom-dashboard-widget-shortmenu'. Each
 element is a cons cell (LABEL . PLIST). LABEL is a string to display after the
@@ -133,6 +133,36 @@ PLIST can have the following properties:
 
 (add-hook 'doom-init-ui-hook #'+doom-dashboard-init-h)
 
+;;
+;;; Faces
+(defgroup doom-dashboard nil
+  "Manage how doom-dashboard is coloured and themed."
+  :prefix "doom-dashboard"
+  :group 'doom-themes)
+
+(defface doom-dashboard-banner '((t (:inherit font-lock-comment-face)))
+  "Face used for the DOOM banner on the dashboard"
+  :group 'doom-dashboard)
+
+(defface doom-dashboard-footer '((t (:inherit font-lock-keyword-face)))
+  "Face used for the footer on the dashboard"
+  :group 'doom-dashboard)
+
+(defface doom-dashboard-footer-icon '((t (:inherit all-the-icons-green)))
+  "Face used for the icon of the footer on the dashboard"
+  :group 'doom-dashboard)
+
+(defface doom-dashboard-loaded '((t (:inherit font-lock-comment-face)))
+  "Face used for the loaded packages benchmark"
+  :group 'doom-dashboard)
+
+(defface doom-dashboard-menu-desc '((t (:inherit font-lock-constant-face)))
+  "Face used for the key description of menu widgets on the dashboard"
+  :group 'doom-dashboard)
+
+(defface doom-dashboard-menu-title '((t (:inherit font-lock-keyword-face)))
+  "Face used for the title of menu widgets on the dashboard"
+  :group 'doom-dashboard)
 
 ;;
 ;;; Major mode
@@ -352,7 +382,7 @@ controlled by `+doom-dashboard-pwd-policy'."
   (let ((point (point)))
     (mapc (lambda (line)
             (insert (propertize (+doom-dashboard--center +doom-dashboard--width line)
-                                'face 'font-lock-comment-face) " ")
+                                'face 'doom-dashboard-banner) " ")
             (insert "\n"))
           '("=================     ===============     ===============   ========  ========"
             "\\\\ . . . . . . .\\\\   //. . . . . . .\\\\   //. . . . . . .\\\\  \\\\. . .\\\\// . . //"
@@ -397,7 +427,7 @@ controlled by `+doom-dashboard-pwd-policy'."
     (+doom-dashboard--center
      +doom-dashboard--width
      (doom-display-benchmark-h 'return))
-    'face 'font-lock-comment-face)
+    'face 'doom-dashboard-loaded)
    "\n"))
 
 (defun doom-dashboard-widget-shortmenu ()
@@ -422,11 +452,11 @@ controlled by `+doom-dashboard-pwd-policy'."
                          `(lambda (_)
                             (call-interactively (or (command-remapping #',action)
                                                     #',action)))
-                         'face (or face 'font-lock-keyword-face)
+                         'face (or face 'doom-dashboard-menu-title)
                          'follow-link t
                          'help-echo
                          (format "%s (%s)" label
-                                 (propertize (symbol-name action) 'face 'font-lock-constant-face)))
+                                 (propertize (symbol-name action) 'face 'doom-dashboard-menu-desc)))
                         (format "%-37s" (buffer-string)))
                       ;; Lookup command keys dynamically
                       (or (when-let (key (where-is-internal action nil t))
@@ -438,7 +468,7 @@ controlled by `+doom-dashboard-pwd-policy'."
                                    (upcase (if (< (length str) 3)
                                                str
                                              (substring str 0 3))))))
-                              (propertize (buffer-string) 'face 'font-lock-constant-face)))
+                              (propertize (buffer-string) 'face 'doom-dashboard-menu-desc)))
                           ""))))
            (if (display-graphic-p)
                "\n\n"
@@ -450,8 +480,8 @@ controlled by `+doom-dashboard-pwd-policy'."
    (+doom-dashboard--center
     (- +doom-dashboard--width 2)
     (with-temp-buffer
-      (insert-text-button (or (all-the-icons-octicon "octoface" :face 'all-the-icons-green :height 1.3 :v-adjust -0.15)
-                              (propertize "github" 'face 'font-lock-keyword-face))
+      (insert-text-button (or (all-the-icons-octicon "octoface" :face 'doom-dashboard-footer-icon :height 1.3 :v-adjust -0.15)
+                              (propertize "github" 'face 'doom-dashboard-footer))
                           'action (lambda (_) (browse-url "https://github.com/hlissner/doom-emacs"))
                           'follow-link t
                           'help-echo "Open Doom Emacs github page")


### PR DESCRIPTION
Doom's dashboard faces are currently hardcoded to font-lock faces set by the current theme. These changes let you customize the faces independently of the current theme without having to change the widget functions themselves.