### PR TITLE
Make pretty-code work with Scala

### DIFF
--- a/modules/lang/scala/config.el
+++ b/modules/lang/scala/config.el
@@ -11,27 +11,29 @@
   (set-pretty-symbols! 'scala-mode
       ;; Functional
       :def "def"
-      :composition "compose"
+      :composition  "compose"
       ;; HKT
-      :lambda "Lambda"
+      :lambda       "Lambda"
       ;; Types
-      :null "none"
-      :Null "None"
-      :true "true"
-      :false "false"
-      :int "Int"
-      :str "String"
-      :float "Float"
-      :bool "Boolean"
-      :list "List"
+      :null         "none"
+      :Null         "None"
+      :true         "true"
+      :false        "false"
+      :int          "Int"
+      :str          "String"
+      :float        "Float"
+      :bool         "Boolean"
+      :list         "List"
       ;; Flow
-      :not "!"
-      :and "&&"
-      :or "||"
-      :yield "yield"
+      :for          "for"
+      :not          "!"
+      :and          "&&"
+      :or           "||"
+      :yield        "yield"
       ;; Other
-      :union "union"
-      :intersect "intersect")
+      :union        "union"
+      :intersect    "intersect"
+      :diff         "diff")
 
   (setq scala-indent:align-parameters t
         ;; indent block comments to first asterix, not second

--- a/modules/lang/scala/config.el
+++ b/modules/lang/scala/config.el
@@ -8,9 +8,35 @@
 ;;; Packages
 
 (after! scala-mode
+  (set-pretty-symbols! 'scala-mode
+      ;; Functional
+      :def "def"
+      :composition "compose"
+      ;; HKT
+      :lambda "Lambda"
+      ;; Types
+      :null "none"
+      :Null "None"
+      :true "true"
+      :false "false"
+      :int "Int"
+      :str "String"
+      :float "Float"
+      :bool "Boolean"
+      :list "List"
+      ;; Flow
+      :not "!"
+      :and "&&"
+      :or "||"
+      :yield "yield"
+      ;; Other
+      :union "union"
+      :intersect "intersect")
+
   (setq scala-indent:align-parameters t
         ;; indent block comments to first asterix, not second
         scala-indent:use-javadoc-style t)
+  
 
   (setq-hook! 'scala-mode-hook
     comment-line-break-function #'+scala-comment-indent-new-line-fn)

--- a/modules/ui/pretty-code/config.el
+++ b/modules/ui/pretty-code/config.el
@@ -1,4 +1,4 @@
-j;;; ui/pretty-code/config.el -*- lexical-binding: t; -*-
+;;; ui/pretty-code/config.el -*- lexical-binding: t; -*-
 
 (defvar +pretty-code-symbols
   '(;; org

--- a/modules/ui/pretty-code/config.el
+++ b/modules/ui/pretty-code/config.el
@@ -1,4 +1,4 @@
-;;; ui/pretty-code/config.el -*- lexical-binding: t; -*-
+j;;; ui/pretty-code/config.el -*- lexical-binding: t; -*-
 
 (defvar +pretty-code-symbols
   '(;; org
@@ -12,12 +12,15 @@
     :map           "↦"
     ;; Types
     :null          "∅"
+    :Null          "∅"
     :true          "𝕋"
     :false         "𝔽"
     :int           "ℤ"
+    :Int           "ℤ"
     :float         "ℝ"
     :str           "𝕊"
     :bool          "𝔹"
+    :list          "𝕃"
     ;; Flow
     :not           "￢"
     :in            "∈"
@@ -29,6 +32,9 @@
     :return        "⟼"
     :yield         "⟻"
     ;; Other
+    :union         "⋃"
+    :intersect     "∩"
+    :diff          "∖"
     :tuple         "⨂"
     :pipe          "" ;; FIXME: find a non-private char
     :dot           "•")


### PR DESCRIPTION
This PR adds pretty-code support for Scala-mode.
Additionally, it adds some new symbols to the pretty-code component in the ui module.