### PR TITLE
Set elisp lookups for helpful-mode

### DIFF
--- a/modules/lang/emacs-lisp/config.el
+++ b/modules/lang/emacs-lisp/config.el
@@ -21,7 +21,7 @@ This marks a foldable marker for `outline-minor-mode' in elisp buffers.")
   :config
   (set-repl-handler! '(emacs-lisp-mode lisp-interaction-mode) #'+emacs-lisp/open-repl)
   (set-eval-handler! '(emacs-lisp-mode lisp-interaction-mode) #'+emacs-lisp-eval)
-  (set-lookup-handlers! 'emacs-lisp-mode
+  (set-lookup-handlers! '(emacs-lisp-mode helpful-mode)
     :definition    #'+emacs-lisp-lookup-definition
     :documentation #'+emacs-lisp-lookup-documentation)
   (set-docsets! '(emacs-lisp-mode lisp-interaction-mode) "Emacs Lisp")


### PR DESCRIPTION
I often read the extracted source code in helpful. This would allow using
`+lookup/documentation` and co. in helpful, which saves a few key presses
compared to the ivy/helm stuff on `SPC h f/v`.