### PR TITLE
fix: missing closing paren in clojure module

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -25,7 +25,7 @@
                  clojurec-mode
                  clojurescript-mode
                  clojurex-mode))
-      (add-to-list 'lsp-language-id-configuration (cons m "clojure"))))
+      (add-to-list 'lsp-language-id-configuration (cons m "clojure")))))
 
 
 (use-package! cider


### PR DESCRIPTION
A missing paren in `modules/lang/clojure/config.el` causes emacs to crash on startup:

```
févr. 25 09:08:27 blade bash[27282]: Warning (initialization): An error occurred while loading ‘/home/paul/.emacs.d/init.el’:
févr. 25 09:08:27 blade bash[27282]: Error in a Doom module: modules/lang/clojure/config.el, (end-of-file /home/paul/.emacs.d/modules/lang/clojure/config.el)
févr. 25 09:08:27 blade bash[27282]: To ensure normal operation, you should investigate and remove the
févr. 25 09:08:27 blade bash[27282]: cause of the error in your initialization file.  Start Emacs with
févr. 25 09:08:27 blade bash[27282]: the ‘--debug-init’ option to view a complete error backtrace.
```

This pull request adds the missing paren to the `when` form.
