### PR TITLE
Enable treemacs workspace/persp support

### DIFF
--- a/modules/ui/treemacs/autoload.el
+++ b/modules/ui/treemacs/autoload.el
@@ -6,8 +6,9 @@
     (cl-letf (((symbol-function 'treemacs-workspace->is-empty?)
                (symbol-function 'ignore)))
       (treemacs--init))
-    (dolist (project (treemacs-workspace->projects (treemacs-current-workspace)))
-      (treemacs-do-remove-project-from-workspace project))
+    (unless (bound-and-true-p persp-mode)
+      (dolist (project (treemacs-workspace->projects (treemacs-current-workspace)))
+        (treemacs-do-remove-project-from-workspace project)))
     (with-current-buffer origin-buffer
       (let ((project-root (or (doom-project-root) default-directory)))
         (treemacs-do-add-project-to-workspace

--- a/modules/ui/treemacs/config.el
+++ b/modules/ui/treemacs/config.el
@@ -66,3 +66,8 @@ This must be set before `treemacs' has loaded.")
 (use-package! treemacs-magit
   :when (featurep! :tools magit)
   :after treemacs magit)
+
+(use-package! treemacs-persp
+  :when (featurep! :ui workspaces)
+  :after (treemacs persp-mode)
+  :config (treemacs-set-scope-type 'Perspectives))

--- a/modules/ui/treemacs/config.el
+++ b/modules/ui/treemacs/config.el
@@ -67,7 +67,8 @@ This must be set before `treemacs' has loaded.")
   :when (featurep! :tools magit)
   :after treemacs magit)
 
+
 (use-package! treemacs-persp
   :when (featurep! :ui workspaces)
-  :after (treemacs persp-mode)
+  :after treemacs
   :config (treemacs-set-scope-type 'Perspectives))

--- a/modules/ui/treemacs/packages.el
+++ b/modules/ui/treemacs/packages.el
@@ -7,3 +7,5 @@
 (package! treemacs-projectile)
 (when (featurep! :tools magit)
   (package! treemacs-magit))
+(when (featurep! :ui workspaces)
+  (package! treemacs-persp))


### PR DESCRIPTION
With https://github.com/Alexander-Miller/treemacs/issues/592 merged,
treemacs now fully supports perspective mode. That is, each treemacs
buffer is scoped to a perspective and initializes itself using projectile.

This change re-enables treemacs-persp, enables the `Perspectives` scope,
and adjusts the doom treemacs init behavior to support the new
treemacs-persp behavior.

I haven't been able to reproduce the prior errors with melpa so I think
this is safe to re-enable now. In my testing it seems to work
well.

Only one issue is that users might need to remove their treemacs persist
file (`~/.emacs.d/.local/cache/treemacs-persist`) after this change if
using persp-mode. I'm not sure if it is necessary since I blew away my
own before testing.