### PR TITLE
Fix name of solarized package

### DIFF
--- a/docs/faq.org
+++ b/docs/faq.org
@@ -614,7 +614,7 @@ install it, then load it:
 
 #+BEGIN_SRC emacs-lisp
 ;;; add to ~/.doom.d/packages.el
-(package! solarized)
+(package! solarized-theme)
 
 ;;; add to ~/.doom.d/config.el
 (setq doom-theme 'solarized-dark)


### PR DESCRIPTION
The example of using a third party theme previously didn't work, because there is no package `solarized`. Instead, `solarized-theme` provides the theme.