### PR TITLE
Use Docker docset for dockerfile-mode

### DIFF
--- a/modules/tools/docker/config.el
+++ b/modules/tools/docker/config.el
@@ -1,6 +1,7 @@
 ;;; tools/docker/config.el -*- lexical-binding: t; -*-
 
 (after! docker
+  (set-docsets! 'dockerfile-mode "Docker")
   (set-evil-initial-state!
     '(docker-container-mode
       docker-image-mode


### PR DESCRIPTION
This patch setups the appropriate docset to use in dockerfile-mode.
Similar to how it is done for other major-modes that have associated
docsets.

----

# Add docset configuration for Docker

When dockerfile-mode is active it make sense to activate the Docker docset.