### PR TITLE
bindings: correct description type-o

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -70,7 +70,7 @@
         :desc "Sudo find file"              "S"   #'doom/sudo-find-file
         :desc "Yank filename"               "y"   #'+default/yank-buffer-filename
         :desc "Open scratch buffer"         "x"   #'doom/open-scratch-buffer
-        :desc "Open project scratch buffer" "X"   #'doom/switch-to-scratch-buffer
+        :desc "Switch to scratch buffer"    "X"   #'doom/switch-to-scratch-buffer
         (:when (featurep! :tools editorconfig)
           :desc "Open project editorconfig"   "."   #'editorconfig-find-current-editorconfig))
 


### PR DESCRIPTION
Fix the description of the binding `C-c f X` binding for emacs users. The correct and new description is "Switch to scratch buffer".