### PR TITLE
dragndrop: insert #+attr_org: :width if specified

### DIFF
--- a/modules/lang/org/contrib/dragndrop.el
+++ b/modules/lang/org/contrib/dragndrop.el
@@ -50,6 +50,8 @@ an file icon produced by `+org-attach-icon-for')."
                (format "#+attr_html: :width %dpx\n" org-download-image-html-width))
              (if (= org-download-image-latex-width 0) ""
                (format "#+attr_latex: :width %dcm\n" org-download-image-latex-width))
+             (if (= org-download-image-org-width 0) ""
+               (format "#+attr_org: :width %dpx\n" org-download-image-org-width))
              (format org-download-link-format
                      (cond ((file-in-directory-p filename org-attach-directory)
                             (file-relative-name filename org-download-image-dir))


### PR DESCRIPTION
In line with latex and html attributes. Essential for high resolution displays.