### PR TITLE
Fix TLS error caused by #2763

### DIFF
--- a/core/autoload/debug.el
+++ b/core/autoload/debug.el
@@ -184,15 +184,45 @@ markdown and copies it to your clipboard, ready to be pasted into bug reports!"
 
 ;;;###autoload
 (defun doom/am-i-secure ()
-  "Test to see if your root certificates are securely configured in emacs."
+  "Test to see if your root certificates are securely configured in emacs.
+Some items are not supported by the `nsm.el' module."
   (declare (interactive-only t))
   (interactive)
   (unless (string-match-p "\\_<GNUTLS\\_>" system-configuration-features)
     (warn "gnutls support isn't built into Emacs, there may be problems"))
   (if-let* ((bad-hosts
              (cl-loop for bad
-                      in '("https://wrong.host.badssl.com/"
-                           "https://self-signed.badssl.com/")
+                      in '("https://expired.badssl.com/"
+                           "https://wrong.host.badssl.com/"
+                           "https://self-signed.badssl.com/"
+                           "https://untrusted-root.badssl.com/"
+                           ;; "https://revoked.badssl.com/"
+                           ;; "https://pinning-test.badssl.com/"
+                           "https://sha1-intermediate.badssl.com/"
+                           "https://rc4-md5.badssl.com/"
+                           "https://rc4.badssl.com/"
+                           "https://3des.badssl.com/"
+                           "https://null.badssl.com/"
+                           "https://sha1-intermediate.badssl.com/"
+                           ;; "https://client-cert-missing.badssl.com/"
+                           "https://dh480.badssl.com/"
+                           "https://dh512.badssl.com/"
+                           "https://dh-small-subgroup.badssl.com/"
+                           "https://dh-composite.badssl.com/"
+                           "https://invalid-expected-sct.badssl.com/"
+                           ;; "https://no-sct.badssl.com/"
+                           ;; "https://mixed-script.badssl.com/"
+                           ;; "https://very.badssl.com/"
+                           "https://subdomain.preloaded-hsts.badssl.com/"
+                           "https://superfish.badssl.com/"
+                           "https://edellroot.badssl.com/"
+                           "https://dsdtestprovider.badssl.com/"
+                           "https://preact-cli.badssl.com/"
+                           "https://webpack-dev-server.badssl.com/"
+                           "https://captive-portal.badssl.com/"
+                           "https://mitm-software.badssl.com/"
+                           "https://sha1-2016.badssl.com/"
+                           "https://sha1-2017.badssl.com/")
                       if (condition-case _e
                              (url-retrieve-synchronously bad)
                            (error nil))

--- a/core/core.el
+++ b/core/core.el
@@ -181,7 +181,9 @@ users).")
 ;; pulls in from all corners of the globe. Let's at least try to be more
 ;; discerning.
 (setq gnutls-verify-error (not (getenv "INSECURE"))
-      gnutls-algorithm-priority "SECURE128:+SECURE192:-VERS-ALL:+VERS-TLS1.2:+VERS-TLS1.3"
+      gnutls-algorithm-priority
+      (let ((support-tls1.3 (if (>= libgnutls-version 30605) ":+VERS-TLS1.3" nil)))
+        (concat "SECURE128:+SECURE192:-VERS-ALL:+VERS-TLS1.2" support-tls1.3))
       ;; `gnutls-min-prime-bits' is set based on recommendations from
       ;; https://www.keylength.com/en/4/
       gnutls-min-prime-bits 3072

--- a/modules/lang/rest/config.el
+++ b/modules/lang/rest/config.el
@@ -15,7 +15,7 @@
     "Forces underlying SSL verification to prompt for self-signed or invalid
 certs, rather than silently reject them."
     :around #'restclient-http-do
-    (let (gnutls-verify-error tls-checktrust)
+    (let ((gnutls-verify-error tls-checktrust))
       (apply orig-fn args)))
 
   (map! :map restclient-mode-map


### PR DESCRIPTION
- Check whether the current gnutls library supports tls1.3, should fix #2781 as well.

- Add more tests for `doom/am-i-secure`.