### PR TITLE
Be explicit about `fc-list` when listing fonts

### DIFF
--- a/core/cli/doctor.el
+++ b/core/cli/doctor.el
@@ -136,7 +136,7 @@ in."
                        (`darwin "~/Library/Fonts/"))
                      (require 'all-the-icons nil t))
             (with-temp-buffer
-              (insert (cdr (doom-call-process "fc-list")))
+              (insert (cdr (doom-call-process "fc-list" "" "file")))
               (dolist (font all-the-icons-font-names)
                 (if (save-excursion (re-search-backward font nil t))
                     (success! "Found font %s" font)


### PR DESCRIPTION
On my redhat 6 box, I always had this "couldn't find font" warning, even though I have installed them and don't have any problem using them. As it turned out, calling `fc-list` prints
```sh
> fc-list
Liberation Mono for Powerline,Literation Mono Powerline:style=Bold Italic
Nimbus Sans L:style=Bold Condensed Italic
URW Bookman L:style=Demi Bold Italic
Liberation Sans:style=Italic
Source Code Pro for Powerline,Source Code Pro Black:style=Black,Regular
Source Code Pro for Powerline,Source Code Pro Light:style=Light,Regular
Meslo LG M DZ for Powerline:style=Regular
...
```
So the results don't have the font location, therefore `doom doctor` think they are not installed. The correct command to call is `fc-list : file`. 