### PR TITLE
Disable namespace indentation in :lang cc

### DIFF
--- a/modules/lang/cc/config.el
+++ b/modules/lang/cc/config.el
@@ -107,7 +107,8 @@ This is ignored by ccls.")
              ;; another level
              (access-label . -)
              (inclass +cc-c++-lineup-inclass +)
-             (label . 0))))
+             (label . 0)
+             (innamespace . [0])))
 
   (when (listp c-default-style)
     (setf (alist-get 'other c-default-style) "doom"))


### PR DESCRIPTION
Most C++ style guides require no indentation in namespaces, and it's *really* bugging me when an extra indentation is added for no reason just because I'm in a namespace. This change would fix that. If you feel that changing the global settings for that isn't the right move, perhaps we could add a config option to customize the C++ style. It also appears there is a hack to force electric to use clang-format to fix indentation, so maybe that can be configurable too. Whatever the case, I would like there to be reasonable defaults.