### PR TITLE
Correct behaviour of normal mode 'o' and 'O' in haskell-mode

### DIFF
--- a/modules/lang/haskell/autoload.el
+++ b/modules/lang/haskell/autoload.el
@@ -12,3 +12,20 @@
            (haskell-session-interactive-buffer (haskell-session))))))
       (window-buffer window)
     (error "Failed to display Haskell REPL")))
+
+;;;###autoload
+(defun +haskell/evil-open-above
+  "Opens a line above the current mode"
+  (interactive)
+  (evil-digit-argument-or-evil-beginning-of-line)
+  (haskell-indentation-newline-and-indent)
+  (evil-previous-line)
+  (haskell-indentation-indent-line)
+  (evil-append-line nil))
+
+;;;###autoload
+(defun +haskell/evil-open-below ()
+  "Opens a line below the current mode"
+  (interactive)
+  (evil-append-line nil)
+  (haskell-indentation-newline-and-indent))

--- a/modules/lang/haskell/autoload.el
+++ b/modules/lang/haskell/autoload.el
@@ -14,7 +14,7 @@
     (error "Failed to display Haskell REPL")))
 
 ;;;###autoload
-(defun +haskell/evil-open-above
+(defun +haskell/evil-open-above ()
   "Opens a line above the current mode"
   (interactive)
   (evil-digit-argument-or-evil-beginning-of-line)

--- a/modules/lang/haskell/config.el
+++ b/modules/lang/haskell/config.el
@@ -32,6 +32,10 @@
 
   (add-to-list 'completion-ignored-extensions ".hi")
 
+  (map! :map haskell-mode-map
+        "o" #'+haskell/evil-open-below
+        "O" #'+haskell/evil-open-above)
+
   (map! :localleader
         :map haskell-mode-map
         ;; this is set to use cabal for dante users and stack for intero users:

--- a/modules/lang/haskell/config.el
+++ b/modules/lang/haskell/config.el
@@ -33,8 +33,8 @@
   (add-to-list 'completion-ignored-extensions ".hi")
 
   (map! :map haskell-mode-map
-        "o" #'+haskell/evil-open-below
-        "O" #'+haskell/evil-open-above)
+        :n "o" #'+haskell/evil-open-below
+        :n "O" #'+haskell/evil-open-above)
 
   (map! :localleader
         :map haskell-mode-map


### PR DESCRIPTION
Overwrite the 'o' and 'O' normal mode commands to correctly indent
new lines.
Code was adapted from: https://github.com/haskell/haskell-mode/issues/1265

This adresses an issue where new lines created by 'o' and 'O' where not correctly indented.
