### PR TITLE
IRC/circe fixes: TLS connection workaround and default server settings

### DIFF
--- a/modules/app/irc/config.el
+++ b/modules/app/irc/config.el
@@ -93,7 +93,7 @@ playback.")
   (add-hook 'circe-channel-mode-hook #'turn-on-visual-line-mode)
   (add-hook 'circe-mode-hook #'+irc--add-circe-buffer-to-persp-h)
   (add-hook 'circe-mode-hook #'turn-off-smartparens-mode)
-  (add-hook 'circe-mode-hook (lambda () (setq-local tls-end-of-info
+  (setq-hook! 'circe-mode-hook tls-end-of-info
       (concat
        "\\("
        ;; `openssl s_client' regexp.  See ssl/ssl_txt.c lines 219-220.
@@ -107,8 +107,7 @@ playback.")
        ;; in `main' the handshake will start after this message.  If the
        ;; handshake fails, the programs will abort.
        "^\\*\\*\\* Starting TLS handshake\n\\)*"
-       "\\)")
-                                         )))
+       "\\)"))
 
 
   (defadvice! +irc--circe-run-disconnect-hook-a (&rest _)

--- a/modules/app/irc/config.el
+++ b/modules/app/irc/config.el
@@ -48,7 +48,6 @@ playback.")
 
 (use-package! circe
   :commands circe circe-server-buffers
-  :init (setq circe-network-defaults nil)
   :config
   (setq circe-default-quit-message nil
         circe-default-part-message nil

--- a/modules/app/irc/config.el
+++ b/modules/app/irc/config.el
@@ -94,6 +94,23 @@ playback.")
   (add-hook 'circe-channel-mode-hook #'turn-on-visual-line-mode)
   (add-hook 'circe-mode-hook #'+irc--add-circe-buffer-to-persp-h)
   (add-hook 'circe-mode-hook #'turn-off-smartparens-mode)
+  (add-hook 'circe-mode-hook (lambda () (setq-local tls-end-of-info
+      (concat
+       "\\("
+       ;; `openssl s_client' regexp.  See ssl/ssl_txt.c lines 219-220.
+       ;; According to apps/s_client.c line 1515 `---' is always the last
+       ;; line that is printed by s_client before the real data.
+       "^    Verify return code: .+\n\\(\\|^    Extended master secret: .+\n\\)\\(\\|^    Max Early Data: .+\n\\)---\n\\|"
+       ;; `gnutls' regexp. See src/cli.c lines 721-.
+       "^- Simple Client Mode:\n"
+       "\\(\n\\|"                           ; ignore blank lines
+       ;; According to GnuTLS v2.1.5 src/cli.c lines 640-650 and 705-715
+       ;; in `main' the handshake will start after this message.  If the
+       ;; handshake fails, the programs will abort.
+       "^\\*\\*\\* Starting TLS handshake\n\\)*"
+       "\\)")
+                                         )))
+
 
   (defadvice! +irc--circe-run-disconnect-hook-a (&rest _)
     "Runs `+irc-disconnect-hook' after circe disconnects."


### PR DESCRIPTION
This PR addresses the problem mentioned in issue #1862 where the IRC module circe is hanging on TLS connections when using OpenSSL versions > 1.1.0. In this case, `tls.el` does not correctly determine the end of the info block and hangs.

This workaround was first proposed here: https://github.com/jorgenschaefer/circe/issues/340#issuecomment-454521683
Since it looks like it will not be fixed upstream, this might be a good place to incorporate the workaround.

Additionally, this PR fixes `circe-network-defaults' being overwritten on init: by default, this list is filled with predefined server details for e.g. Freenode.net which is rather useful.

Please note that this code works fine on my setup and with my OpenSSL setup (1.1.1a on Ubuntu Mate 19.10) connecting to Freenode.net but I have not yet been able to test it on another system/server connection.