### PR TITLE
Add LSP support for Dockerfile

### DIFF
--- a/docs/modules.org
+++ b/docs/modules.org
@@ -158,7 +158,7 @@ Small modules that give Emacs access to external tools & services.
 + ansible - TODO
 + debugger - A (nigh-)universal debugger in Emacs
 + [[file:../modules/tools/direnv/README.org][direnv]] - TODO
-+ [[file:../modules/tools/docker/README.org][docker]] - TODO
++ [[file:../modules/tools/docker/README.org][docker]] =+lsp= - TODO
 + [[file:../modules/tools/editorconfig/README.org][editorconfig]] - TODO
 + [[file:../modules/tools/ein/README.org][ein]] - TODO
 + [[file:../modules/tools/eval/README.org][eval]] =+overlay= - REPL & code evaluation support for a variety of languages

--- a/modules/tools/docker/README.org
+++ b/modules/tools/docker/README.org
@@ -29,7 +29,7 @@ convenience functions allow images to be built easily.
 =docker-tramp.el= offers a [[https://www.gnu.org/software/tramp/][TRAMP]] method for Docker containers.
 
 ** Module Flags
-This module provides no flags.
++ =+lsp= Enables integration for the Dockerfile Language Server.
 
 ** Plugins
  + [[https://github.com/Silex/docker.el][docker]]
@@ -39,6 +39,10 @@ This module provides no flags.
 * Prerequisites
 This module assumes =docker=, =docker-compose= and =docker-machine= binaries
 are installed and accessible from your PATH.
+
+Optionally, this module also uses the following programs:
+
++ =docker-langserver= (for LSP users): ~npm install -g dockerfile-language-server-nodejs~
 
 * Features
 ** Docker control

--- a/modules/tools/docker/config.el
+++ b/modules/tools/docker/config.el
@@ -1,7 +1,6 @@
 ;;; tools/docker/config.el -*- lexical-binding: t; -*-
 
 (after! docker
-  (set-docsets! 'dockerfile-mode "Docker")
   (set-evil-initial-state!
     '(docker-container-mode
       docker-image-mode
@@ -9,3 +8,9 @@
       docker-volume-mode
       docker-machine-mode)
     'emacs))
+
+(after! dockerfile-mode
+  (set-docsets! 'dockerfile-mode "Docker")
+
+  (when (featurep! +lsp)
+    (add-hook 'dockerfile-mode-local-vars-hook #'lsp!)))


### PR DESCRIPTION
## Description

- Add LSP support for Dockerfile. This enables:
  - code completion
  - documentation
  - diagnostics
- Currently the server doesn't complete file paths.
