### PR TITLE
Improve solidity layer

### DIFF
--- a/modules/lang/javascript/config.el
+++ b/modules/lang/javascript/config.el
@@ -284,7 +284,13 @@ to tide."
 ;;; Projects
 
 (def-project-mode! +javascript-npm-mode
-  :modes '(html-mode css-mode web-mode markdown-mode js-mode typescript-mode)
+  :modes '(html-mode
+           css-mode
+           web-mode
+           markdown-mode
+           js-mode
+           typescript-mode
+           solidity-mode)
   :when (locate-dominating-file default-directory "package.json")
   :add-hooks '(+javascript-add-node-modules-path-h npm-mode))
 

--- a/modules/lang/solidity/config.el
+++ b/modules/lang/solidity/config.el
@@ -11,6 +11,7 @@
   :when (featurep! :checkers syntax)
   :after solidity-mode
   :config
+  (set-docsets! 'solidity-mode "Solidity")
   (setq flycheck-solidity-solc-addstd-contracts t)
   (when (funcall flycheck-executable-find solidity-solc-path)
     (add-to-list 'flycheck-checkers 'solidity-checker nil #'eq))


### PR DESCRIPTION
## Description

- [x] Enable `+javascript-npm-mode` in `solidity-mode` when `package.json` exists.
- [x] Set Dash docsets for solidity-mode.
- ~[ ] Enable flycheck checkers by default~
  https://github.com/ethereum/emacs-solidity/blob/master/solidity-flycheck.el#L89
  if we set it active by default, it throws errors when the executables were not found.
- [x] Use locally-installed solium (Ethlint)
- ~[ ] Format a Solidity file with Prettier + prettier-plugin-solidity~
  -> don't do in this PR because it's still experimental.