### PR TITLE
use updated brew package name to get clang

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -153,7 +153,7 @@ Homebrew users have a number of formulas available to them. Before they can be
 installed, start with Doom's dependencies:
 
 #+BEGIN_SRC bash
-brew install coreutils git ripgrep fd clang
+brew install coreutils git ripgrep fd llvm
 #+END_SRC
 
 For Emacs itself these three are the best options, ordered from most to least


### PR DESCRIPTION
I believe llvm package is correct way to get clang:

https://formulae.brew.sh/formula/llvm
https://github.com/Homebrew/homebrew-core/blob/4f169c6375b1bc8c23ddf374a78d33a0caba8ec9/Formula/llvm.rb#L72

