### PR TITLE
Ensure org-capture buffer is focussed

### DIFF
--- a/bin/org-capture
+++ b/bin/org-capture
@@ -33,10 +33,10 @@ shift $((OPTIND-1))
 if [ $daemon ]; then
   emacsclient -a "" \
     -c -F '((name . "org-capture") (width . 70) (height . 25) (transient . t))' \
-    -e "(+org-capture/open-frame \"$str\" ${key:-nil})"
+    -e "(progn (select-frame-set-input-focus (selected-frame))(+org-capture/open-frame \"$str\" ${key:-nil}))"
 else
   # Non-daemon servers flicker a lot if frames are created from terminal, so we
   # do it internally instead.
   emacsclient -a "" \
-    -e "(+org-capture/open-frame \"$str\" ${key:-nil})"
+    -e "(progn (select-frame-set-input-focus (selected-frame))(+org-capture/open-frame \"$str\" ${key:-nil}))"
 fi


### PR DESCRIPTION
The capture buffer could end up under other windows and not being focussed, this solves it.