### PR TITLE
emacs: vc: browse-at-remote: bump to 771a3079e2

### DIFF
--- a/modules/emacs/vc/autoload/vc.el
+++ b/modules/emacs/vc/autoload/vc.el
@@ -5,9 +5,7 @@
 
 ;;;###autoload
 (defun +vc/browse-at-remote-kill-file-or-region ()
-  "Copy the current file's remote URL to your clipboard.
-If a selection is active, highlight them. Otherwise omits the #L<N> suffix in
-the URL."
+  "Copy the current file's remote URL, with line number, to your clipboard."
   (interactive)
   (let ((url (browse-at-remote-get-url)))
     (kill-new url)

--- a/modules/emacs/vc/packages.el
+++ b/modules/emacs/vc/packages.el
@@ -5,7 +5,7 @@
 (package! vc-annotate :built-in t)
 (package! smerge-mode :built-in t)
 
-(package! browse-at-remote :pin "aeee6bf38f")
+(package! browse-at-remote :pin "771a3079e2")
 (package! git-timemachine :pin "391eb61050")
 (package! gitconfig-mode :pin "55468314a5")
 (package! gitignore-mode :pin "55468314a5")


### PR DESCRIPTION
It now defaults to adding the line number. Controlled by [this variable](https://github.com/rmuslimov/browse-at-remote/blob/771a3079e27f397d2f5a9470b945980fa68ee048/browse-at-remote.el#L79-L85).