### PR TITLE
Make `ls` aliases work with subdirectories (Eshell)

### DIFF
--- a/modules/term/eshell/config.el
+++ b/modules/term/eshell/config.el
@@ -25,8 +25,8 @@ buffer.")
     ("d"  "dired $1")
     ("bd" "eshell-up $1")
     ("rg" "rg --color=always $*")
-    ("l"  "ls -lh")
-    ("ll" "ls -lah")
+    ("l"  "ls -lh $*")
+    ("ll" "ls -lah $*")
     ("clear" "clear-scrollback")) ; more sensible than default
   "An alist of default eshell aliases, meant to emulate useful shell utilities,
 like fasd and bd. Note that you may overwrite these in your


### PR DESCRIPTION
Hello there,

`ls` aliases for Eshell do not take any params and it is a bit annoying to use different commands between the current directory and subdirectories. Let's allow them to take params.