### PR TITLE
Associate xhtml files with web-mode

### DIFF
--- a/modules/lang/web/+html.el
+++ b/modules/lang/web/+html.el
@@ -1,7 +1,7 @@
 ;;; lang/web/+html.el -*- lexical-binding: t; -*-
 
 (use-package! web-mode
-  :mode "\\.p?html?\\'"
+  :mode "\\.[px]?html?\\'"
   :mode "\\.\\(?:tpl\\|blade\\)\\(?:\\.php\\)?\\'"
   :mode "\\.erb\\'"
   :mode "\\.eex\\'"


### PR DESCRIPTION
Although xhtml files are indeed xml, they usually have embedded JavaScript and CSS like
normal HTML, so `web-mode` fits them better than `nXML-mode` (the default)