### PR TITLE
Enable flyspell in git-commit-mode

### DIFF
--- a/modules/checkers/spell/config.el
+++ b/modules/checkers/spell/config.el
@@ -51,7 +51,8 @@
                TeX-mode-hook
                rst-mode-hook
                mu4e-compose-mode-hook
-               message-mode-hook)
+               message-mode-hook
+               git-commit-mode-hook)
              #'flyspell-mode)
 
   (when (featurep! +everywhere)


### PR DESCRIPTION
Not sure why flyspell was not enabled in text-mode before. For me, it's a bit annoying when I write commit messages in magit, but it's NOT spell-checked.
