### PR TITLE
Prefer jar file for plantuml-mode if it is available

### DIFF
--- a/modules/lang/plantuml/config.el
+++ b/modules/lang/plantuml/config.el
@@ -9,8 +9,8 @@
   (set-popup-rule! "^\\*PLANTUML" :size 0.4 :select nil :ttl 0)
 
   (setq plantuml-default-exec-mode
-        (cond ((executable-find "plantuml") 'executable)
-              ((file-exists-p plantuml-jar-path) 'jar)
+        (cond ((file-exists-p plantuml-jar-path) 'jar)
+              ((executable-find "plantuml") 'executable)
               (plantuml-default-exec-mode))))
 
 


### PR DESCRIPTION
Hello,

## The Problem

There is a problem with PlantUML on macOS at the moment, the default executable (from HomeBrew) produces warnings in the output, and the `plantuml-mode` does not filter them. As a result, when you try to preview your graph within Doom Emacs you will see something like this instead of the image:

```
2020-03-17 01:16:07.106 java[8100:11358722] CoreText note: Client requested name ".SFNS-Regular", it will get Times-Roman rather than the intended font. All system UI font access should be through proper APIs such as CTFontCreateUIFontForLanguage() or +[NSFont systemFontOfSize:].
2020-03-17 01:16:07.106 java[8100:11358722] CoreText note: Set a breakpoint on CTFontLogSystemFontNameRequest to debug.
2020-03-17 01:16:07.107 java[8100:11358722] CoreText note: Client requested name ".SFNS-Bold", it will get Times-Roman rather than the intended font. All system UI font access should be through proper APIs such as CTFontCreateUIFontForLanguage() or +[NSFont systemFontOfSize:].
2020-03-17 01:16:07.107 java[8100:11358722] CoreText note: Client requested name ".SFNSMono-Regular", it will get Times-Roman rather than the intended font. All system UI font access should be through proper APIs such as CTFontCreateUIFontForLanguage() or +[NSFont systemFontOfSize:].
2020-03-17 01:16:07.110 java[8100:11358722] CoreText note: Client requested name ".SFNSMono-Regular", it will get Times-Roman rather than the intended font. All system UI font access should be through proper APIs such as CTFontCreateUIFontForLanguage() or +[NSFont systemFontOfSize:].
2020-03-17 01:16:07.110 java[8100:11358722] CoreText note: Client requested name ".SFNSMono-Regular", it will get Times-Roman rather than the intended font. All system UI font access should be through proper APIs such as CTFontCreateUIFontForLanguage() or +[NSFont systemFontOfSize:].
2020-03-17 01:16:07.113 java[8100:11358722] CoreText note: Client requested name ".SFNS-Regular", it will get Times-Roman rather than the intended font. All system UI font access should be through proper APIs such as CTFontCreateUIFontForLanguage() or +[NSFont systemFontOfSize:].
2020-03-17 01:16:07.113 java[8100:11358722] CoreText note: Client requested name ".SFNS-Bold", it will get Times-Roman rather than the intended font. All system UI font access should be through proper APIs such as CTFontCreateUIFontForLanguage() or +[NSFont systemFontOfSize:].
\211PNG^M
...
BASE64 IMAGE HERE
```

You can install a `jar` file with `plantuml-download-jar` to resolve the problem, but Doom prefers the executable even if the `jar` file is available.

## The solution

In the PR, I changed the order, now Doom prefers the installed `jar` and only then looking for an executable.

Let me know if there are better options or something is wrong with the PR.