### PR TITLE
Disable deft's buffer auto-save

### DIFF
--- a/modules/ui/deft/config.el
+++ b/modules/ui/deft/config.el
@@ -7,6 +7,8 @@
         ;; de-couples filename and note title:
         deft-use-filename-as-title nil
         deft-use-filter-string-for-filename t
+        ;; disable auto-save
+        deft-auto-save-interval -1.0
         ;; converts the filter string into a readable file-name using kebab-case:
         deft-file-naming-rules
         '((noslash . "-")


### PR DESCRIPTION
By default deft will save a changed buffer that it opens after 1 second.

This causes problematic interactions with the rest of doom - like with
wsbutler (insert space, try to insert a link, and it will eat the
space before the link is inserted).

I think it's best for auto-save to be managed by a separate package,
rather than this ad-hoc save that occurs only in buffers that deft opens.