### PR TITLE
Make uuidgen consistent for org-id-new

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -514,12 +514,12 @@ current workspace (and clean them up)."
                     (apply old-create-image file-or-data type data-p props)))))
       (apply orig-fn args)))
 
-  (defadvice! +org--fix-inconsistent-uuidgen-case (orig-fn &rest args)
+  (defadvice! +org--fix-inconsistent-uuidgen-case-a (uuid)
     "Ensure uuidgen always produces lowercase output regardless of system."
-    :around #'org-id-new
-    (if (equal org-id-method 'uuid)
-        (downcase (apply orig-fn args))
-      (apply orig-fn args))))
+    :filter-return #'org-id-new
+    (if (eq org-id-method 'uuid)
+        (downcase uuid)
+      uuid)))
 
 
 (defun +org-init-keybinds-h ()

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -512,6 +512,13 @@ current workspace (and clean them up)."
                 (lambda (file-or-data &optional type data-p &rest props)
                   (let ((type (if (plist-get props :width) type)))
                     (apply old-create-image file-or-data type data-p props)))))
+      (apply orig-fn args)))
+
+  (defadvice! +org--fix-inconsistent-uuidgen-case (orig-fn &rest args)
+    "Ensure uuidgen always produces lowercase output regardless of system."
+    :around #'org-id-new
+    (if (equal org-id-method 'uuid)
+        (downcase (apply orig-fn args))
       (apply orig-fn args))))
 
 


### PR DESCRIPTION
On macos/bsd systems, uuidgen produces all uppercase output. On
Linux/GNU systems it produces all lowercase output. This leads to
problems when managing org files across both systems (see e.g.
https://lists.gnu.org/archive/html/emacs-orgmode/2019-07/msg00081.html).

This change adds a defadvice for `org-id-new` to always lowercase the
output of `uuidgen` so the behavior is consistent across platforms.