### PR TITLE
Closes #2331

### DIFF
--- a/bin/doom
+++ b/bin/doom
@@ -13,7 +13,7 @@
        (loaddir (file-name-directory (file-truename load-file-name)))
        (emacsdir (getenv "EMACSDIR"))
        (user-emacs-directory
-        (abbreviate-file-name (or emacsdir (expand-file-name "../" loaddir)))))
+        (abbreviate-file-name (or emacsdir (expand-file-name "../" loaddir))))))
 
   (push (expand-file-name "core" user-emacs-directory) load-path)
   (require 'core)


### PR DESCRIPTION
> - [x] This PR targets the `develop` branch and not `master`
> - [x] Its commits' summaries are reasonably descriptive
> - [x] You've described what this PR addresses below

>
> Thank you for contributing to Doom Emacs! <3

Missing ) was causing error "Symbol's value as variable is void" . Counted parentheses to verify. After adding ')' install works.

"(let*" was not closed

Also this could be a thing with my system as well? A moment ago, I got flychecker got error 255
and said emacs-lisp may be too old

Un-related note: I love doom-emacs, thanks to all who develop on it.