### PR TITLE
Fix pdf-outline error

### DIFF
--- a/modules/tools/pdf/config.el
+++ b/modules/tools/pdf/config.el
@@ -45,7 +45,7 @@
 
   ;; Handle PDF-tools related popups better
   (set-popup-rules!
-    '(("^\\*Outline*" :side 'right :size 40 :select nil)
+    '(("^\\*Outline*" :side right :size 40 :select nil)
       ("\\(?:^\\*Contents\\|'s annots\\*$\\)" :ignore t)))
 
   ;; The mode-line does serve any useful purpose is annotation windows


### PR DESCRIPTION
Runnning `pdf-outline` resulting in the error `Invalid side 'right specified`. This PR fixes it.