### PR TITLE
Change clojure linter to clj-kondo

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -157,6 +157,6 @@
         :desc "refactor" "R" #'hydra-cljr-help-menu/body))
 
 
-(use-package! flycheck-joker
+(use-package! flycheck-clj-kondo
   :when (featurep! :checkers syntax)
   :after flycheck)

--- a/modules/lang/clojure/packages.el
+++ b/modules/lang/clojure/packages.el
@@ -5,4 +5,4 @@
 (package! clj-refactor :pin "e24ba62843")
 
 (when (featurep! :checkers syntax)
-  (package! flycheck-joker :pin "51e99e6977"))
+  (package! flycheck-clj-kondo :pin "f652a8dc4c"))


### PR DESCRIPTION
[Clj-kondo](https://github.com/borkdude/clj-kondo) is a much more full-featured and actively developed linter compared to Joker, and is set as the (recommended) default on Spacemacs and the VScode Calva plugin.