### PR TITLE
Fix issue with wrong argument for executable-find

### DIFF
--- a/modules/lang/ledger/config.el
+++ b/modules/lang/ledger/config.el
@@ -8,7 +8,7 @@
 
   :config
   (setq ledger-binary-path
-        (or (cl-delete-if-not #'executable-find (list "hledger" "ledger"))
+        (or (first (cl-delete-if-not #'executable-find (list "hledger" "ledger"))
             "ledger"))
 
   (defadvice! +ledger--check-version-a (orig-fn)


### PR DESCRIPTION
Previously, a list would be passed as an argument to 'executable-find' in '+ledger--check-version-a', resulting in an error.

This instead passes "hledger" as an argument if found, else "ledger".