### PR TITLE
Make +evil:copy-this-file autoload interactively

### DIFF
--- a/modules/editor/evil/autoload/files.el
+++ b/modules/editor/evil/autoload/files.el
@@ -20,7 +20,7 @@ overwrite the destination file if it exists, without confirmation."
     (user-error "No new path was specified"))
   (doom/move-this-file new-path force-p))
 
-;;;###autoload (autoload '+evil:copy-this-file "editor/evil/autoload/files" nil nil)
+;;;###autoload (autoload '+evil:copy-this-file "editor/evil/autoload/files" nil t)
 (evil-define-command +evil:copy-this-file (new-path &optional force-p)
   "Copy current buffer's file to NEW-PATH. Replaces %, # and other vim-esque
 filename modifiers (see `+evil*ex-replace-special-filenames'). If FORCE-P,


### PR DESCRIPTION
`:cp` was not autoloaded correctly beforehand. I just changed `+evil:copy-this-file`'s autoload
signature it so it would match `+evil:move-this-file`, with which I had no issue - and it works!