### PR TITLE
Fix recenter after evil search

### DIFF
--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -159,7 +159,7 @@ directives. By default, this only recognizes C directives.")
   ;; Recenter screen after most searches
   (dolist (fn '(evil-visualstar/begin-search-forward
                 evil-visualstar/begin-search-backward
-                evil-ex-search-word-backward
+                evil-ex-search-word-forward
                 evil-ex-search-word-backward
                 evil-ex-search-forward
                 evil-ex-search-backward))

--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -161,6 +161,8 @@ directives. By default, this only recognizes C directives.")
                 evil-visualstar/begin-search-backward
                 evil-ex-search-word-forward
                 evil-ex-search-word-backward
+                evil-ex-search-next
+                evil-ex-search-previous
                 evil-ex-search-forward
                 evil-ex-search-backward))
     (advice-add fn :after #'doom-recenter-a))


### PR DESCRIPTION
This PR adds after-advice to following evil search functions:
- evil-ex-search-word-forward
- evil-ex-search-next    
- evil-ex-search-previous