### PR TITLE
Fix clojure link in modules.org

### DIFF
--- a/docs/modules.org
+++ b/docs/modules.org
@@ -92,7 +92,7 @@ Modules that bring support for a language or group of languages to Emacs.
 + [[file:../modules/lang/agda/README.org][agda]] - TODO
 + assembly - TODO
 + [[file:../modules/lang/cc/README.org][cc]] =+lsp= - TODO
-+ [[file:/mnt/projects/conf/doom-emacs/modules/lang/clojure/README.org][clojure]] =+lsp= - TODO
++ [[file:../modules/lang/clojure/README.org][clojure]] =+lsp= - TODO
 + common-lisp - TODO
 + [[file:../modules/lang/coq/README.org][coq]] - TODO
 + crystal - TODO


### PR DESCRIPTION
Now the link is relative and not dependent of the absolute location of `doom-emacs-dir`.