### PR TITLE
Construct org-id-locations-file using expand-file-name

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -985,7 +985,7 @@ compelling reason, so..."
   ;; Global ID state means we can have ID links anywhere. This is required for
   ;; `org-brain', however.
   (setq org-id-track-globally t
-        org-id-locations-file (concat org-directory ".orgids")
+        org-id-locations-file (expand-file-name ".orgids" org-directory)
         org-id-locations-file-relative t)
 
   ;; HACK `org-id' doesn't check if `org-id-locations-file' exists or is


### PR DESCRIPTION
Otherwise if you forgot a trailing slash on your `org-directory`, you end up with a wrong file