### PR TITLE
bump rustic

### DIFF
--- a/modules/lang/rust/config.el
+++ b/modules/lang/rust/config.el
@@ -15,7 +15,6 @@
   (set-popup-rule! "^\\*rustic-compilation" :vslot -1)
 
   (setq rustic-indent-method-chain t
-        rustic-flycheck-setup-mode-line-p nil
         ;; use :editor format instead
         rustic-format-trigger nil
         ;; REVIEW `rust-ordinary-lt-gt-p' is terribly expensive in large rust

--- a/modules/lang/rust/packages.el
+++ b/modules/lang/rust/packages.el
@@ -1,6 +1,6 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; lang/rust/packages.el
 
-(package! rustic :pin "99396915c7")
+(package! rustic :pin "373f5a1940")
 (unless (featurep! +lsp)
   (package! racer :pin "a0bdf778f0"))

--- a/modules/tools/lsp/packages.el
+++ b/modules/tools/lsp/packages.el
@@ -1,7 +1,7 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; tools/lsp/packages.el
 
-(package! lsp-mode :pin "2e6b748183")
+(package! lsp-mode :pin "6a943561e2")
 (package! lsp-ui :pin "c99ba09c30")
 (when (featurep! :completion company)
   (package! company-lsp :pin "f921ffa0cd"))


### PR DESCRIPTION
I moved some code to lsp-mode because there are issues with requiring lsp-mode related code in doom. An error will be thrown when starting the first lsp session. I've tried the fix in doom, but it would be good if somebody can confirm this.