### PR TITLE
add benchmark bindings (,tbs and ,tba)

### DIFF
--- a/modules/lang/go/autoload.el
+++ b/modules/lang/go/autoload.el
@@ -42,6 +42,21 @@
     (error "Must be in a _test.go file")))
 
 ;;;###autoload
+(defun +go/bench-all ()
+  (interactive)
+  (+go--run-tests "-test.run=NONE -test.bench=\".*\""))
+
+;;;###autoload
+(defun +go/bench-single ()
+  (interactive)
+  (if (string-match "_test\\.go" buffer-file-name)
+      (save-excursion
+        (re-search-backward "^func[ ]+\\(([[:alnum:]]*?[ ]?[*]?[[:alnum:]]+)[ ]+\\)?\\(Benchmark[[:alnum:]_]+\\)(.*)")
+        (+go--run-tests (concat "-test.run=NONE -test.bench" "='" (match-string-no-properties 2) "'")))
+    (error "Must be in a _test.go file")))
+
+
+;;;###autoload
 (defun +go/play-buffer-or-region (&optional beg end)
   "TODO"
   (interactive "r")

--- a/modules/lang/go/config.el
+++ b/modules/lang/go/config.el
@@ -55,8 +55,10 @@
           "n" #'+go/test-nested
           "g" #'go-gen-test-dwim
           "G" #'go-gen-test-all
-          "e" #'go-gen-test-exported)))
-
+          "e" #'go-gen-test-exported)
+        (:prefix ("tb" . "bench")
+          "s" #'+go/bench-single
+          "a" #'+go/bench-all)))
 
 (use-package! gorepl-mode
   :commands gorepl-run-load-current-file)

--- a/modules/lang/go/config.el
+++ b/modules/lang/go/config.el
@@ -55,10 +55,11 @@
           "n" #'+go/test-nested
           "g" #'go-gen-test-dwim
           "G" #'go-gen-test-all
-          "e" #'go-gen-test-exported)
-        (:prefix ("tb" . "bench")
-          "s" #'+go/bench-single
-          "a" #'+go/bench-all)))
+          "e" #'go-gen-test-exported
+          (:prefix ("b" . "bench")
+            "s" #'+go/bench-single
+            "a" #'+go/bench-all))))
+
 
 (use-package! gorepl-mode
   :commands gorepl-run-load-current-file)


### PR DESCRIPTION
go supports running benchmarks much similar to running tests,
the new key bindings will run single or all benchmarks.