### PR TITLE
Add cdlatex feature in LaTeX

### DIFF
--- a/docs/modules.org
+++ b/docs/modules.org
@@ -113,7 +113,7 @@ Modules that bring support for a language or group of languages to Emacs.
 + [[file:../modules/lang/javascript/README.org][javascript]] =+lsp= - JavaScript, TypeScript, and CoffeeScript support
 + julia - TODO
 + kotlin =+lsp+= - TODO
-+ [[file:../modules/lang/latex/README.org][latex]] =+latexmk +cdlatex=
++ [[file:../modules/lang/latex/README.org][latex]] =+latexmk +cdlatex= - TODO
 + lean - TODO
 + [[file:../modules/lang/ledger/README.org][ledger]] - TODO
 + lua =+moonscript= - TODO

--- a/docs/modules.org
+++ b/docs/modules.org
@@ -113,7 +113,7 @@ Modules that bring support for a language or group of languages to Emacs.
 + [[file:../modules/lang/javascript/README.org][javascript]] =+lsp= - JavaScript, TypeScript, and CoffeeScript support
 + julia - TODO
 + kotlin =+lsp+= - TODO
-+ [[file:../modules/lang/latex/README.org][latex]] - TODO
++ [[file:../modules/lang/latex/README.org][latex]] =+latexmk +cdlatex=
 + lean - TODO
 + [[file:../modules/lang/ledger/README.org][ledger]] - TODO
 + lua =+moonscript= - TODO

