### PR TITLE
Change org-re-reveal reveal.js root path to https://revealjs.com

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -442,7 +442,7 @@ file isn't in `org-directory'."
     (setq org-pandoc-options
           '((standalone . t)
             (mathjax . t)
-            (variable . "revealjs-url=https://cdn.jsdelivr.net/npm/reveal.js@3/")))))
+            (variable . "revealjs-url=https://revealjs.com")))))
 
 
 (defun +org-init-habit-h ()

--- a/modules/lang/org/contrib/present.el
+++ b/modules/lang/org/contrib/present.el
@@ -14,7 +14,7 @@
 (use-package! org-re-reveal
   :after ox
   :init
-  (setq org-re-reveal-root "https://cdn.jsdelivr.net/npm/reveal.js@3/"))
+  (setq org-re-reveal-root "https://revealjs.com"))
 
 
 (use-package! org-tree-slide


### PR DESCRIPTION
In org-re-reveal, a reveal.js plugin will look for things relative to the path specified by the variable `org-re-reveal-root`. E.g. the `notes` plugin will look for `.../plugin/notes/notes.html`. But the current URL gives the `notes.html` file in .txt form, rendering the plugin unusable.

Instead, consider using `https://revealjs.com`, which is one of the customization option of the variable [[1]](https://gitlab.com/oer/org-re-reveal/-/blob/master/org-re-reveal.el#L228).