### PR TITLE
Integrate evil-lion into evil-mode

### DIFF
--- a/modules/editor/evil/README.org
+++ b/modules/editor/evil/README.org
@@ -34,6 +34,7 @@ This holy module brings the vim experience to Emacs.
 + [[https://github.com/syl20bnr/evil-escape][evil-escape]]
 + [[https://github.com/Dewdrops/evil-exchange][evil-exchange]]
 + [[https://github.com/TheBB/evil-indent-plus][evil-indent-plus]]
++ [[https://github.com/edkolev/evil-lion][evil-lion]]
 + [[https://github.com/redguardtoo/evil-nerd-commenter][evil-nerd-commentary]]
 + [[https://github.com/redguardtoo/evil-matchit][evil-matchit]]
 + [[https://github.com/cofi/evil-numbers][evil-numbers]]
@@ -68,6 +69,7 @@ The following vim plugins have been ported to evil:
 |-----------------------+--------------------------------+--------------------------------------------|
 | vim-commentary        | evil-nerd-commenter            | omap =gc=                                  |
 | vim-easymotion        | evil-easymotion                | omap =gs=                                  |
+| vim-lion              | evil-lion                      | omap =gl= / =gL=                           |
 | vim-seek or vim-sneak | evil-snipe                     | mmap =s= / =S=, omap =z= / =Z= & =x= / =X= |
 | vim-surround          | evil-embrace and evil-surround | vmap =S=, omap =ys=                        |
 

--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -589,6 +589,12 @@ To change these keys see `+evil-repeat-keys'."
       :o "s" #'evil-surround-edit
       :o "S" #'evil-Surround-edit
 
+      ;; evil-lion
+      :n "gl" #'evil-lion-left
+      :n "gL" #'evil-lion-right
+      :v "gl" #'evil-lion-left
+      :v "gL" #'evil-lion-right
+
       ;; Omni-completion
       (:when (featurep! :completion company)
         (:prefix "C-x"

--- a/modules/editor/evil/packages.el
+++ b/modules/editor/evil/packages.el
@@ -8,6 +8,7 @@
 (package! evil-escape :pin "f4e9116bfb")
 (package! evil-exchange :pin "3030e21ee1")
 (package! evil-indent-plus :pin "0c7501e6ef")
+(package! evil-lion :pin "6b03593f5d")
 (package! evil-nerd-commenter :pin "fa40dab8d2")
 (package! evil-numbers
   :recipe (:host github :repo "janpath/evil-numbers")


### PR DESCRIPTION
This is a direct response to #2559. 

I've updated `:editor evil`'s docs about it accordingly.

`evil-lion` autoloads the correct operators, so there's really not much left for
me to do.

----

Adds `gl`, `gL` operators for alignment.