### PR TITLE
VTerm remembers insert point when leaving normal mode

### DIFF
--- a/modules/term/vterm/autoload.el
+++ b/modules/term/vterm/autoload.el
@@ -55,3 +55,15 @@ If prefix ARG is non-nil, cd into `default-directory' instead of project root."
               default-directory
             (or (doom-project-root) default-directory))))
     (vterm)))
+
+;;;###autoload
+(defun +vterm-remember-insert-point-h ()
+  "Remember point when leaving insert mode."
+  (setq-local +vterm-insert-point (point)))
+
+;;;###autoload
+(defun +vterm-goto-insert-point-h ()
+  "Go to the point we were at when we left insert mode."
+  (when +vterm-insert-point
+    (goto-char +vterm-insert-point)
+    (setq-local +vterm-insert-point nil)))

--- a/modules/term/vterm/autoload.el
+++ b/modules/term/vterm/autoload.el
@@ -56,14 +56,17 @@ If prefix ARG is non-nil, cd into `default-directory' instead of project root."
             (or (doom-project-root) default-directory))))
     (vterm)))
 
+
+(defvar +vterm--insert-point nil)
+
 ;;;###autoload
 (defun +vterm-remember-insert-point-h ()
   "Remember point when leaving insert mode."
-  (setq-local +vterm-insert-point (point)))
+  (setq-local +vterm--insert-point (point)))
 
 ;;;###autoload
 (defun +vterm-goto-insert-point-h ()
   "Go to the point we were at when we left insert mode."
-  (when +vterm-insert-point
-    (goto-char +vterm-insert-point)
-    (setq-local +vterm-insert-point nil)))
+  (when +vterm--insert-point
+    (goto-char +vterm--insert-point)
+    (setq-local +vterm--insert-point nil)))

--- a/modules/term/vterm/config.el
+++ b/modules/term/vterm/config.el
@@ -16,11 +16,10 @@
   (setq vterm-kill-buffer-on-exit t)
 
   (when (featurep! :editor evil)
-    (defvar +vterm-insert-point nil)
-    (add-hook 'vterm-mode-hook
-      (lambda ()
-        (add-hook 'evil-insert-state-exit-hook '+vterm-remember-insert-point-h nil t)
-        (add-hook 'evil-insert-state-entry-hook '+vterm-goto-insert-point-h nil t))))
+    (add-hook! 'vterm-mode-hook
+      (defun +vterm-init-remember-point-h ()
+        (add-hook 'evil-insert-state-exit-hook #'+vterm-remember-insert-point-h nil t)
+        (add-hook 'evil-insert-state-entry-hook #'+vterm-goto-insert-point-h nil t))))
 
   (add-hook 'vterm-mode-hook #'doom-mark-buffer-as-real-h)
   ;; Modeline serves no purpose in vterm

--- a/modules/term/vterm/config.el
+++ b/modules/term/vterm/config.el
@@ -15,6 +15,13 @@
 
   (setq vterm-kill-buffer-on-exit t)
 
+  (when (featurep! :editor evil)
+    (defvar +vterm-insert-point nil)
+    (add-hook 'vterm-mode-hook
+      (lambda ()
+        (add-hook 'evil-insert-state-exit-hook '+vterm-remember-insert-point-h nil t)
+        (add-hook 'evil-insert-state-entry-hook '+vterm-goto-insert-point-h nil t))))
+
   (add-hook 'vterm-mode-hook #'doom-mark-buffer-as-real-h)
   ;; Modeline serves no purpose in vterm
   (add-hook 'vterm-mode-hook #'hide-mode-line-mode))


### PR DESCRIPTION
It is useful to be able to enter normal mode in vterm, but going back to insert
gets weird, because there is only one place where inserting makes sense in
vterm; where you left it.

Setting some buffer local hooks for insert entry/exit, and storing `(point)` in
a buffer local variable.

This is my first PR to doom :) Thank you for this awesome project, brought me
back to emacs <3