### PR TITLE
Add dart to `init.example.el`

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -114,6 +114,7 @@
        ;;crystal           ; ruby at the speed of c
        ;;csharp            ; unity, .NET, and mono shenanigans
        data              ; config/data formats
+       ;;(dart +flutter)   ; paint ui and not much else
        ;;elixir            ; erlang done right
        ;;elm               ; care for a cup of TEA?
        emacs-lisp        ; drown in parentheses


### PR DESCRIPTION
Thought it will be added, but I see it's absent after the merge so I added it myself.