--- a/modules/lang/latex/README.org
+++ b/modules/lang/latex/README.org
@@ -12,6 +12,7 @@
 - [[#customization][Customization]]
   - [[#specifying-the-location-of-a-bibtex-file--corresponding-pdfs][Specifying the location of a bibtex file & corresponding PDFs]]
   - [[#changing-the-pdfs-viewer][Changing the PDFs viewer]]
+  - [[#using-cdlatexs-snippets-despite-having-yasnippet][Using cdlatex's snippets despite having yasnippet]]
 
 * Description
 Provide a helping hand when working with LaTeX documents.
@@ -27,7 +28,8 @@ Provide a helping hand when working with LaTeX documents.
 + Compile your .tex code only once using LatexMk
 
 ** Module Flags
-+ ~+latexmk~ Use LatexMk instead of LaTeX to compile documents.
++ =+latexmk= Use LatexMk instead of LaTeX to compile documents.
++ =+cdlatex= Enable [[https://github.com/cdominik/cdlatex][cdlatex]] for fast math insertion.
 
 ** Plugins
 + [[http://www.gnu.org/software/auctex/][auctex]]
@@ -38,6 +40,7 @@ Provide a helping hand when working with LaTeX documents.
 + [[https://github.com/TheBB/company-reftex][company-reftex]]*
 + [[https://github.com/vspinu/company-math][company-math]]*
 + [[https://github.com/tmalsburg/helm-bibtex][ivy-bibtex]]* or [[https://github.com/tmalsburg/helm-bibtex][helm-bibtex]]*
++ [[https://github.com/cdominik/cdlatex][cdlatex]] (=+cdlatex=)
 
 * TODO Prerequisites
 
@@ -76,3 +79,17 @@ tool, for instance:
 If none of these tools are found, ~latex-preview-pane~ (uses ~DocView~ in Emacs)
 is used as a fallback. You can use this exclusively by setting ~+latex-viewers~
 to ~nil~.
+
+** Using cdlatex's snippets despite having yasnippet
+cdlatex has a snippet insertion capability which is disabled in favor of
+yasnippet when using ~:editor snippets~. If you still wanna use it, simply rebind
+the ~TAB~ key for cdlatex, which takes care of snippet-related stuff:
+
+#+BEGIN_SRC emacs-lisp
+(map! :map cdlatex-mode-map
+    :i "TAB" #'cdlatex-tab)
+#+END_SRC
+
+This would favor yasnippet's expansion and cursor movement over cdlatex's
+expansion and movement, but that shouldn't matter if you're not using yasnippet
+in latex buffers.

--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -125,22 +125,25 @@ If no viewers are found, `latex-preview-pane' is used.")
   :hook (LaTeX-mode . cdlatex-mode)
   :config
   ;; Disabling keys that have overlapping functionality with other parts of Doom
-  ;; smartparens takes care of inserting closing delimiters
-  (define-key cdlatex-mode-map  "$" nil)
-  (define-key cdlatex-mode-map  "(" nil)
-  (define-key cdlatex-mode-map  "{" nil)
-  (define-key cdlatex-mode-map  "[" nil)
-  (define-key cdlatex-mode-map  "|" nil)
-  (define-key cdlatex-mode-map  "<" nil)
-  ;; TAB is used for cdlatex's snippets and navigation. But have yasnippet for that.
-  (when (featurep! :editor snippets)
-    (define-key cdlatex-mode-map  "\t" nil))
-
-  ;; AUCTeX takes care of auto-inserting {} on _^ if you want, with `TeX-electric-sub-and-superscript'
-  (define-key cdlatex-mode-map  "^" nil)
-  (define-key cdlatex-mode-map  "_" nil)
-  ;; AUCTeX already provides this with `LaTeX-insert-item'
-  (define-key cdlatex-mode-map  [(control return)] nil))
+  (map! :map cdlatex-mode-map
+        ;; smartparens takes care of inserting closing delimiters, and if you
+        ;; don't use smartparens you probably won't want these also.
+        :g  "$" nil
+        :g  "(" nil
+        :g  "{" nil
+        :g  "[" nil
+        :g  "|" nil
+        :g  "<" nil
+        ;; TAB is used for cdlatex's snippets and navigation. But have yasnippet
+        ;; for that.
+        (:when (featurep! :editor snippets)
+          :g "TAB" nil)
+        ;; AUCTeX takes care of auto-inserting {} on _^ if you want, with
+        ;; `TeX-electric-sub-and-superscript'
+        :g  "^" nil
+        :g  "_" nil
+        ;; AUCTeX already provides this with `LaTeX-insert-item'
+        :g  [(control return)] nil))
 
 
 ;; Nicely indent lines that have wrapped when visual line mode is activated

--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -134,8 +134,8 @@ If no viewers are found, `latex-preview-pane' is used.")
         :g  "[" nil
         :g  "|" nil
         :g  "<" nil
-        ;; TAB is used for cdlatex's snippets and navigation. But have yasnippet
-        ;; for that.
+        ;; TAB is used for cdlatex's snippets and navigation. But we have
+        ;; yasnippet for that.
         (:when (featurep! :editor snippets)
           :g "TAB" nil)
         ;; AUCTeX takes care of auto-inserting {} on _^ if you want, with

--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -119,6 +119,30 @@ If no viewers are found, `latex-preview-pane' is used.")
                 (lambda () (* (/ 10.0 (preview-document-pt)) preview-scale))))
 
 
+(use-package! cdlatex
+  :defer t
+  :when (featurep! +cdlatex)
+  :hook (LaTeX-mode . cdlatex-mode)
+  :config
+  ;; Disabling keys that have overlapping functionality with other parts of Doom
+  ;; smartparens takes care of inserting closing delimiters
+  (define-key cdlatex-mode-map  "$" nil)
+  (define-key cdlatex-mode-map  "(" nil)
+  (define-key cdlatex-mode-map  "{" nil)
+  (define-key cdlatex-mode-map  "[" nil)
+  (define-key cdlatex-mode-map  "|" nil)
+  (define-key cdlatex-mode-map  "<" nil)
+  ;; TAB is used for cdlatex's snippets and navigation. But have yasnippet for that.
+  (when (featurep! :editor snippets)
+    (define-key cdlatex-mode-map  "\t" nil))
+
+  ;; AUCTeX takes care of auto-inserting {} on _^ if you want, with `TeX-electric-sub-and-superscript'
+  (define-key cdlatex-mode-map  "^" nil)
+  (define-key cdlatex-mode-map  "_" nil)
+  ;; AUCTeX already provides this with `LaTeX-insert-item'
+  (define-key cdlatex-mode-map  [(control return)] nil))
+
+
 ;; Nicely indent lines that have wrapped when visual line mode is activated
 (use-package! adaptive-wrap
   :hook (LaTeX-mode . adaptive-wrap-prefix-mode)

--- a/modules/lang/latex/packages.el
+++ b/modules/lang/latex/packages.el
@@ -10,6 +10,9 @@
 (when (featurep! +latexmk)
   (package! auctex-latexmk :pin "4d35352265"))
 
+(when (featurep! +cdlatex)
+  (package! cdlatex :pin "b7af5a9884"))
+
 ;; Features according to other user selected options
 
 (when (featurep! :completion company)


### PR DESCRIPTION
This adds a cdlatex support to the latex module.

The whole configuration is just disabling parts of cdlatex that overlap with
standard doom features; I've specified the reasons in comments, and added a
section in the docs about how to re-enable cdlatex's snippets despite having
yasnippet enabled.