### PR TITLE
lang/python: add additional checks

### DIFF
--- a/modules/lang/python/doctor.el
+++ b/modules/lang/python/doctor.el
@@ -5,7 +5,7 @@
          "This module requires (:tools lsp)")
 
 (if (not (executable-find "python"))
-    (warn! "Python isn't installed.")
+    (assert! "Python isn't installed.")
   (unless (featurep! +lsp)
     (unless (zerop (shell-command "python -c 'import setuptools'"))
       (warn! "setuptools wasn't detected, which anaconda-mode requires"))))

--- a/modules/lang/python/doctor.el
+++ b/modules/lang/python/doctor.el
@@ -20,6 +20,30 @@
   (unless (executable-find "conda")
     (warn! "Couldn't find conda in your PATH")))
 
+(when (featurep! +cython)
+  (unless (executable-find "cython")
+    (warn! "Couldn't find cython. cython-mode will not work.")))
+
 (when (featurep! +ipython)
   (unless (executable-find "ipython")
     (warn! "Couldn't find ipython in your PATH")))
+
+(if (and (featurep! :editor format)
+         (not (executable-find "black")))
+    (warn! "Couldn't find black. Code formatting will not work."))
+
+(if (not (executable-find "pytest"))
+    (warn! "Couldn't find pytest. Running tests through pytest will not work."))
+
+(if (not (executable-find "nosetests"))
+    (warn! "Couldn't find nosetests. Running tests through nose will not work."))
+
+(if (not (executable-find "pipenv"))
+    (warn! "Couldn't find pipenv. pipenv support will not work."))
+
+(if (not (executable-find "isort"))
+    (warn! "Couldn't find isort. Import sorting will not work."))
+
+(if (and (featurep! :editor format)
+         (not (executable-find "pyflakes")))
+    (warn! "Couldn't find pyflakes. Import management will not work."))

--- a/modules/lang/python/doctor.el
+++ b/modules/lang/python/doctor.el
@@ -28,10 +28,6 @@
   (unless (executable-find "ipython")
     (warn! "Couldn't find ipython in your PATH")))
 
-(if (and (featurep! :editor format)
-         (not (executable-find "black")))
-    (warn! "Couldn't find black. Code formatting will not work."))
-
 (if (not (executable-find "pytest"))
     (warn! "Couldn't find pytest. Running tests through pytest will not work."))
 
@@ -44,6 +40,8 @@
 (if (not (executable-find "isort"))
     (warn! "Couldn't find isort. Import sorting will not work."))
 
-(if (and (featurep! :editor format)
-         (not (executable-find "pyflakes")))
+(when (featurep! :editor format)
+  (unless (executable-find "pyflakes")
     (warn! "Couldn't find pyflakes. Import management will not work."))
+  (unless (executable-find "black")
+    (warn! "Couldn't find black. Code formatting will not work.")))

--- a/modules/lang/python/doctor.el
+++ b/modules/lang/python/doctor.el
@@ -5,7 +5,7 @@
          "This module requires (:tools lsp)")
 
 (if (not (executable-find "python"))
-    (assert! "Python isn't installed.")
+    (error! "Python isn't installed.")
   (unless (featurep! +lsp)
     (unless (zerop (shell-command "python -c 'import setuptools'"))
       (warn! "setuptools wasn't detected, which anaconda-mode requires"))))

--- a/modules/lang/python/doctor.el
+++ b/modules/lang/python/doctor.el
@@ -28,17 +28,17 @@
   (unless (executable-find "ipython")
     (warn! "Couldn't find ipython in your PATH")))
 
-(if (not (executable-find "pytest"))
-    (warn! "Couldn't find pytest. Running tests through pytest will not work."))
+(unless (executable-find "pytest")
+  (warn! "Couldn't find pytest. Running tests through pytest will not work."))
 
-(if (not (executable-find "nosetests"))
-    (warn! "Couldn't find nosetests. Running tests through nose will not work."))
+(unless (executable-find "nosetests")
+  (warn! "Couldn't find nosetests. Running tests through nose will not work."))
 
-(if (not (executable-find "pipenv"))
-    (warn! "Couldn't find pipenv. pipenv support will not work."))
+(unless (executable-find "pipenv")
+  (warn! "Couldn't find pipenv. pipenv support will not work."))
 
-(if (not (executable-find "isort"))
-    (warn! "Couldn't find isort. Import sorting will not work."))
+(unless (executable-find "isort")
+  (warn! "Couldn't find isort. Import sorting will not work."))
 
 (when (featurep! :editor format)
   (unless (executable-find "pyflakes")


### PR DESCRIPTION
Related: #2180, #2193 

A few questions and a comment:

1) Should line 8 be an assertion? Is `python` not being installed a blocker?
2) I realize these doctor checks are all checking for global installations of various packages. How does this conflict with the various virtualenv solutions people are using?
3) How do you determine where to put intermixed dependencies? For example, should the `editor` module also check if `python` is enabled and warn about `black`?
4) Finally, I settled on using the format of "couldn't find $executable. $feature will not work". Doom seems to be a little bit inconsistent here, but this format seemed to be most common.