### PR TITLE
Update lsp-server-install-dir location

### DIFF
--- a/modules/tools/lsp/config.el
+++ b/modules/tools/lsp/config.el
@@ -22,7 +22,8 @@ This can be a single company backend or a list thereof. It can be anything
   (setq lsp-keep-workspace-alive nil)
 
   ;; For `lsp-clients'
-  (setq lsp-fsharp-server-install-dir (concat doom-etc-dir "lsp-fsharp/")
+  (setq lsp-server-install-dir (concat doom-etc-dir "lsp")
+        lsp-fsharp-server-install-dir (concat doom-etc-dir "lsp-fsharp/")
         lsp-groovy-server-install-dir (concat doom-etc-dir "lsp-groovy/")
         lsp-intelephense-storage-path (concat doom-cache-dir "lsp-intelephense/"))
 


### PR DESCRIPTION
Update the lsp-server-install-dir to doom-etc-dir. This aligns the installation
location with other lsp servers.

----

# 

Other lsp servers are installed under doom-etc-dir. When the user installs a
server through the command lsp-install-server it make sense if those servers
are also installed under the doom-etc-dir. At the moment they are instead
installed in the default location which is .emacs.d/.cache/lsp.