### PR TITLE
[WIP] Make evil-escape work in vterm-mode

### DIFF
--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -268,7 +268,7 @@ directives. By default, this only recognizes C directives.")
   :after-call pre-command-hook
   :init
   (setq evil-escape-excluded-states '(normal visual multiedit emacs motion)
-        evil-escape-excluded-major-modes '(neotree-mode treemacs-mode vterm-mode)
+        evil-escape-excluded-major-modes '(neotree-mode treemacs-mode)
         evil-escape-key-sequence "jk"
         evil-escape-delay 0.15)
   (evil-define-key* '(insert replace visual operator) 'global "\C-g" #'evil-escape)

--- a/modules/term/vterm/autoload.el
+++ b/modules/term/vterm/autoload.el
@@ -58,13 +58,13 @@ If prefix ARG is non-nil, cd into `default-directory' instead of project root."
 
 
 ;;;###autoload
-(defun +evil-escape--insert-2-a (oldfunc &rest args)
-  (if (eq major-mode 'vterm-mode)
-      (call-interactively #'vterm-send)
-    (apply oldfunc args)))
+(defun +vterm--escape-insert-2-a (&rest _)
+  (when (eq major-mode 'vterm-mode)
+    (call-interactively #'vterm-send)
+    t))
 
 ;;;###autoload
-(defun +evil-escape--delete-2-a (oldfunc &rest args)
-  (if (eq major-mode 'vterm-mode)
-      (call-interactively #'vterm-send-backspace)
-    (apply oldfunc args)))
+(defun +vterm--escape-delete-2-a (&rest _)
+  (when (eq major-mode 'vterm-mode)
+    (call-interactively #'vterm-send-backspace)
+    t))

--- a/modules/term/vterm/autoload.el
+++ b/modules/term/vterm/autoload.el
@@ -55,3 +55,16 @@ If prefix ARG is non-nil, cd into `default-directory' instead of project root."
               default-directory
             (or (doom-project-root) default-directory))))
     (vterm)))
+
+
+;;;###autoload
+(defun +evil-escape--insert-2-a (oldfunc &rest args)
+  (if (eq major-mode 'vterm-mode)
+      (call-interactively #'vterm-send)
+    (apply oldfunc args)))
+
+;;;###autoload
+(defun +evil-escape--delete-2-a (oldfunc &rest args)
+  (if (eq major-mode 'vterm-mode)
+      (call-interactively #'vterm-send-backspace)
+    (apply oldfunc args)))

--- a/modules/term/vterm/config.el
+++ b/modules/term/vterm/config.el
@@ -21,5 +21,5 @@
 
   ;; Have evil-escape work in `vterm-mode'
   (when (featurep! :editor evil +everywhere)
-    (advice-add #'evil-escape--insert-2 :around #'+evil-escape--insert-2-a)
-    (advice-add #'evil-escape--delete-2 :around #'+evil-escape--delete-2-a)))
+    (advice-add #'evil-escape--insert-2 :before-until #'+vterm--escape-insert-2-a)
+    (advice-add #'evil-escape--delete-2 :before-until #'+vterm--escape-delete-2-a)))

--- a/modules/term/vterm/config.el
+++ b/modules/term/vterm/config.el
@@ -17,4 +17,9 @@
 
   (add-hook 'vterm-mode-hook #'doom-mark-buffer-as-real-h)
   ;; Modeline serves no purpose in vterm
-  (add-hook 'vterm-mode-hook #'hide-mode-line-mode))
+  (add-hook 'vterm-mode-hook #'hide-mode-line-mode)
+
+  ;; Have evil-escape work in `vterm-mode'
+  (when (featurep! :editor evil +everywhere)
+    (advice-add #'evil-escape--insert-2 :around #'+evil-escape--insert-2-a)
+    (advice-add #'evil-escape--delete-2 :around #'+evil-escape--delete-2-a)))


### PR DESCRIPTION
# Description

- Make evil-escape work in `vterm-mode`
- This is almost an upstream issue, but another similar PR has not been merged for nearly 2 years.
  https://github.com/syl20bnr/evil-escape/pull/87