### PR TITLE
Add macOS Preview to +latex-viewers

### DIFF
--- a/modules/lang/latex/+viewers.el
+++ b/modules/lang/latex/+viewers.el
@@ -20,7 +20,8 @@
     (`preview
      (when (and IS-MAC
                 (file-exists-p! "/System/Applications/Preview.app"))
-       (add-to-list 'TeX-view-program-selection '(output-pdf "Preview"))))
+       (add-to-list 'TeX-view-program-selection '(output-pdf "Preview"))
+       (add-to-list 'TeX-view-program-list '("Preview" ("open %o -a Preview")))))
 
     (`sumatrapdf
      (when (and IS-WINDOWS

--- a/modules/lang/latex/+viewers.el
+++ b/modules/lang/latex/+viewers.el
@@ -17,6 +17,11 @@
                     (list "Skim" (format "%s/Contents/SharedSupport/displayline -b -g %%n %%o %%b"
                                          app-path)))))
 
+    (`preview
+     (when (and IS-MAC
+                (file-exists-p! "/System/Applications/Preview.app"))
+       (add-to-list 'TeX-view-program-selection '(output-pdf "Preview"))))
+
     (`sumatrapdf
      (when (and IS-WINDOWS
                 (executable-find "SumatraPDF"))

--- a/modules/lang/latex/README.org
+++ b/modules/lang/latex/README.org
@@ -56,9 +56,10 @@ PDFs:
 #+END_SRC
 
 ** Changing the PDFs viewer
-This module provides integration for four supported pdf viewers. They are
+This module provides integration for seven supported pdf viewers. They are
 
 + [[https://skim-app.sourceforge.io/][Skim.app]] (MacOS only)
++ Preview (MacOS only)
 + Evince
 + Sumatra PDF
 + Zathura

--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -11,10 +11,10 @@
 enabling unicode symbols in math regions. This requires the unicode-math latex
 package to be installed.")
 
-(defvar +latex-viewers '(skim evince sumatrapdf zathura okular pdf-tools)
+(defvar +latex-viewers '(skim preview evince sumatrapdf zathura okular pdf-tools)
   "A list of enabled latex viewers to use, in this order. If they don't exist,
-they will be ignored. Recognized viewers are skim, evince, sumatrapdf, zathura,
-okular and pdf-tools.
+they will be ignored. Recognized viewers are skim, preview, evince, sumatrapdf,
+zathura, okular and pdf-tools.
 
 If no viewers are found, `latex-preview-pane' is used.")
 


### PR DESCRIPTION
This PR adds the built-in macOS Preview App as an option to the `:lang latex` variable `+latex-viewers`.