### PR TITLE
fix: change display-line-numbers-type to 't

### DIFF
--- a/core/templates/config.example.el
+++ b/core/templates/config.example.el
@@ -32,7 +32,7 @@
 
 ;; This determines the style of line numbers in effect. If set to `nil', line
 ;; numbers are disabled. For relative line numbers, set this to `relative'.
-(setq display-line-numbers-type t)
+(setq display-line-numbers-type 't)
 
 
 ;; Here are some additional functions/macros that could help you configure Doom:


### PR DESCRIPTION
I can not change display-line-numbers-type variable for org buffer https://github.com/Lenin1917/dotfiles/blob/master/emacs/.config/doom.d/config.el#L25 before edit t -> 't