### PR TITLE
mdempsky doesnt work with modules, updating to stamblerre

### DIFF
--- a/modules/lang/go/README.org
+++ b/modules/lang/go/README.org
@@ -77,7 +77,7 @@ This module requires a valid ~GOPATH~, and the following Go packages:
 export GOPATH=~/work/go
 
 go get -u github.com/motemen/gore/cmd/gore
-go get -u github.com/mdempsky/gocode
+go get -u github.com/stamblerre/gocode
 go get -u golang.org/x/tools/cmd/godoc
 go get -u golang.org/x/tools/cmd/goimports
 go get -u golang.org/x/tools/cmd/gorename


### PR DESCRIPTION
github.com/mdempsky/gocode is an unmaintained fork of github.com/nsf/gocode which is also unmaintained.

github.com/stamblerre/gocode seems to be the current working module, which is also in "maintenance" mode as people are recommended to switch to `gopls`.

This is get the doom go module in working order until it can be switched to use gopls.