### PR TITLE
Fix source code highlighting when using marked.js

### DIFF
--- a/modules/lang/markdown/config.el
+++ b/modules/lang/markdown/config.el
@@ -40,7 +40,7 @@ capture, the end position, and the output buffer.")
         (concat "<meta name='viewport' content='width=device-width, initial-scale=1, shrink-to-fit=no'>"
                 "<style> body { box-sizing: border-box; max-width: 740px; width: 100%; margin: 40px auto; padding: 0 10px; } </style>"
                 "<script src='https://cdn.jsdelivr.net/gh/highlightjs/cdn-release/build/highlight.min.js'></script>"
-                "<script>document.addEventListener('DOMContentLoaded', () => { document.body.classList.add('markdown-body'); document.querySelectorAll('pre[lang] > code').forEach((code) => { code.classList.add(code.parentElement.lang); hljs.highlightBlock(code); }); }); </script>"))
+                "<script>document.addEventListener('DOMContentLoaded', () => { document.body.classList.add('markdown-body'); document.querySelectorAll('pre[lang] > code').forEach((code) => { code.classList.add(code.parentElement.lang); }); document.querySelectorAll('pre > code').forEach((code) => { hljs.highlightBlock(code); }); });</script>"))
 
   :config
   (set-flyspell-predicate! '(markdown-mode gfm-mode)


### PR DESCRIPTION
I'm currently experiencing problems getting the source code highlighting to work with https://github.com/markedjs/marked

The reason is that Marked outputs the following structure:

```html
<pre><code class="language-js">const hello = 'world';</code></pre>
```

and the current selector expects the `pre` tag to have a `lang` attribute. 

This PR splits the forwarding of the `lang` attribute to a class and the code that initialise the highlighting for each block. It will try to initialise the highlighting for every `code` block that is inside a `pre` tag.