### PR TITLE
Enable pipenv-with-projectile

### DIFF
--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -209,7 +209,7 @@ called.")
       (:description . "Run Python script")))
   (map! :map python-mode-map
         :localleader
-        :prefix "e"
+        :prefix ("e" . "pipenv")
         :desc "activate"    "a" #'pipenv-activate
         :desc "deactivate"  "d" #'pipenv-deactivate
         :desc "install"     "i" #'pipenv-install

--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -198,7 +198,6 @@ called.")
 (use-package! pipenv
   :commands pipenv-project-p
   :hook (python-mode . pipenv-mode)
-  :init (setq pipenv-with-projectile nil)
   :config
   (set-eval-handler! 'python-mode
     '((:command . (lambda () python-shell-interpreter))


### PR DESCRIPTION
Pipenv was not automatically enabled when entering a Pipenv project, now it is. Not sure why it was disabled explicitly in the first place.

I guess this also resolves #1666