### PR TITLE
Make magit-gitflow an optional feature

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -91,7 +91,8 @@
         +docsets)        ; ...or in Dash docsets locally
        ;;lsp
        ;;macos             ; MacOS-specific commands
-       magit             ; a git porcelain for Emacs
+       (magit            ; a git porcelain for Emacs
+        +gitflow)
        ;;make              ; run make tasks from Emacs
        ;;pass              ; password manager for nerds
        ;;pdf               ; pdf enhancements

--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -133,6 +133,7 @@ ensure it is built when we actually use Forge."
 
 
 (use-package! magit-gitflow
+  :when (featurep! :tools magit +gitflow)
   :hook (magit-mode . turn-on-magit-gitflow))
 
 

--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -151,9 +151,11 @@ ensure it is built when we actually use Forge."
     "0") ; moved to g=
   (evil-define-key* 'normal magit-status-mode-map [escape] nil) ; q is enough
   (evil-define-key* '(normal visual) magit-mode-map
-    "%"  #'magit-gitflow-popup
     "zz" #'evil-scroll-line-to-center
     "g=" #'magit-diff-default-context)
+  (when (featurep! :tools magit +gitflow)
+    (evil-define-key* '(normal visual) magit-mode-map
+      "%"  #'magit-gitflow-popup))
   (define-key! 'normal
     (magit-status-mode-map
      magit-stash-mode-map

--- a/modules/tools/magit/packages.el
+++ b/modules/tools/magit/packages.el
@@ -3,7 +3,8 @@
 
 (when (package! magit)
   (package! forge)
-  (package! magit-gitflow)
+  (when (featurep! :tools magit +gitflow)
+    (package! magit-gitflow))
   (package! magit-todos)
   (package! github-review)
   (when (featurep! :editor evil +everywhere)


### PR DESCRIPTION
Because this requires the nonstandard `git-flow` system library to be installed, I feel like this feature should be optional. Sometimes, I just want to use the default `magit-worktree` functionality.

An alternative would be to check for the existence of `git flow` commands and automatically enable `magit-gitflow` only if they are available.

I revised the `init.example.el` file so this is enabled by default, to mimic the current behavior. However, this _will_ disable `magit-gitflow` in everyone's current `init.el` files.