### PR TITLE
Add missing paren in lsp invocation on terraform/config

### DIFF
--- a/modules/tools/terraform/config.el
+++ b/modules/tools/terraform/config.el
@@ -1,7 +1,7 @@
 ;;; tools/terraform/config.el -*- lexical-binding: t; -*-
 
 (when (featurep! +lsp)
-  (add-hook 'terraform-mode-local-vars-hook #'lsp!)
+  (add-hook 'terraform-mode-local-vars-hook #'lsp!))
 
 
 (map! :after terraform-mode


### PR DESCRIPTION
Original change introduced in https://github.com/hlissner/doom-emacs/commit/9b620c3b59944881d9111936b5d464969777bb11