### PR TITLE
Change +workspace-list-names to respect order

### DIFF
--- a/modules/ui/workspaces/autoload/workspaces.el
+++ b/modules/ui/workspaces/autoload/workspaces.el
@@ -74,7 +74,8 @@ error if NAME doesn't exist."
 ;;;###autoload
 (defun +workspace-list-names ()
   "Return the list of names of open workspaces."
-  (mapcar #'safe-persp-name (+workspace-list)))
+  (cdr persp-names-cache))
+
 
 ;;;###autoload
 (defun +workspace-buffer-list (&optional persp)


### PR DESCRIPTION
This change address issue #2487. Originally, `+workspace-list-names` would get names from `+workspace-list` which looped over the hash table. In the documentation for `+workspace-list` there is an allusion to not using `hash-table-values` since it does not respect order on older emacs versions. I'm not sure if changes were made such that this solution also no longer respects order.

However, persp-mode provides the variable `persp-names-cache` which keeps track of the ordered workspace names. It seems to fix my issue, not sure if it breaks anything else. 

Also, it doesn't seem like +workspace-list is used for anything anymore. However, I neglected to remove it.