### PR TITLE
Helm posframe fixes

### DIFF
--- a/modules/completion/helm/autoload/posframe.el
+++ b/modules/completion/helm/autoload/posframe.el
@@ -10,6 +10,9 @@ bottom, which is easier on the eyes on big displays."
           (truncate (/ (frame-pixel-height parent-frame)
                        2)))))
 
+(when helm-echo-input-in-header-line
+  (add-hook 'helm-minibuffer-set-up-hook #'helm-hide-minibuffer-maybe))
+
 (defvar +helm--posframe-buffer nil)
 ;;;###autoload
 (defun +helm-posframe-display-fn (buffer &optional _resume)
@@ -23,6 +26,7 @@ bottom, which is easier on the eyes on big displays."
        (setq +helm--posframe-buffer buffer)
        :position (point)
        :poshandler +helm-posframe-handler
+       :respect-header-line helm-echo-input-in-header-line
        :width
        (max (cl-typecase .width
               (integer .width)

--- a/modules/completion/helm/autoload/posframe.el
+++ b/modules/completion/helm/autoload/posframe.el
@@ -10,9 +10,6 @@ bottom, which is easier on the eyes on big displays."
           (truncate (/ (frame-pixel-height parent-frame)
                        2)))))
 
-(when helm-echo-input-in-header-line
-  (add-hook 'helm-minibuffer-set-up-hook #'helm-hide-minibuffer-maybe))
-
 (defvar +helm--posframe-buffer nil)
 ;;;###autoload
 (defun +helm-posframe-display-fn (buffer &optional _resume)

--- a/modules/completion/helm/config.el
+++ b/modules/completion/helm/config.el
@@ -67,6 +67,9 @@ be negative.")
         helm-ff-lynx-style-map nil)
 
   (when (featurep! :editor evil +everywhere)
+    ;; If this is set to 'iconify-top-level then Emacs will be minimized upon
+    ;; helm completion.
+    (setq iconify-child-frame 'make-invisible)
     (setq helm-default-prompt-display-function #'+helm--set-prompt-display))
 
   :init

--- a/modules/completion/helm/config.el
+++ b/modules/completion/helm/config.el
@@ -67,13 +67,13 @@ be negative.")
         helm-ff-lynx-style-map nil)
 
   (when (featurep! :editor evil +everywhere)
-    ;; If this is set to 'iconify-top-level then Emacs will be minimized upon
-    ;; helm completion.
-    (setq iconify-child-frame 'make-invisible)
     (setq helm-default-prompt-display-function #'+helm--set-prompt-display))
 
   :init
   (when (featurep! +childframe)
+    ;; If this is set to 'iconify-top-level then Emacs will be minimized upon
+    ;; helm completion.
+    (setq iconify-child-frame 'make-invisible)
     (setq helm-display-function #'+helm-posframe-display-fn))
 
   (let ((fuzzy (featurep! +fuzzy)))

--- a/modules/completion/helm/config.el
+++ b/modules/completion/helm/config.el
@@ -114,6 +114,9 @@ be negative.")
   (advice-add #'helm-display-mode-line :override #'+helm--hide-mode-line)
   (advice-add #'helm-ag-show-status-default-mode-line :override #'ignore)
 
+  ;; Hide minibuffer if `helm-echo-input-in-header-line'
+  (add-hook 'helm-minibuffer-set-up-hook #'helm-hide-minibuffer-maybe)
+
   ;; Use helpful instead of describe-* to display documentation
   (dolist (fn '(helm-describe-variable helm-describe-function))
     (advice-add fn :around #'doom-use-helpful-a)))


### PR DESCRIPTION
- Fixes https://github.com/hlissner/doom-emacs/issues/2397
- Displays Helm input in header line on top of posframe if `helm-echo-input-in-header-line` is set to true.
