### PR TITLE
Add default gnome support for org +dragndrop

### DIFF
--- a/modules/lang/org/contrib/dragndrop.el
+++ b/modules/lang/org/contrib/dragndrop.el
@@ -29,7 +29,8 @@
         (cond (IS-MAC "screencapture -i %s")
               (IS-LINUX
                (cond ((executable-find "maim")  "maim -s %s")
-                     ((executable-find "scrot") "scrot -s %s")))))
+                     ((executable-find "scrot") "scrot -s %s")
+                     ((executable-find "gnome-screenshot") "gnome-screenshot -a -f %s")))))
 
   ;; Handle non-image files a little differently. Images should be inserted
   ;; as-is, as image previews. Other files, like pdfs or zips, should be linked


### PR DESCRIPTION
By default Gnome based distros (like Ubuntu) have `gnome-screenshot`
installed. This change modifies `+dragndrop` to support gnome-screenshot
by default.