### PR TITLE
Use s-titleized-words (if defined) for title in org template

### DIFF
--- a/modules/editor/file-templates/templates/org-mode/__
+++ b/modules/editor/file-templates/templates/org-mode/__
@@ -1,6 +1,20 @@
 # -*- mode: snippet -*-
 # name: Org template
 # --
-#+TITLE: ${1:`(file-name-base buffer-file-name)`}
+#+TITLE: ${1:`
+(string-join
+ (mapcar #'capitalize
+         ;; Replace -,_... with space
+         (split-string
+          (let (case-fold-search)
+            ;; Seperating lower from upper: hello|World
+            (replace-regexp-in-string
+             "\\([[:lower:]]\\)\\([[:upper:]]\\)" "\\1 \\2"
+             ;; Separating upper from (upper and lower): HTTP|Server
+             (replace-regexp-in-string "\\([[:upper:]]\\)\\([[:upper:]][0-9[:lower:]]\\)"
+                                       "\\1 \\2" (file-name-base buffer-file-name))))
+          "[^[:word:]0-9]+"
+          )) " " )
+`}
 
 $0


### PR DESCRIPTION
`s-titleized-words` of the file name is generally a much better heuristic for
the title than just the file name.

I didn't want to add s.el as a dependency for file-templates, so if not defined,
the template uses the normal `buffer-file-name`. If you think its legit to add
s.el as a dependency, I'll do so.