### PR TITLE
Add a keybinding to sync the list of known projects with search path

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -550,6 +550,7 @@
         :desc "Find recent project files"    "r" #'projectile-recentf
         :desc "Run project"                  "R" #'projectile-run-project
         :desc "Save project files"           "s" #'projectile-save-project-buffers
+        :desc "Sync known projects"          "S" #'projectile-discover-projects-in-search-path
         :desc "Pop up scratch buffer"        "x" #'doom/open-project-scratch-buffer
         :desc "Switch to scratch buffer"     "X" #'doom/switch-to-project-scratch-buffer
         :desc "List project tasks"           "t" #'magit-todos-list


### PR DESCRIPTION
This scratched my itch as a custom keybinding, but it seemed generally useful.

The use case is that the contents of the `projectile-project-search-path` directory changes on disk (i.e. you add a new project your the terminal or file manager) and Emacs / projectile doesn't know about it until this command is run. I found it a common enough case to have a keybinding for. An alternative would be to have it run periodically in the background, but it's not clear how often, and typically once you add a directory, you wouldn't want to wait around for it to fire, just get working on the project.

Note, I considered 'pD' (for 'discover'), but that seems better suited to `projectile-discover-projects-in-directory`. I didn't add that (yet) though, as there is no room for it in the SPC-p panel, and I don't use it :-)