### PR TITLE
Fix missing parenthesis in terraform config

### DIFF
--- a/modules/tools/terraform/config.el
+++ b/modules/tools/terraform/config.el
@@ -1,7 +1,7 @@
 ;;; tools/terraform/config.el -*- lexical-binding: t; -*-
 
 (when (featurep! +lsp)
-  (add-hook 'terraform-mode-local-vars-hook #'lsp!)
+  (add-hook 'terraform-mode-local-vars-hook #'lsp!))
 
 
 (map! :after terraform-mode


### PR DESCRIPTION
A parenthesis was missing in PR #2553, this makes doom fail to load his config.