### PR TITLE
Doctor: Check whether rbenv is enabled before complaining

### DIFF
--- a/modules/lang/ruby/doctor.el
+++ b/modules/lang/ruby/doctor.el
@@ -7,6 +7,6 @@
 (unless (executable-find "ruby")
   (warn! "Ruby isn't installed."))
 
-(when (executable-find "rbenv")
+(when (and (executable-find "rbenv") (featurep! +rbenv))
   (unless (split-string (shell-command-to-string "rbenv versions --bare") "\n" t)
     (warn! "No versions of ruby are available via rbenv, did you forget to install one?")))


### PR DESCRIPTION
This fixes an issue where `doom doctor` was giving me the error:

```
      ! No versions of ruby are available via rbenv, did you forget to install one?
```

even though I have `(ruby +rvm)` in my `init.el` and don't use rbenv.