### PR TITLE
Remove Ivy/helm-bibtex

### DIFF
--- a/modules/lang/latex/+ref.el
+++ b/modules/lang/latex/+ref.el
@@ -1,10 +1,5 @@
 ;;; lang/latex/+ref.el -*- lexical-binding: t; -*-
 
-(when (stringp +latex-bibtex-file)
-  (setq bibtex-completion-bibliography (list (expand-file-name +latex-bibtex-file))
-        reftex-default-bibliography bibtex-completion-bibliography))
-
-
 (use-package! reftex
   :hook (LaTeX-mode . reftex-mode)
   :config

--- a/modules/lang/latex/README.org
+++ b/modules/lang/latex/README.org
@@ -24,7 +24,6 @@ Provide a helping hand when working with LaTeX documents.
 + Change PDF viewer to Okular or ~latex-preview-pane~
 + Bibtex editor
 + Autocompletion using ~company-mode~
-+ Ivy or Helm for selecting bibliography
 + Compile your .tex code only once using LatexMk
 
 ** Module Flags
@@ -39,7 +38,6 @@ Provide a helping hand when working with LaTeX documents.
 + [[https://github.com/alexeyr/company-auctex][company-auctex]]*
 + [[https://github.com/TheBB/company-reftex][company-reftex]]*
 + [[https://github.com/vspinu/company-math][company-math]]*
-+ [[https://github.com/tmalsburg/helm-bibtex][ivy-bibtex]]* or [[https://github.com/tmalsburg/helm-bibtex][helm-bibtex]]*
 + [[https://github.com/cdominik/cdlatex][cdlatex]] (=+cdlatex=)
 
 * TODO Prerequisites
@@ -48,14 +46,11 @@ Provide a helping hand when working with LaTeX documents.
 
 * Customization
 ** Specifying the location of a bibtex file & corresponding PDFs
-The reftex and bibtex-completion packages have two variables that allow you to
-specify where it should find your bibliography file(s) and their corresponding
-PDFs:
+Reftex has a variable that allow you to
+specify where it should find your bibliography file(s):
 
 #+BEGIN_SRC emacs-lisp
 (setq reftex-default-bibliography "/your/bib/file.bib")
-;; Optionally specifying a location for the corresponding PDFs
-(setq bibtex-completion-library-path (list "/your/bib/pdfs"))
 #+END_SRC
 
 ** Changing the PDFs viewer

--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -3,9 +3,6 @@
 (defvar +latex-indent-level-item-continuation 4
   "Custom indentation level for items in enumeration-type environments")
 
-(defvar +latex-bibtex-file nil
-  "File AUCTeX (specifically RefTeX) uses to search for citations.")
-
 (defvar +latex-enable-unicode-math nil
   "If non-nil, use `company-math-symbols-unicode' backend in LaTeX-mode,
 enabling unicode symbols in math regions. This requires the unicode-math latex

--- a/modules/lang/latex/packages.el
+++ b/modules/lang/latex/packages.el
@@ -19,7 +19,3 @@
   (package! company-auctex :pin "48c42c58ce")
   (package! company-reftex :pin "275ef708f0")
   (package! company-math :pin "a796053590"))
-(when (featurep! :completion ivy)
-  (package! ivy-bibtex :pin "d4471232be"))
-(when (featurep! :completion helm)
-  (package! helm-bibtex :pin "d4471232be"))


### PR DESCRIPTION
Ivy/helm-bibtex is unused throughout the latex module, aside from implicitly by setting the `bibtex-completion-bibliography` variable. This is confusing, and unnecessary.

Ivy/helm-bibtex is a great tool, but it is also language agnostic (it can be used to insert citations in org and markdown modes), and latex mode already has excellent citation autocompletion from `company-reftex`. In my opinion, ivy/helm-bibtex would be a good candidate for inclusion in a distinct bib module, but should be removed from the latex module.