### PR TITLE
Move an aspell specific argument to appropriate block

### DIFF
--- a/modules/checkers/spell/config.el
+++ b/modules/checkers/spell/config.el
@@ -3,8 +3,6 @@
 (defvar ispell-dictionary "en_US")
 
 (after! ispell
-  (add-to-list 'ispell-extra-args "--dont-tex-check-comments")
-
   ;; Don't spellcheck org blocks
   (pushnew! ispell-skip-region-alist
             '(":\\(PROPERTIES\\|LOGBOOK\\):" . ":END:")
@@ -22,7 +20,7 @@
                ((executable-find "hunspell") 'hunspell))
     (`aspell
      (setq ispell-program-name "aspell"
-           ispell-extra-args '("--sug-mode=ultra" "--run-together"))
+           ispell-extra-args '("--sug-mode=ultra" "--run-together" "--dont-tex-check-comments"))
 
      (add-hook! 'text-mode-hook
        (defun +spell-remove-run-together-switch-for-aspell-h ()


### PR DESCRIPTION
Fix for https://github.com/hlissner/doom-emacs/issues/2381

A CLI argument specific to `aspell` was also passed to `ispell`, which was then unable to start and printed its help message instead.