### PR TITLE
add `open-in-iterm` shortcut for macos module

### DIFF
--- a/modules/tools/macos/autoload.el
+++ b/modules/tools/macos/autoload.el
@@ -49,3 +49,6 @@
 ;;;###autoload (autoload '+macos/send-project-to-launchbar "tools/macos/autoload" nil t)
 (+macos--open-with send-project-to-launchbar "LaunchBar"
                    (or (doom-project-root) default-directory))
+
+;;;###autoload (autoload '+macos/open-in-iterm "tools/macos/autoload" nil t)
+(+macos--open-with open-in-iterm "iTerm" default-directory)


### PR DESCRIPTION
`+macos/open-in-iterm` opens the current directory in `iTerm`. 
[`iTerm`](https://iterm2.com/) is a popular alternative to the macos's default terminal emulator `term`.