### PR TITLE
docs: update mu macos install cmd

### DIFF
--- a/modules/email/mu4e/README.org
+++ b/modules/email/mu4e/README.org
@@ -43,7 +43,7 @@ This module requires:
 
 ** MacOS
 #+BEGIN_SRC sh
-brew install mu --with-emacs
+brew install mu
 # And one of the following
 brew install isync  # mbsync
 brew install offlineimap


### PR DESCRIPTION
`--with-emacs` arg no longer exists in the formula

Just a docs PR, skipped a bunch of the template steps that aren't needed.
