### PR TITLE
Move away from obsolete org-roam function in org +roam

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -487,7 +487,7 @@
             :desc "Switch to buffer" "b" #'org-roam-switch-to-buffer
             :desc "Insert"           "i" #'org-roam-insert
             :desc "Find file"        "f" #'org-roam-find-file
-            :desc "Show graph"       "g" #'org-roam-show-graph))
+            :desc "Show graph"       "g" #'org-roam-graph-show))
 
         (:when (featurep! :lang org +journal)
           (:prefix ("j" . "journal")

--- a/modules/lang/org/contrib/roam.el
+++ b/modules/lang/org/contrib/roam.el
@@ -6,7 +6,7 @@
              org-roam-insert
              org-roam-find-file
              org-roam-switch-to-buffer
-             org-roam-show-graph)
+             org-roam-graph-show)
   :init
   (map! :after org
         :map org-mode-map
@@ -16,7 +16,7 @@
         "i" #'org-roam-insert
         "b" #'org-roam-switch-to-buffer
         "f" #'org-roam-find-file
-        "g" #'org-roam-show-graph
+        "g" #'org-roam-graph-show
         "i" #'org-roam-insert)
   :config
   (setq org-roam-directory org-directory)


### PR DESCRIPTION
The command org-roam-show-graph was marked obsolete in favor of org-roam-graph-show by org-roam commit 22b9d4b (before org-roam's pinning at b86d2c8), see https://github.com/jethrokuan/org-roam/pull/363.