### PR TITLE
Fix syntax error in Clojure module

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -25,7 +25,7 @@
                  clojurec-mode
                  clojurescript-mode
                  clojurex-mode))
-      (add-to-list 'lsp-language-id-configuration (cons m "clojure"))))
+      (add-to-list 'lsp-language-id-configuration (cons m "clojure")))))
 
 
 (use-package! cider


### PR DESCRIPTION
Looks like this bug was introduced in a65403011e930fceaa59664dceabdee27b4c4cb4.
It causes Doom Emacs to fail on start-up if the `:lang clojure` module is enabled.
The workaround would be to disable this module until this change is merged in.