### PR TITLE
Add polymode to handle RMarkdown and RNoweb files

### DIFF
--- a/modules/lang/ess/packages.el
+++ b/modules/lang/ess/packages.el
@@ -3,3 +3,5 @@
 
 (package! ess :pin "2812b85880")
 (package! ess-R-data-view :pin "d6e98d3ae1")
+(package! polymode :pin "3eab3c9eed")
+(package! poly-R :pin "0443c89b4d")

--- a/modules/lang/ess/packages.el
+++ b/modules/lang/ess/packages.el
@@ -1,7 +1,7 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; lang/ess/packages.el
 
-(package! ess :pin "2812b85880")
+(package! ess :pin "a2be8cb97c")
 (package! ess-R-data-view :pin "d6e98d3ae1")
 (package! polymode :pin "3eab3c9eed")
 (package! poly-R :pin "0443c89b4d")


### PR DESCRIPTION
As of ESS 19+, ess-noweb and ess-swv libraries are now obsolete, and
polymode should be used instead (https://emacs.stackexchange.com/a/17065).