### PR TITLE
irc: only use the switch buffer logic during creation

### DIFF
--- a/modules/app/irc/autoload/irc.el
+++ b/modules/app/irc/autoload/irc.el
@@ -7,12 +7,14 @@
              (not inhibit-workspace))
     (+workspace-switch +irc--workspace-name 'auto-create))
   (let ((buffers (doom-buffers-in-mode 'circe-mode nil t)))
-    (if buffers
-        (ignore (switch-to-buffer (car buffers)))
-      (require 'circe)
-      (delete-other-windows)
-      (switch-to-buffer (doom-fallback-buffer))
-      t)))
+    (if (not (member (window-buffer) buffers))
+        (if buffers
+            (ignore (switch-to-buffer (car buffers)))
+          (require 'circe)
+          (delete-other-windows)
+          (switch-to-buffer (doom-fallback-buffer))
+          t)
+      (user-error "IRC buffer is already active and selected"))))
 
 ;;;###autoload
 (defun =irc (&optional inhibit-workspace)


### PR DESCRIPTION
This fixes a problem where calling IRC (e.g. C-c I I) will switch to
a (seemingly random but is ordered by load order) buffer.


----

#