### PR TITLE
Replace obsolete elisp function in dante-mode

### DIFF
--- a/modules/lang/haskell/+dante.el
+++ b/modules/lang/haskell/+dante.el
@@ -35,6 +35,6 @@ reformatting), so we restore a (false) modified state."
         :localleader
         "t" #'dante-type-at
         "i" #'dante-info
-        "l" #'haskell-process-load-or-reload
+        "l" #'haskell-process-load-file
         "e" #'dante-eval-block
         "a" #'attrap-attrap))


### PR DESCRIPTION
`dante-mode` was using `haskell-process-load-or-reload` on `, l` and `haskell-mode` complained about it being obsolete.
This PR changes it to `haskell-process-load-file`, same as bound to `C-c C-l`.