### PR TITLE
Change projectile dirconfig file to .project

### DIFF
--- a/core/core-projects.el
+++ b/core/core-projects.el
@@ -75,6 +75,17 @@ Emacs.")
 
   (push (abbreviate-file-name doom-local-dir) projectile-globally-ignored-directories)
 
+  ;; Override projectile's dirconfig file '.projectile' with doom's project marker '.project'.
+  (defun projectile-dirconfig-file ()
+    "Return the absolute path to the project's dirconfig file.
+
+By default this will be `.project' in the root of the project.
+If a `.projectile' file exists, it will use that instead."
+    (cond
+     ;; Prefers '.projectile' to maintain compatibility with existing projects.
+     ((file-exists-p! (or ".projectile" ".project") (projectile-project-root)))
+     ((expand-file-name ".project" (projectile-project-root)))))
+
   ;; Disable commands that won't work, as is, and that Doom already provides a
   ;; better alternative for.
   (put 'projectile-ag 'disabled "Use +{ivy,helm}/project-search instead")

--- a/core/core-projects.el
+++ b/core/core-projects.el
@@ -76,11 +76,8 @@ Emacs.")
   (push (abbreviate-file-name doom-local-dir) projectile-globally-ignored-directories)
 
   ;; Override projectile's dirconfig file '.projectile' with doom's project marker '.project'.
-  (defun projectile-dirconfig-file ()
-    "Return the absolute path to the project's dirconfig file.
-
-By default this will be `.project' in the root of the project.
-If a `.projectile' file exists, it will use that instead."
+  (defadvice! doom--projectile-dirconfig-file-a ()
+    :override #'projectile-dirconfig-file
     (cond
      ;; Prefers '.projectile' to maintain compatibility with existing projects.
      ((file-exists-p! (or ".projectile" ".project") (projectile-project-root)))


### PR DESCRIPTION
So it matches the doom project marker `.project`. Otherwise you need to
create both a `.project` and then a `.projectile` with the project
configuration.

To maintain backwards compatibility, it will prefer a `.projectile` file
for dirconfig if found.