### PR TITLE
lang/org: pretty symbols for the old and new word case style

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -163,8 +163,15 @@ Is relative to `org-directory', unless it is absolute. Is used in Doom's default
 
   (set-pretty-symbols! 'org-mode
     :name "#+NAME:"
+    :name "#+name:"
     :src_block "#+BEGIN_SRC"
-    :src_block_end "#+END_SRC"))
+    :src_block "#+begin_src"
+    :src_block_end "#+END_SRC"
+    :src_block_end "#+end_src"
+    :quote "#+BEGIN_QUOTE"
+    :quote "#+begin_quote"
+    :quote_end "#+END_QUOTE"
+    :quote_end "#+end_quote"))
 
 
 (defun +org-init-babel-h ()

--- a/modules/ui/pretty-code/config.el
+++ b/modules/ui/pretty-code/config.el
@@ -5,6 +5,8 @@
     :name          "»"
     :src_block     "»"
     :src_block_end "«"
+    :quote         "“"
+    :quote_end     "”"
     ;; Functional
     :lambda        "λ"
     :def           "ƒ"


### PR DESCRIPTION
org-mode recently changed the standard for naming blocks. Previously, it would use capitalized names; now it uses lower case names.

E.g., `#+BEGIN_SRC` -> `#+begin_src`

This change adds support for both naming conventions within the pretty symbols mode. Note that in many org files in the Doom documentation mix both styles and this PR helps in having a consistent visualization. This doesn't mean that we should probably choose only one "casing" convention and stick to it. I personally prefer the new style (i.e., using lower case, I don't like my code screaming back at me). 

Also, add a "quote" symbol for the `#+{begin,end}_quote` block.