### PR TITLE
[WIP] lang/org: Improve Jupyter support

### DIFF
--- a/modules/lang/org/autoload/contrib-jupyter.el
+++ b/modules/lang/org/autoload/contrib-jupyter.el
@@ -1,0 +1,29 @@
+;;; lang/org/autoload/contrib-jupyter.el -*- lexical-binding: t; -*-
+;;;###if (featurep! +jupyter)
+
+;;;###autoload
+(defun +org--in-jupyter-src-block-p ()
+  (when-let ((info (org-babel-get-src-block-info))
+             (lang (car info)))
+    (string-prefix-p "jupyter-" lang)))
+
+;;;###autoload
+(defun +org--ob-jupyter-initiate-session-a (&rest _)
+  (unless (bound-and-true-p jupyter-org-interaction-mode)
+    (jupyter-org-interaction-mode)))
+
+;;;###autoload
+(defun +org/jupyter-documentation-lookup-handler ()
+  (interactive)
+  (when (and (+org--in-jupyter-src-block-p)
+             (call-interactively #'jupyter-inspect-at-point))
+    (display-buffer (help-buffer))
+    t))
+
+;;;###autoload
+(defun +org--company-box-icons-jupyter (candidate)
+  (when (+org--in-jupyter-src-block-p)
+    (when-let* ((type (get-text-property 0 'annot candidate))
+                (type (string-trim type)))
+      (alist-get type +org--company-box-icons-jupyter-alist nil nil
+                 #'string-equal))))

--- a/modules/lang/org/autoload/org.el
+++ b/modules/lang/org/autoload/org.el
@@ -218,7 +218,9 @@ If on a:
        (save-excursion (org-update-statistics-cookies arg)))
 
       ((or `src-block `inline-src-block)
-       (org-babel-execute-src-block arg))
+       (if (and (featurep! +jupyter) (+org--in-jupyter-src-block-p))
+           (jupyter-org-execute-and-next-block)
+         (org-babel-execute-src-block arg)))
 
       ((or `latex-fragment `latex-environment)
        (org-latex-preview arg))

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -1076,6 +1076,8 @@ compelling reason, so..."
   ;; `org-brain', however.
   (setq org-id-locations-file-relative t)
 
+  (set-company-backend! 'org-mode 'company-capf)
+
   ;; HACK `org-id' doesn't check if `org-id-locations-file' exists or is
   ;;      writeable before trying to read/write to it.
   (defadvice! +org--fail-gracefully-a (&rest _)

--- a/modules/lang/org/contrib/jupyter.el
+++ b/modules/lang/org/contrib/jupyter.el
@@ -1,11 +1,26 @@
 ;;; lang/org/contrib/jupyter.el -*- lexical-binding: t; -*-
 ;;;###if (featurep! +jupyter)
 
+(defconst +org--company-box-icons-jupyter-alist '(("class"     . Class)
+                                                  ("function"  . Function)
+                                                  ("instance"  . Variable)
+                                                  ("keyword"   . Keyword)
+                                                  ("module"    . Module)
+                                                  ("statement" . Variable)
+                                                  ("param"     . Property)
+                                                  ("path"      . File)))
+
+(set-lookup-handlers! 'org-mode
+  :documentation '+org/jupyter-documentation-lookup-handler)
+
 (use-package! ob-jupyter
   :defer t
   :init
   (after! ob-async
-    (pushnew! ob-async-no-async-languages-alist "jupyter-python" "jupyter-julia"))
+    (pushnew! ob-async-no-async-languages-alist
+              "jupyter-python"
+              "jupyter-julia"
+              "jupyter-R"))
 
   (after! org-src
     (dolist (lang '(python julia R))
@@ -24,4 +39,12 @@
                (add-to-list 'org-src-lang-modes (cons lang-name (intern lang-tail)))))
         (with-demoted-errors "Jupyter: %s"
           (require lang nil t)
-          (require 'ob-jupyter nil t))))))
+          (require 'ob-jupyter nil t)))))
+  :config
+  (advice-add 'org-babel-jupyter-initiate-session
+              :after #'+org--ob-jupyter-initiate-session-a)
+  ;; Remove text/html since it's not human readable
+  (delq! :text/html jupyter-org-mime-types))
+
+(after! company-box
+  (push #'+org--company-box-icons-jupyter company-box-icons-functions))


### PR DESCRIPTION
## Description

* Remove `text/html` since it's not human readable
* Enable documentation lookup in in Jupyter code blocks
* Enable Jupyter code completion in Jupyter code blocks
* Integrate Jupyter code completion + company-box
* Make dwim in Jupyter code blocks jump to a next block
* Fix Jupyter + R deferred loading

### Todos

- [ ] Fix default params for Jupyter code blocks won't be loaded at the first run (existing bug, seems upstream issue)
  -> https://github.com/hlissner/doom-emacs/issues/3171
- [x] ~Enable `jupyter-org-interaction-mode` for the buffers created before `ob-jupyter` loaded~ -> done
  - It's normally enabled in `org-mode-hook`