### PR TITLE
Fix broken MacOS irony-mode building command.

### DIFF
--- a/modules/lang/cc/README.org
+++ b/modules/lang/cc/README.org
@@ -76,7 +76,8 @@ mkdir irony-mode/server/build
 pushd irony-mode/server/build
 
 DEST="$HOME/.emacs.d/.local/etc/irony-server/"
-cmake -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON \
+cmake -DCMAKE_PREFIX_PATH=/usr/local/opt/llvm \
+      -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON \
       -DCMAKE_INSTALL_PREFIX="$DEST" ../
 cmake --build . --use-stderr --config Release --target install
 


### PR DESCRIPTION
CMake error occurred when followed the instruction on the cc language page for MacOS for building irony-mode:
```
CMake Warning at src/CMakeLists.txt:4 (find_package):
  By not providing "FindClang.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Clang", but
  CMake did not find one.

  Could not find a package configuration file provided by "Clang" with any of
  the following names:

    ClangConfig.cmake
    clang-config.cmake

  Add the installation prefix of "Clang" to CMAKE_PREFIX_PATH or set
  "Clang_DIR" to a directory containing one of the above files.  If "Clang"
  provides a separate development package or SDK, be sure it has been
  installed.


CMake Error at /usr/local/Cellar/cmake/3.16.2/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:146 (message):
  Could NOT find LibClang (missing: LIBCLANG_LIBRARY LIBCLANG_INCLUDE_DIR)
Call Stack (most recent call first):
  /usr/local/Cellar/cmake/3.16.2/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:393 (_FPHSA_FAILURE_MESSAGE)
  cmake/modules/FindLibClang.cmake:94 (find_package_handle_standard_args)
  src/CMakeLists.txt:28 (find_package)


-- Configuring incomplete, errors occurred!
See also "/Users/aaa/Downloads/irony-mode/server/build/CMakeFiles/CMakeOutput.log".
```
Found same issue described here: https://www.reddit.com/r/emacs/comments/d0kxj4/ironymode_installing_server_help/
https://github.com/Sarcasm/irony-mode/wiki/Mac-OS-X-issues-and-workaround

The solution here is just adding CMAKE_PREFIX_PATH pointing to the llvm install path.

