### PR TITLE
disable all-the-icons font install on windows

### DIFF
--- a/core/cli/install.el
+++ b/core/cli/install.el
@@ -80,16 +80,22 @@ DOOMDIR environment variable. e.g.
     (print! "Regenerating autoloads files")
     (doom-cli-reload-autoloads)
        
-    (if nofonts-p
-        (print! (warn "Not installing fonts, as requested"))
-      (if IS-WINDOWS
-          (print! (warn "Automated installation is not supported on Windows, see installation instructions: https://github.com/domtronn/all-the-icons.el#installing-fonts"))
-        (when (or doom-auto-accept
-                  (y-or-n-p "Download and install all-the-icon's fonts?"))
+    (cond (nofonts-p)
+         (IS-WINDOWS
+          (print! (warn "Doom cannot install all-the-icons' fonts on Windows!\n"))
+          (print-group!
+           (print!
+            (concat "You'll have to do so manually:\n\n"
+                    "  1. Launch Doom Emacs\n"
+                    "  2. Execute 'M-x all-the-icons-install-fonts' to download the fonts\n"
+                    "  3. Open the download location in windows explorer\n"
+                    "  4. Open each font file to install them"))))
+         ((or doom-auto-accept
+              (y-or-n-p "Download and install all-the-icon's fonts?"))
           (require 'all-the-icons)
           (let ((window-system (cond (IS-MAC 'ns)
                                      (IS-LINUX 'x))))
-            (all-the-icons-install-fonts 'yes)))))
+            (all-the-icons-install-fonts 'yes))))
 
     (when (file-exists-p "~/.emacs")
       (print! (warn "A ~/.emacs file was detected. This conflicts with Doom and should be deleted!")))

--- a/core/cli/install.el
+++ b/core/cli/install.el
@@ -80,14 +80,15 @@ DOOMDIR environment variable. e.g.
     (print! "Regenerating autoloads files")
     (doom-cli-reload-autoloads)
 
-    (if nofonts-p
-        (print! (warn "Not installing fonts, as requested"))
-      (when (or doom-auto-accept
-                (y-or-n-p "Download and install all-the-icon's fonts?"))
-        (require 'all-the-icons)
-        (let ((window-system (cond (IS-MAC 'ns)
-                                   (IS-LINUX 'x))))
-          (all-the-icons-install-fonts 'yes))))
+    (unless IS-WINDOWS
+        (if nofonts-p
+            (print! (warn "Not installing fonts, as requested"))
+          (when (or doom-auto-accept
+                    (y-or-n-p "Download and install all-the-icon's fonts?"))
+            (require 'all-the-icons)
+            (let ((window-system (cond (IS-MAC 'ns)
+                                       (IS-LINUX 'x))))
+              (all-the-icons-install-fonts 'yes)))))
 
     (when (file-exists-p "~/.emacs")
       (print! (warn "A ~/.emacs file was detected. This conflicts with Doom and should be deleted!")))

--- a/core/cli/install.el
+++ b/core/cli/install.el
@@ -80,15 +80,16 @@ DOOMDIR environment variable. e.g.
     (print! "Regenerating autoloads files")
     (doom-cli-reload-autoloads)
 
-    (unless IS-WINDOWS
-        (if nofonts-p
-            (print! (warn "Not installing fonts, as requested"))
-          (when (or doom-auto-accept
-                    (y-or-n-p "Download and install all-the-icon's fonts?"))
-            (require 'all-the-icons)
-            (let ((window-system (cond (IS-MAC 'ns)
-                                       (IS-LINUX 'x))))
-              (all-the-icons-install-fonts 'yes)))))
+    
+    (if nofonts-p
+        (print! (warn "Not installing fonts, as requested"))
+      (unless IS-WINDOWS
+        (when (or doom-auto-accept
+                  (y-or-n-p "Download and install all-the-icon's fonts?"))
+          (require 'all-the-icons)
+          (let ((window-system (cond (IS-MAC 'ns)
+                                     (IS-LINUX 'x))))
+            (all-the-icons-install-fonts 'yes)))))
 
     (when (file-exists-p "~/.emacs")
       (print! (warn "A ~/.emacs file was detected. This conflicts with Doom and should be deleted!")))

--- a/core/cli/install.el
+++ b/core/cli/install.el
@@ -79,11 +79,11 @@ DOOMDIR environment variable. e.g.
 
     (print! "Regenerating autoloads files")
     (doom-cli-reload-autoloads)
-
-    
+       
     (if nofonts-p
         (print! (warn "Not installing fonts, as requested"))
-      (unless IS-WINDOWS
+      (if IS-WINDOWS
+          (print! (warn "Automated installation is not supported on Windows, see installation instructions: https://github.com/domtronn/all-the-icons.el#installing-fonts"))
         (when (or doom-auto-accept
                   (y-or-n-p "Download and install all-the-icon's fonts?"))
           (require 'all-the-icons)


### PR DESCRIPTION
prevent installing `all-the-icons` fonts on windows, which require emacs to be running with elevated privileges to install anyway, for most Windows users downloading & installing fonts manually is more idiomatic (I imagine)