### PR TITLE
cli: Handle --help without an argument

### DIFF
--- a/bin/doom
+++ b/bin/doom
@@ -51,7 +51,8 @@ with a different private module."
       (setq doom-auto-accept t)
       (print! (info "Auto-yes on")))
     (when help-p
-      (push command args)
+      (when command
+        (push command args))
       (setq command "help"))
 
     ;; Reload core in case any of the directories were changed.


### PR DESCRIPTION
Fixes https://github.com/hlissner/doom-emacs/issues/2303. 