### PR TITLE
Add LSP support for ESS R

### DIFF
--- a/docs/modules.org
+++ b/docs/modules.org
@@ -106,7 +106,7 @@ Modules that bring support for a language or group of languages to Emacs.
 + elm - TODO
 + emacs-lisp - TODO
 + erlang - TODO
-+ [[file:../modules/lang/ess/README.org][ess]] - TODO
++ [[file:../modules/lang/ess/README.org][ess]] =+lsp= - TODO
 + [[file:../modules/lang/faust/README.org][faust]] - TODO
 + [[file:../modules/lang/fsharp/README.org][fsharp]] - TODO
 + [[file:../modules/lang/go/README.org][go]] =+lsp= - TODO

--- a/modules/lang/ess/README.org
+++ b/modules/lang/ess/README.org
@@ -4,9 +4,16 @@ This module adds support for various statistics languages, including R, S-Plus,
 SAS, Julia and Stata.
 
 * Table of Contents :TOC:
-- [[Appendix][Appendix]]
-  - [[Keybindings][Keybindings]]
+- [[#prequisites][Prequisites]]
+- [[#appendix][Appendix]]
+  - [[#keybindings][Keybindings]]
 
+* Prequisites
+This module has sevral optional dependencies:
+
++ [[https://github.com/jimhester/lintr][lintr]]: Enables R linting.
++ [[https://github.com/REditorSupport/languageserver][languageserver]]: Enables LSP support in an R buffer (with =+lsp= flag).
+ 
 * Appendix
 ** Keybindings
 *** :map ess-doc-map

--- a/modules/lang/ess/README.org
+++ b/modules/lang/ess/README.org
@@ -9,7 +9,7 @@ SAS, Julia and Stata.
   - [[#keybindings][Keybindings]]
 
 * Prequisites
-This module has sevral optional dependencies:
+This module has several optional dependencies:
 
 + [[https://github.com/jimhester/lintr][lintr]]: Enables R linting.
 + [[https://github.com/REditorSupport/languageserver][languageserver]]: Enables LSP support in an R buffer (with =+lsp= flag).

--- a/modules/lang/ess/config.el
+++ b/modules/lang/ess/config.el
@@ -21,7 +21,7 @@
 
   (set-docsets! 'ess-r-mode "R")
   (when (featurep! +lsp)
-    (add-hook 'ess-r-mode-hook #'lsp!))
+    (add-hook 'ess-r-mode-local-vars-hook #'lsp!))
 
   (set-repl-handler! 'ess-r-mode #'+ess/open-r-repl)
   (set-repl-handler! 'ess-julia-mode #'+ess/open-julia-repl)

--- a/modules/lang/ess/config.el
+++ b/modules/lang/ess/config.el
@@ -19,9 +19,15 @@
         ess-style 'DEFAULT
         ess-history-directory (expand-file-name "ess-history/" doom-cache-dir))
 
+  (set-docsets! 'ess-r-mode "R")
+  (if (featurep! +lsp)
+      (add-hook 'ess-r-mode-hook #'lsp!)
+    (set-lookup-handlers! 'ess-r-mode
+      :documentation #'ess-display-help-on-object))
+
   (set-repl-handler! 'ess-r-mode #'+ess/open-r-repl)
   (set-repl-handler! 'ess-julia-mode #'+ess/open-julia-repl)
-  (set-lookup-handlers! '(ess-r-mode ess-julia-mode)
+  (set-lookup-handlers! 'ess-julia-mode
     :documentation #'ess-display-help-on-object)
 
   (set-evil-initial-state! 'ess-r-help-mode 'normal)

--- a/modules/lang/ess/config.el
+++ b/modules/lang/ess/config.el
@@ -20,14 +20,12 @@
         ess-history-directory (expand-file-name "ess-history/" doom-cache-dir))
 
   (set-docsets! 'ess-r-mode "R")
-  (if (featurep! +lsp)
-      (add-hook 'ess-r-mode-hook #'lsp!)
-    (set-lookup-handlers! 'ess-r-mode
-      :documentation #'ess-display-help-on-object))
+  (when (featurep! +lsp)
+    (add-hook 'ess-r-mode-hook #'lsp!))
 
   (set-repl-handler! 'ess-r-mode #'+ess/open-r-repl)
   (set-repl-handler! 'ess-julia-mode #'+ess/open-julia-repl)
-  (set-lookup-handlers! 'ess-julia-mode
+  (set-lookup-handlers! '(ess-r-mode ess-julia-mode)
     :documentation #'ess-display-help-on-object)
 
   (set-evil-initial-state! 'ess-r-help-mode 'normal)


### PR DESCRIPTION
# Description

- Add LSP support for ESS R
- Refer R Dash doc for the symbols in an R buffer
- Add `lintr` to prequisites in the module doc

![screenshot](https://user-images.githubusercontent.com/11665236/73589143-c5992800-4515-11ea-90d8-49d8f9784a0c.png)
