### PR TITLE
Also look for 'fdfind' executable

### DIFF
--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -264,10 +264,8 @@ evil-ex-specific constructs, so we disable it solely in evil-ex."
     "Change `counsel-file-jump' to use fd or ripgrep, if they are available."
     :override #'counsel--find-return-list
     (cl-destructuring-bind (find-program . args)
-        (cond ((executable-find "fd")
-               (cons "fd" (list "-t" "f" "-E" ".git")))
-              ((executable-find "fdfind")
-               (cons "fdfind" (list "-t" "f" "-E" ".git")))
+        (cond ((executable-find doom-projectile-fd-binary)
+               (cons doom-projectile-fd-binary (list "-t" "f" "-E" ".git")))
               ((executable-find "rg")
                (cons "rg" (list "--files" "--hidden" "--no-messages")))
               ((cons find-program args)))
@@ -277,7 +275,7 @@ evil-ex-specific constructs, so we disable it solely in evil-ex."
        (cons find-program args)
        (lambda ()
          (goto-char (point-min))
-         (let ((offset (if (member find-program '("fd" "fdfind" "rg")) 0 2))
+         (let ((offset (if (member find-program (list "rg" doom-projectile-fd-binary)) 0 2))
                files)
            (while (< (point) (point-max))
              (push (buffer-substring

--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -266,6 +266,8 @@ evil-ex-specific constructs, so we disable it solely in evil-ex."
     (cl-destructuring-bind (find-program . args)
         (cond ((executable-find "fd")
                (cons "fd" (list "-t" "f" "-E" ".git")))
+              ((executable-find "fdfind")
+               (cons "fdfind" (list "-t" "f" "-E" ".git")))
               ((executable-find "rg")
                (cons "rg" (list "--files" "--hidden" "--no-messages")))
               ((cons find-program args)))
@@ -275,7 +277,7 @@ evil-ex-specific constructs, so we disable it solely in evil-ex."
        (cons find-program args)
        (lambda ()
          (goto-char (point-min))
-         (let ((offset (if (member find-program '("fd" "rg")) 0 2))
+         (let ((offset (if (member find-program '("fd" "fdfind" "rg")) 0 2))
                files)
            (while (< (point) (point-max))
              (push (buffer-substring


### PR DESCRIPTION
This makes `+ivy--counsel-file-jump-use-fd-rg-a` also search for the `fdfind`
executable, and not only `fd`. (On debian its called 'fdfind'.)