### PR TITLE
Adjust org-capture popup rule to exclude capture.org filename

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -669,9 +669,9 @@ between the two."
       ("^\\*\\(?:Agenda Com\\|Calendar\\|Org Export Dispatcher\\)"
        :slot -1 :vslot -1 :size #'+popup-shrink-to-fit :ttl 0)
       ("^\\*Org Select" :slot -1 :vslot -2 :ttl 0 :size 0.25)
-      ("^\\*Org Agenda"    :ignore t)
-      ("^\\*Org Src"       :size 0.4  :quit nil :select t :autosave t :modeline t :ttl nil)
-      ("^CAPTURE.*\\.org$" :size 0.25 :quit nil :select t :autosave t))))
+      ("^\\*Org Agenda"     :ignore t)
+      ("^\\*Org Src"        :size 0.4  :quit nil :select t :autosave t :modeline t :ttl nil)
+      ("^CAPTURE-.*\\.org$" :size 0.25 :quit nil :select t :autosave t))))
 
 
 (defun +org-init-protocol-lazy-loader-h ()


### PR DESCRIPTION
I think it's pretty common for people (myself included) to name their capture file `capture.org` file, and currently this rule matches it, so if you open capture.org, your end up with it opened in a popup (I believe it wasn't intended?). My fix makes it so it matches only capture buffers (they've got name like `CAPTURE-filename.org`). I believe there shouldn't be any unanticipated consequences of the change?

As far as I understand, the problem is that in elisp, regexes are case insensitive by default, and the sensitivity is controlled by a [variable](http://ergoemacs.org/emacs/emacs_regex.html), so I struggle to see what's the proper way to control it (especially considering the window manipulation happens in `window.el`). If you know of a way to deal with this, happy to implement and update my pull request!