### PR TITLE
Improve org pretty-symbols for begin_src/end_src

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -179,7 +179,9 @@ background (and foreground) match the current theme."
   (set-pretty-symbols! 'org-mode
     :name "#+NAME:"
     :src_block "#+BEGIN_SRC"
-    :src_block_end "#+END_SRC"))
+    :src_block_end "#+END_SRC"
+    :src_block "#+begin_src"
+    :src_block_end "#+end_src"))
 
 
 (defun +org-init-babel-h ()


### PR DESCRIPTION
When using `org-insert-structure-template`, it inserts the code blocks
as lowercase. This change tweaks the pretty-symbols to match the
lowercase version of `begin_src`/`end_src`.