### PR TITLE
Make sudo-this-file usable in dired-buffers

### DIFF
--- a/core/autoload/files.el
+++ b/core/autoload/files.el
@@ -345,7 +345,10 @@ file if it exists, without confirmation."
 (defun doom/sudo-this-file ()
   "Open the current file as root."
   (interactive)
-  (find-alternate-file (doom--sudo-file buffer-file-name)))
+  (find-alternate-file (doom--sudo-file (or buffer-file-name
+                                            (when (or (derived-mode-p 'dired-mode)
+                                                      (derived-mode-p 'wdired-mode))
+                                              default-directory)))))
 
 ;;;###autoload
 (defun doom/sudo-save-buffer ()


### PR DESCRIPTION
Hi Henrik,

this PR allows doom/sudo-this-file to be called from dired-buffers, opening the directory as root. Previously such invocations would lead to an error, since buffer-file-name is nil for dired-buffers.