### PR TITLE
make +org--insert-item respect emacs-mode

### DIFF
--- a/modules/lang/org/autoload/org.el
+++ b/modules/lang/org/autoload/org.el
@@ -82,7 +82,8 @@
 
     (when (org-invisible-p)
       (org-show-hidden-entry))
-    (when (bound-and-true-p evil-local-mode)
+    (when (and (bound-and-true-p evil-local-mode)
+               (not (evil-emacs-state-p)))
       (evil-insert 1))))
 
 (defun +org--get-property (name &optional bound)


### PR DESCRIPTION
   No change of behaviour in non-emacs modes, but in emacs-mode stays there
   instead of switching to insert-mode.

--

In upstream Doom Emacs hitting C-RET in org-mode switches to insert-mode regardless
even if the editor was in emacs-mode, which I at least find quite disorienting.

