### PR TITLE
Inhibit ivy-erlang-completion when lsp is active

### DIFF
--- a/modules/lang/erlang/config.el
+++ b/modules/lang/erlang/config.el
@@ -14,6 +14,7 @@
 
 (use-package! ivy-erlang-complete
   :when (featurep! :completion ivy)
+  :unless (featurep! +lsp)
   :hook (erlang-mode . ivy-erlang-complete-init)
   :config
   (add-hook! 'erlang-mode-hook


### PR DESCRIPTION
I noticed this issue while trying to get `erlang_ls` up and running in doom. Basically, prior to this fix, if you have `ivy` enabled in your `init.el` and you add `(erlang +lsp)` to your config, you get the following message when attempting to open a `.erl` file:

```
File mode specification error: (file-missing Cannot open load file No such file or directory ivy-erlang-complete)
```

Like with `company` completion, this fix simply disables `ivy-erlang-completion` if the `+lsp` flag is active for erlang.