### PR TITLE
Fix #2036: Copy local variables into formatting buffer.

### DIFF
--- a/modules/editor/format/autoload/format.el
+++ b/modules/editor/format/autoload/format.el
@@ -138,11 +138,11 @@ See `+format/buffer' for the interactive version of this function, and
                   ;; Ensure this temp buffer _seems_ as much like the origin
                   ;; buffer as possible.
                   (cl-loop for (var . val) in (buffer-local-variables origin-buffer)
-                    ;; Making enable-multibyte-characters buffer-local
-                    ;; causes an error.
-                    unless (eq var 'enable-multibyte-characters)
-                    ;; Using setq-local would quote var.
-                    do (set (make-local-variable var) val))
+                           ;; Making enable-multibyte-characters buffer-local
+                           ;; causes an error.
+                           unless (eq var 'enable-multibyte-characters)
+                           ;; Using setq-local would quote var.
+                           do (set (make-local-variable var) val))
                   ;; Since we're piping a region of text to the formatter, remove
                   ;; any leading indentation to make it look like a file.
                   (when preserve-indent-p

--- a/modules/editor/format/autoload/format.el
+++ b/modules/editor/format/autoload/format.el
@@ -131,9 +131,7 @@ See `+format/buffer' for the interactive version of this function, and
             ;; like `gofmt') widen the buffer, in order to only format a region of
             ;; text, we must make a copy of the buffer to apply formatting to.
             (let ((output (buffer-substring-no-properties (point-min) (point-max)))
-                  (origin-buffer (or (buffer-base-buffer) (current-buffer)))
-                  (origin-buffer-file-name (buffer-file-name (buffer-base-buffer)))
-                  (origin-default-directory default-directory))
+                  (origin-buffer (or (buffer-base-buffer) (current-buffer))))
               (with-temp-buffer
                 (with-silent-modifications
                   (insert output)


### PR DESCRIPTION
Make `+format-buffer` copy all buffer-local variables from the original buffer into the temporary buffer. When resolving a symbol inside of a formatter, the value it is bound to in the formatted buffer will now be used instead of the default value. Fixes #2036.