### PR TITLE
Fix Spring bug on Ruby Rspec Mode

### DIFF
--- a/modules/lang/ruby/config.el
+++ b/modules/lang/ruby/config.el
@@ -130,6 +130,7 @@
 (use-package! rspec-mode
   :mode ("/\\.rspec\\'" . text-mode)
   :init
+  (setq rspec-use-spring-when-possible nil)
   (when (featurep! :editor evil)
     (add-hook 'rspec-mode-hook #'evil-normalize-keymaps))
   :config


### PR DESCRIPTION
Without this, Rails 6 (new version) always try to use spring.  Adding this modification, fix it for all rails versions.  If the user really want, they can add on config.el.