### PR TITLE
Use newer cider-ns-refresh in Clojure bindings

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -112,7 +112,7 @@
             (:prefix ("r" . "repl")
               "n" #'cider-repl-set-ns
               "q" #'cider-quit
-              "r" #'cider-refresh
+              "r" #'cider-ns-refresh
               "R" #'cider-restart
               "b" #'cider-switch-to-repl-buffer
               "B" #'+clojure/cider-switch-to-repl-buffer-and-switch-ns


### PR DESCRIPTION
Cider deprecated `cider-refresh` in favour of `cider-ns-refresh` in version 0.18.

https://github.com/clojure-emacs/cider/blob/master/CHANGELOG.md#changes-6
