### PR TITLE
Add LSP support for YAML

### DIFF
--- a/modules/lang/data/config.el
+++ b/modules/lang/data/config.el
@@ -43,7 +43,10 @@
   (set-electric! 'jsonnet-mode :chars '(?\n ?: ?{ ?})))
 
 (after! yaml-mode
-  (setq-hook! 'yaml-mode-hook tab-width yaml-indent-offset))
+  (setq-hook! 'yaml-mode-hook tab-width yaml-indent-offset)
+
+  (when (featurep! +yaml-lsp)
+    (add-hook 'yaml-mode-local-vars-hook #'lsp!)))
 
 
 ;;


### PR DESCRIPTION
## Description

* Move `yaml-mode` in `data` to a new module `yaml`
* Enable LSP for `yaml-mode` if `+lsp` is present, which enables:
  * code completion
  * documentation
  * diagnostics
    (these are based on schemas downloaded by [JSON Schema Store](http://schemastore.org/json)).