### PR TITLE
Fix for https://github.com/hlissner/doom-emacs/issues/2343

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -263,6 +263,8 @@ I like:
    vimperator, dmenu or a global keybinding."
   (setq org-default-notes-file
         (expand-file-name +org-capture-notes-file org-directory)
+        +org-capture-journal-file
+        (expand-file-name +org-capture-journal-file org-directory)
         org-capture-templates
         '(("t" "Personal todo" entry
            (file+headline +org-capture-todo-file "Inbox")


### PR DESCRIPTION
https://github.com/hlissner/doom-emacs/issues/2343 seems to describe an issue where the correct `journal.org` isn't found. I experienced the same problems. Based off https://github.com/hlissner/doom-emacs/issues/2343#issuecomment-572719940, I figured that setting `(setq +org capture-journal-file (expand-file-name "my_journal.org"  org-directory)` in `.../org/config.el` would fix the issue, which it did. 

If there is a more elegant solution you'd prefer, I'd be happy to change (I'm still a relative noob when it comes to elisp!) 
