### PR TITLE
Set org-babel-python-command to be same as python-shell-interpreter

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -194,7 +194,10 @@ Is relative to `org-directory', unless it is absolute. Is used in Doom's default
 
   ;; Fix 'require(...).print is not a function' error from `ob-js' when
   ;; executing JS src blocks
-  (setq org-babel-js-function-wrapper "console.log(require('util').inspect(function(){\n%s\n}()));"))
+  (setq org-babel-js-function-wrapper "console.log(require('util').inspect(function(){\n%s\n}()));")
+
+  (after! python
+    (setq org-babel-python-command python-shell-interpreter)))
 
 
 (defun +org-init-babel-lazy-loader-h ()


### PR DESCRIPTION
By default it's `python` so suffers from the same issues as `python-shell-interpreter`.

tbh, not sure if the way I'm suggesting is a good one, maybe it make more sense to simply copy-paste the [bit of logic](https://github.com/hlissner/doom-emacs/blob/56cba7828c295acafbbd0e14938f62dd23080a3d/modules/lang/python/config.el#L51-L55) for python-shell-interpreter. Let me know what you think is the right way!