### PR TITLE
Use conditional binding for 'SPC n d' "Open deft"

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -464,7 +464,8 @@
         :desc "Org agenda"                   "a" #'org-agenda
         :desc "Toggle org-clock"             "c" #'+org/toggle-clock
         :desc "Cancel org-clock"             "C" #'org-clock-cancel
-        :desc "Open deft"                    "d" #'deft
+        (:when (featurep! :ui deft)
+          :desc "Open deft"                  "d" #'deft)
         :desc "Find file in notes"           "f" #'+default/find-in-notes
         :desc "Browse notes"                 "F" #'+default/browse-notes
         :desc "Org store link"               "l" #'org-store-link


### PR DESCRIPTION
Deft is not enabled by default and trying to open it with the shortcut
is confusing newbie users (including me) with weird error.

Remove this shortcut if deft is not enabled by using :when key.
