### PR TITLE
Potential fix for direnv argument list too long

### DIFF
--- a/modules/tools/direnv/config.el
+++ b/modules/tools/direnv/config.el
@@ -21,13 +21,6 @@ Emacs."
         (add-hook 'after-change-major-mode-hook
                   #'direnv--maybe-update-environment))))
 
-  (defadvice! +direnv--make-process-environment-buffer-local-a (items)
-    :filter-return #'direnv--export
-    (when items
-      (mapc 'kill-local-variable '(process-environment exec-path))
-      (mapc 'make-local-variable '(process-environment exec-path)))
-    items)
-
   ;; Fontify special .envrc keywords; it's a good indication of whether or not
   ;; we've typed them correctly.
   (add-hook! 'direnv-envrc-mode-hook


### PR DESCRIPTION
Potential fix for https://github.com/hlissner/doom-emacs/issues/2335

The removed code looks similar to what already is done in direnv-emacs: https://github.com/wbolster/emacs-direnv/commit/bb0de5e8f662c3f522b931c6e2c2340e4ed682af

The commit that introduced this feature to doom, also has a comment on it that complains about missing environment variables: https://github.com/hlissner/doom-emacs/commit/4860bb86ce34c17ae1b064e029843a4931b1847c

@ocharles could you test this as well?