### PR TITLE
Fix garbage minibuffer history when launching debugger

### DIFF
--- a/modules/tools/debugger/config.el
+++ b/modules/tools/debugger/config.el
@@ -105,7 +105,7 @@
                    (if (boundp 'starting-directory)
                        (realgud-cmdbuf-info-starting-directory= starting-directory))
                    (set minibuffer-history-var
-                        (cl-remove-duplicates (cons cmd-str minibuffer-history)
+                        (cl-remove-duplicates (cons cmd-str (eval minibuffer-history-var))
                                               :from-end t))))))
             (t
              (if cmd-buf (switch-to-buffer cmd-buf))


### PR DESCRIPTION
Quoting my comment [here](https://github.com/hlissner/doom-emacs/commit/9a93aa1df99423c57e08147e3219f059a00b60a5#commitcomment-36934820):

> Looking at the [source](https://github.com/realgud/realgud/blob/master/realgud/common/run.el#L156) for the overridden function, it looks like the `eval` is intended, but the problem is that this advice renamed `minibuffer-history` to `minibuffer-history-var` everywhere _except_ on this line. Therefore I think the correct fix is actually:
> 
> ```
> (set minibuffer-history-var
>      (cl-remove-duplicates
> ￼     (cons cmd-str (eval minibuffer-history-var)) :from-end t))))))
> ```
> 
> Otherwise, when launching the debugger, you will get garbage entries in the minibuffer history.
