### PR TITLE
grammar/langtool: support setting the path to the binary i/o jar

### DIFF
--- a/modules/checkers/grammar/config.el
+++ b/modules/checkers/grammar/config.el
@@ -7,7 +7,8 @@
              langtool-correct-buffer)
   :init (setq langtool-default-language "en-US")
   :config
-  (unless langtool-language-tool-jar
+  (unless (or langtool-bin
+              langtool-language-tool-jar)
     (setq langtool-language-tool-jar
           (cond (IS-MAC
                  (locate-file "libexec/languagetool-commandline.jar"


### PR DESCRIPTION
On nix we create a wrapper script that handles java for us, so allow setting `langtool-bin` instead of forcing looking for the `jar`.