### PR TITLE
Suppress delete-window in org related functions

### DIFF
--- a/modules/ui/popup/+hacks.el
+++ b/modules/ui/popup/+hacks.el
@@ -240,6 +240,8 @@ the command buffer."
               org-fast-todo-selection)
     (if +popup-mode
         (cl-letf (((symbol-function #'delete-other-windows)
+                   (symbol-function #'ignore))
+                  ((symbol-function #'delete-window)
                    (symbol-function #'ignore)))
           (apply orig-fn args))
       (apply orig-fn args)))


### PR DESCRIPTION
- If there's only one other window, delete-window would be called,
  instead of delete-other-windows
- when there is only one window other than the popup, this other window
  is the main window in this frame, delete it would raise an error:
  `delete-window: Attempt to delete main window of frame <frame name>`
