### PR TITLE
evil: use featurep! on word-wrap/zen bindings

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -621,8 +621,10 @@
           :desc "Flyspell"                   "s" #'flyspell-mode)
         (:when (featurep! :lang org +pomodoro)
           :desc "Pomodoro timer"             "t" #'org-pomodoro)
-        :desc "Word-wrap mode"               "w" #'+word-wrap-mode
-        :desc "Zen mode"                     "z" #'writeroom-mode))
+        (:when (featurep! :editor word-wrap)
+          :desc "Word-wrap mode"             "w" #'+word-wrap-mode)
+        (:when (featurep! :ui zen)
+          :desc "Zen mode"                   "z" #'writeroom-mode)))
 
 (after! which-key
   (let ((prefix-re (regexp-opt (list doom-leader-key doom-leader-alt-key))))


### PR DESCRIPTION
Just a quick fix for those who don't have those modules enabled.