### PR TITLE
Only use the vterm popup rule for Doom vterm helpers

### DIFF
--- a/modules/term/vterm/autoload.el
+++ b/modules/term/vterm/autoload.el
@@ -1,5 +1,7 @@
 ;;; term/vterm/autoload.el -*- lexical-binding: t; -*-
 
+(defvar +vterm--popup-rule '("^vterm" :size 0.25 :vslot -4 :select t :quit nil :ttl 0))
+
 ;;;###autoload
 (defun +vterm/toggle (arg)
   "Toggles a terminal popup window at project root.
@@ -33,7 +35,8 @@ If prefix ARG is non-nil, recreate vterm buffer in the current project's root."
       (let ((buffer (get-buffer-create buffer-name)))
         (with-current-buffer buffer
           (unless (eq major-mode 'vterm-mode)
-            (vterm-mode)))
+            (with-popup-rules! '('+vterm--popup-rule)
+              (vterm-mode))))
         (pop-to-buffer buffer)))))
 
 ;;;###autoload
@@ -55,7 +58,8 @@ If prefix ARG is non-nil, cd into `default-directory' instead of project root."
              project-root))
          display-buffer-alist)
     (setenv "PROOT" project-root)
-    (vterm)))
+    (with-popup-rules! '('+vterm--popup-rule)
+      (vterm))))
 
 
 (defvar +vterm--insert-point nil)

--- a/modules/term/vterm/config.el
+++ b/modules/term/vterm/config.el
@@ -5,7 +5,6 @@
   :commands (vterm vterm-mode)
   :preface (setq vterm-install t)
   :config
-  (set-popup-rule! "^vterm" :size 0.25 :vslot -4 :select t :quit nil :ttl 0)
 
   (setq-hook! 'vterm-mode-hook
     ;; Don't prompt about processes when killing vterm


### PR DESCRIPTION
The popup rule for vterm applies to all vterm buffers but sometimes I want to open vterm buffers to take up the full screen or window.  This PR make the Doom popup rule for vterm specific to the Doom vterm helpers.