### PR TITLE
Fix list passed as argument to executable-find

### DIFF
--- a/modules/lang/ledger/config.el
+++ b/modules/lang/ledger/config.el
@@ -10,7 +10,7 @@
   (setq ledger-binary-path
         (if (executable-find "hledger")
             "hledger"
-            "ledger"))
+          "ledger"))
 
   (defadvice! +ledger--check-version-a (orig-fn)
     "Fail gracefully if ledger binary isn't available."

--- a/modules/lang/ledger/config.el
+++ b/modules/lang/ledger/config.el
@@ -8,7 +8,8 @@
 
   :config
   (setq ledger-binary-path
-        (or (cl-delete-if-not #'executable-find (list "hledger" "ledger"))
+        (if (executable-find "hledger")
+            "hledger"
             "ledger"))
 
   (defadvice! +ledger--check-version-a (orig-fn)


### PR DESCRIPTION
Previously, a list would be passed as an argument to 'executable-find' in '+ledger--check-version-a'.

This instead passes "hledger" as an argument if found, else "ledger".
