### PR TITLE
fix: revert ranger version to fix paste over

### DIFF
--- a/modules/emacs/dired/packages.el
+++ b/modules/emacs/dired/packages.el
@@ -6,7 +6,7 @@
 (package! diff-hl :pin "2cf8b489f3")
 (package! dired-rsync :pin "bfd5c155be")
 (when (featurep! +ranger)
-  (package! ranger :pin "ae9b3816a6"))
+  (package! ranger :pin "af6f781a60"))
 (when (featurep! +icons)
   (package! all-the-icons-dired :pin "816987d339"))
 (package! fd-dired :pin "fd4c3f490b")


### PR DESCRIPTION
With current version of ranger.el if you copy file with ranger and paste it in the same place ranger fails  with erro instead of  appending "~1" as before. 

Related issue:
https://github.com/ralesi/ranger.el/issues/217

If newer features are not worth it, maybe we should pin older commit while waiting for fix.