### PR TITLE
Extend backend-agnostic vc functionality

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -395,15 +395,17 @@
         :desc "Sudo this file"              "U"   #'doom/sudo-this-file
         :desc "Yank filename"               "y"   #'+default/yank-buffer-filename)
 
-      ;;; <leader> g --- git
+      ;;; <leader> g --- git/version control
       (:prefix-map ("g" . "git")
-        :desc "Git revert file"             "R"   #'vc-revert
+        :desc "Revert file"                 "R"   #'vc-revert
         :desc "Copy link to remote"         "y"   #'+vc/browse-at-remote-kill-file-or-region
         :desc "Copy link to homepage"       "Y"   #'+vc/browse-at-remote-kill-homepage
         (:when (featurep! :ui hydra)
           :desc "SMerge"                    "m"   #'+vc/smerge-hydra/body)
         (:when (featurep! :ui vc-gutter)
-          :desc "Git revert hunk"           "r"   #'git-gutter:revert-hunk
+          (:when (featurep! :ui hydra)
+            :desc "VCGutter"                "."   #'+vc/gutter-hydra/body)
+          :desc "Revert hunk"               "r"   #'git-gutter:revert-hunk
           :desc "Git stage hunk"            "s"   #'git-gutter:stage-hunk
           :desc "Git time machine"          "t"   #'git-timemachine-toggle
           :desc "Jump to next hunk"         "]"   #'git-gutter:next-hunk

--- a/modules/emacs/vc/config.el
+++ b/modules/emacs/vc/config.el
@@ -3,18 +3,31 @@
 (when IS-WINDOWS
   (setenv "GIT_ASKPASS" "git-gui--askpass"))
 
+(after! log-view
+  (set-evil-initial-state!
+    '(log-view-mode
+      vc-git-log-view-mode
+      vc-hg-log-view-mode
+      vc-bzr-log-view-mode
+      vc-svn-log-view-mode)
+    'emacs)
+  (evil-define-key* '(emacs) log-view-mode-map (kbd doom-leader-key) 'doom/leader)
+  (map! :mode log-view-mode
+        "j" #'log-view-msg-next
+        "k" #'log-view-msg-prev))
 
 (after! vc-annotate
   (set-popup-rules!
-    '(("^\\vc-d" :select nil) ; *vc-diff*
-      ("^\\vc-c" :select t))) ; *vc-change-log*
+    '(("^\\*vc-diff" :select nil)   ; *vc-diff*
+      ("^\\*vc-change" :select t))) ; *vc-change-log*
   (set-evil-initial-state!
-    '(vc-annotate-mode vc-git-log-view-mode)
+    '(vc-annotate-mode)
     'normal)
 
   ;; Clean up after itself
   (define-key vc-annotate-mode-map [remap quit-window] #'kill-current-buffer))
 
+(after! vc-dir (set-evil-initial-state! '(vc-dir-mode) 'emacs))
 
 (after! git-timemachine
   ;; Sometimes I forget `git-timemachine' is enabled in a buffer, so instead of

--- a/modules/ui/vc-gutter/autoload.el
+++ b/modules/ui/vc-gutter/autoload.el
@@ -23,5 +23,12 @@
   ("m" git-gutter:mark-hunk)
   ("p" git-gutter:popup-hunk)
   ("R" git-gutter:set-start-revision)
-  ("q" nil :color blue)
-  ("Q" (git-gutter-mode -1) :color blue))
+  ("q"
+   (when (get-buffer git-gutter:popup-buffer)
+     (kill-buffer (get-buffer git-gutter:popup-buffer)))
+   :color blue)
+  ("Q"
+   (progn (git-gutter-mode -1)
+          (when (get-buffer git-gutter:popup-buffer)
+            (kill-buffer (get-buffer git-gutter:popup-buffer))))
+   :color blue))

--- a/modules/ui/vc-gutter/config.el
+++ b/modules/ui/vc-gutter/config.el
@@ -51,6 +51,7 @@ is deferred until the file is saved. Respects `git-gutter:disabled-modes'."
               (git-gutter-mode +1)
               (remove-hook 'after-save-hook #'+vc-gutter-init-maybe-h 'local)))))))
 
+  (setq git-gutter:handled-backends '(git hg svn bzr))
   ;; Disable in Org mode, as per
   ;; <https://github.com/syl20bnr/spacemacs/issues/10555> and
   ;; <https://github.com/syohex/emacs-git-gutter/issues/24>. Apparently, the


### PR DESCRIPTION
This PR extends support for non-git version control systems in the following ways:

1. `git-gutter:handled-backends` is extended to `(git hg svn bzr)`. I'm using the `hg` backend with no issues so far, though I haven't tried `svn` or `bzr`. In the latter two cases I'm relying on git-gutter's claim of support but if that is deemed to risky we might as well reduce it to `(git hg)` for now

2. if both `hydra` and `vc-gutter` are enabled, `<leader> g .` is bound to the (IMO very useful) `+vc/gutter-hydra`.

3. `+vc/gutter-hydra`'s quit functions are extended to automatically close the `git-gutter` popup (not sure if that is what other users want, as it doesn't currently differentiate between popups opened through the hydra itself and a preexisting git-gutter popup)

4. I believe the popup rules defined for `vc-annotate` were slightly incorrect before (no leading asterisk and the too-unspecific `vc-d` prefix matched anything starting with `*vc-dir` as well)

5. the various `log-view` modes invoked by, e.g., `vc-print-log` now start up in emacs state, with added `j`/`k` keybindings to navigate between entries. Although meta-leader works out of the box, the functionality shadowed by enabling doom's usual `SPC` leader is not useful enough, IMO, to break muscle memory, so I'm reenabling the default leader within those mode maps. The way I currently do this is rather ugly though; is there some helper function or macro that sets a mode's initial state to `emacs` but leaves the leader key in effect?