### PR TITLE
Add +fold flag to lang/latex for TeX-fold

### DIFF
--- a/docs/modules.org
+++ b/docs/modules.org
@@ -114,7 +114,7 @@ Modules that bring support for a language or group of languages to Emacs.
 + [[file:../modules/lang/javascript/README.org][javascript]] =+lsp= - JavaScript, TypeScript, and CoffeeScript support
 + julia - TODO
 + kotlin =+lsp+= - TODO
-+ [[file:../modules/lang/latex/README.org][latex]] =+latexmk +cdlatex= - TODO
++ [[file:../modules/lang/latex/README.org][latex]] =+latexmk +cdlatex= =+fold= - TODO
 + lean - TODO
 + [[file:../modules/lang/ledger/README.org][ledger]] - TODO
 + lua =+moonscript= - TODO

--- a/docs/modules.org
+++ b/docs/modules.org
@@ -114,7 +114,7 @@ Modules that bring support for a language or group of languages to Emacs.
 + [[file:../modules/lang/javascript/README.org][javascript]] =+lsp= - JavaScript, TypeScript, and CoffeeScript support
 + julia - TODO
 + kotlin =+lsp+= - TODO
-+ [[file:../modules/lang/latex/README.org][latex]] =+latexmk +cdlatex= =+fold= - TODO
++ [[file:../modules/lang/latex/README.org][latex]] =+latexmk +cdlatex +fold= - TODO
 + lean - TODO
 + [[file:../modules/lang/ledger/README.org][ledger]] - TODO
 + lua =+moonscript= - TODO

--- a/modules/lang/latex/README.org
+++ b/modules/lang/latex/README.org
@@ -30,6 +30,8 @@ Provide a helping hand when working with LaTeX documents.
 ** Module Flags
 + =+latexmk= Use LatexMk instead of LaTeX to compile documents.
 + =+cdlatex= Enable [[https://github.com/cdominik/cdlatex][cdlatex]] for fast math insertion.
++ =+fold= Use TeX-fold (from auctex) to fold LaTeX macros to unicode, and make
+  folding hook-based and less manual.
 
 ** Plugins
 + [[http://www.gnu.org/software/auctex/][auctex]]

--- a/modules/lang/latex/autoload.el
+++ b/modules/lang/latex/autoload.el
@@ -40,6 +40,18 @@ Continuation lines are indented either twice `LaTeX-indent-level', or
             ((+ contin indent))))))
 
 ;;;###autoload
+(defun +latex-fold-last-macro-a (&rest _)
+  "Advice to auto-fold LaTeX macros after functions that
+typically insert macros."
+  ;; A simpler approach would be to just fold the whole line, but if point was
+  ;; inside a macro that would would kick it out. So instead we fold the last
+  ;; macro before point, hoping its the one newly inserted.
+  (TeX-fold-region (save-excursion
+                     (search-backward "\\" (line-beginning-position) t)
+                     (point))
+                   (1+ (point))))
+
+;;;###autoload
 (defun +latex-symbols-company-backend (command &optional arg &rest _ignored)
   "A wrapper backend for `company-mode' that either uses
 `company-math-symbols-unicode' or `company-math-symbols-latex'. If

--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -56,8 +56,6 @@ If no viewers are found, `latex-preview-pane' is used.")
     fill-nobreak-predicate (cons #'texmathp fill-nobreak-predicate))
   ;; Enable word wrapping
   (add-hook 'TeX-mode-hook #'visual-line-mode)
-  ;; Fold TeX macros
-  (add-hook 'TeX-mode-hook #'TeX-fold-mode)
   ;; Enable rainbow mode after applying styles to the buffer
   (add-hook 'TeX-update-style-hook #'rainbow-delimiters-mode)
   ;; display output of latex commands in popup
@@ -76,6 +74,45 @@ If no viewers are found, `latex-preview-pane' is used.")
       ;; And tweak these so that users can decide whether they want use latex
       ;; quotes or not, via `+latex-enable-plain-double-quotes'
       (sp-local-pair modes "``" nil :unless '(:add sp-in-math-p)))))
+
+
+(use-package! tex-fold
+  :when (featurep! +fold)
+  :hook (TeX-mode . TeX-fold-buffer)
+  :hook (TeX-mode . TeX-fold-mode)
+
+  :config
+  ;; Fold after all auctex macro insertions
+  (advice-add #'TeX-insert-macro :after #'+latex-fold-last-macro-a)
+  ;; Fold after cdlatex macro insertions
+  (advice-add #'cdlatex-math-symbol :after #'+latex-fold-last-macro-a)
+  (advice-add #'cdlatex-math-modify :after #'+latex-fold-last-macro-a)
+  ;; Fold after snippets
+  (when (featurep! :editor snippets)
+    (add-hook 'TeX-fold-mode-hook
+              (defun +latex-fold-set-yas-hook-h ()
+                "Set a local after-snippet-hook to fold the snippet contents."
+                (add-hook! 'yas-after-exit-snippet-hook :local
+                  (TeX-fold-region yas-snippet-beg yas-snippet-end)))))
+
+  (add-hook 'mixed-pitch-mode-hook
+            (defun +latex-fold-set-variable-pitch-h ()
+              "Fix folded things invariably getting fixed pitch when using mixed-pitch.
+Math faces should stay fixed by the mixed-pitch blacklist, this
+is mostly for \\section etc."
+              (when mixed-pitch-mode
+                ;; Adding to this list makes mixed-pitch clean the face remaps after us
+                (add-to-list 'mixed-pitch-fixed-cookie
+                             (face-remap-add-relative
+                              'TeX-fold-folded-face
+                              :family (face-attribute 'variable-pitch :family)
+                              :height (face-attribute 'variable-pitch :height))))))
+
+  (map! :map TeX-fold-mode-map
+        :localleader
+        :desc "Fold paragraph"   "f"   #'TeX-fold-paragraph
+        :desc "Unfold paragraph" "F"   #'TeX-fold-clearout-paragraph
+        :desc "Unfold buffer"    "C-f" #'TeX-fold-clearout-buffer))
 
 
 (after! latex


### PR DESCRIPTION
This utilizes auctex's TeX-fold package to auto-fold latex macros after commands
that usually insert macros: snippets, cdlatex, and auctex's macro insertions. And on startup.

Demo of me using it, expanding a snippet and inserting a macro with cdlatex:

![fold](https://user-images.githubusercontent.com/40410676/78191513-d49d4780-747e-11ea-8988-8a63ba33f8da.gif)


I've had this in my latex config for a very long time. Not long ago @tecosaur
also got interested, and I thought I should just make it a doom module.