### PR TITLE
Update feature check of flycheck in evil-bindings

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -372,7 +372,7 @@
         :desc "Delete trailing whitespace"            "w"   #'delete-trailing-whitespace
         :desc "Delete trailing newlines"              "W"   #'doom/delete-trailing-newlines
         :desc "List errors"                           "x"   #'flymake-show-diagnostics-buffer
-        (:when (featurep! :tools flycheck)
+        (:when (featurep! :checkers syntax)
           :desc "List errors"                         "x"   #'flycheck-list-errors))
 
       ;;; <leader> f --- file
@@ -606,7 +606,7 @@
       (:prefix-map ("t" . "toggle")
         :desc "Big mode"                     "b" #'doom-big-font-mode
         :desc "Flymake"                      "f" #'flymake-mode
-        (:when (featurep! :tools flycheck)
+        (:when (featurep! :checkers syntax)
           :desc "Flycheck"                   "f" #'flycheck-mode)
         :desc "Frame fullscreen"             "F" #'toggle-frame-fullscreen
         :desc "Evil goggles"                 "g" #'evil-goggles-mode


### PR DESCRIPTION
This patch updates the check for enabling flycheck bindings to the new
module location.


----

# 

the evil-bindings check for enabling flycheck bindings is not synced with the
new module location.