### PR TITLE
Fix install link

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -564,7 +564,7 @@ disabled by adding or removing them from your ~doom!~ block (found in
 =$DOOMDIR/init.el=).
 
 #+begin_quote
-If =$DOOMDIR/init.el= doesn't exist, you haven't installed Doom yet. See [[*Install][the
+If =$DOOMDIR/init.el= doesn't exist, you haven't installed Doom yet. See [[#install][the
 "Install" section]] above.
 #+end_quote
 


### PR DESCRIPTION
The install link in the docs is incorrect. This will link to the install section at the top of the file.