### PR TITLE
lang/ruby: Add detection for additional files

### DIFF
--- a/modules/lang/ruby/config.el
+++ b/modules/lang/ruby/config.el
@@ -9,8 +9,8 @@
 
 (use-package! enh-ruby-mode
   :mode ("\\.\\(?:pry\\|irb\\)rc\\'" . +ruby-init-h)
-  :mode ("\\.\\(?:rb\\|rake\\|rabl\\|ru\\|builder\\|gemspec\\|jbuilder\\|thor\\)\\'" .  +ruby-init-h)
-  :mode ("/\\(?:Berks\\|Cap\\|Gem\\|Guard\\|Pod\\|Puppet\\|Rake\\|Thor\\|Vagrant\\)file\\'" .  +ruby-init-h)
+  :mode ("\\.\\(?:rb\\|rake\\|rabl\\|ru\\|builder\\|gemspec\\|podspec\\|jbuilder\\|thor\\)\\'" .  +ruby-init-h)
+  :mode ("/\\(?:Berks\\|Brew\\|Cap\\|Fast\\|Gem\\|Guard\\|Pod\\|Puppet\\|Rake\\|Thor\\|Vagrant\\)file\\'" .  +ruby-init-h)
   :interpreter ("j?ruby\\([0-9.]+\\)" . +ruby-init-h)
   :preface
   (after! ruby-mode


### PR DESCRIPTION
This adds support for podspecs used by Cocoapods, Brewfiles from Homebrew Bundle, and Fastfiles from Fastlane.