### PR TITLE
Fix #2349: Make +format-completing-read return symbol

### DIFF
--- a/modules/editor/format/autoload/format.el
+++ b/modules/editor/format/autoload/format.el
@@ -95,7 +95,7 @@ Stolen shamelessly from go-mode"
   (require 'format-all)
   (let* ((fmtlist (mapcar #'symbol-name (hash-table-keys format-all--format-table)))
          (fmt (completing-read "Formatter: " fmtlist)))
-    (if fmt (cons (intern fmt) t))))
+    (if fmt (intern fmt))))
 
 ;;;###autoload
 (defun +format-probe-a (orig-fn)


### PR DESCRIPTION
Currently `+format-completing-read` returns a cons cell like `(symbol . t)`, where `+format/buffer` expects a symbol. This commit makes `+format-completing-read` return a symbol instead. Fixes #2349.