### PR TITLE
Add +lsp to Julia and override some defaults in julia-repl

### DIFF
--- a/docs/modules.org
+++ b/docs/modules.org
@@ -113,7 +113,7 @@ Modules that bring support for a language or group of languages to Emacs.
 + [[file:../modules/lang/idris/README.org][idris]] - TODO
 + java =+meghanada +lsp= - TODO
 + [[file:../modules/lang/javascript/README.org][javascript]] =+lsp= - JavaScript, TypeScript, and CoffeeScript support
-+ julia - TODO
++ julia =+lsp= - TODO
 + kotlin =+lsp+= - TODO
 + [[file:../modules/lang/latex/README.org][latex]] =+latexmk +cdlatex +fold= - TODO
 + lean - TODO

--- a/modules/lang/julia/README.org
+++ b/modules/lang/julia/README.org
@@ -26,7 +26,7 @@ Adds Julia support to Doom Emacs
 + [[https://github.com/tpapp/julia-repl][julia-mode]]
 + [[https://github.com/JuliaEditorSupport/julia-emacs/][julia-repl]]
 + =+lsp= and =:tools lsp=
-  + [[https://github.com/non-jedi/lsp-julia][lsp-julia]]
+  + [[https://github.com/non-jedi/lsp-julia][lsp-julia]]*
   + [[https://github.com/emacs-lsp/lsp-mode][lsp]]
 
 * Prerequisites
@@ -45,18 +45,21 @@ packaged version of ~LanguageServer.jl~ and its dependencies.
 * Features
   # An in-depth list of features, how to use them, and their dependencies.
 ** Language Server
-   ~lsp-julia~ comes with an installation of ~LanguageServer.jl~ currently
-   compatible with Julia v1.0.5 (current LTS) and Julia v1.3.
+   ~+lsp~ adds code completion, syntax checking, formatting and other ~lsp-mode~
+   features. This requires a manual installation of ~lsp-julia~ as it bundles
+   ~LanguageServer.jl~ and its dependencies.
   
 * Configuration
-~lsp-julia~ requires a variable be set for the Julia environment. This is set to v1.0 by default as it is the current LTS.
+~lsp-julia~ requires a variable be set for the Julia environment. This is set to
+v1.0 by default as it is the current LTS.
 
 #+BEGIN_SRC elisp
 ;; ~/.doom.d/config.el
 (setq lsp-julia-default-environment "~/.julia/environments/v1.0")
 #+END_SRC
 
-If you would like to use your own installation of ~LanguageServer.jl~, put the following in your personal ~config.el~.
+If you would like to use your own installation of ~LanguageServer.jl~, put the
+following in your personal ~config.el~.
 
 #+BEGIN_SRC elisp
 ;; ~/.doom.d/config.el

--- a/modules/lang/julia/README.org
+++ b/modules/lang/julia/README.org
@@ -1,0 +1,50 @@
+#+TITLE:   lang/julia
+#+DATE:    April 8, 2020
+#+SINCE:   {replace with next tagged release version}
+#+STARTUP: inlineimages nofold
+
+* Table of Contents :TOC_3:noexport:
+- [[#description][Description]]
+  - [[#module-flags][Module Flags]]
+  - [[#plugins][Plugins]]
+- [[#prerequisites][Prerequisites]]
+- [[#features][Features]]
+  - [[#language-server][Language Server]]
+- [[#configuration][Configuration]]
+
+* Description
+Adds Julia support to Doom Emacs
+
++ Syntax highlighting and latex symbols from ~julia-mode~
++ REPL integration from ~julia-repl~
++ Code completion and syntax checking, requires ~:tools lsp~ and ~+lsp~
+
+** Module Flags
++ =+lsp= Language Server Protocol support
+** Plugins
++ [[https://github.com/tpapp/julia-repl][julia-mode]]
++ [[https://github.com/JuliaEditorSupport/julia-emacs/][julia-repl]]
++ =+lsp= and =:tools lsp=
+  + [[https://github.com/non-jedi/lsp-julia][lsp-julia]]
+  + [[https://github.com/emacs-lsp/lsp-mode][lsp]]
+
+* Prerequisites
+This module has no direct prerequisites.
+
+* Features
+  # An in-depth list of features, how to use them, and their dependencies.
+** Language Server
+   ~lsp-julia~ comes with an installation of ~LanguageServer.jl~ currently compatible with Julia v1.0.5 (current LTS) and Julia v1.3.
+* Configuration
+~lsp-julia~ requires a variable be set for the Julia environment. This is set to v1.0 by default.
+
+#+BEGIN_SRC elisp
+;; ~/.doom.d/config.el
+(setq lsp-julia-default-environment "~/.julia/environments/v1.0")
+#+END_SRC
+
+If you would like to use your own installation of ~LanguageServer.jl~, put the following in your personal ~config.el~.
+#+BEGIN_SRC elisp
+;; ~/.doom.d/config.el
+(setq lsp-julia-package-dir nil)
+#+END_SRC

--- a/modules/lang/julia/README.org
+++ b/modules/lang/julia/README.org
@@ -8,8 +8,9 @@
   - [[#module-flags][Module Flags]]
   - [[#plugins][Plugins]]
 - [[#prerequisites][Prerequisites]]
-- [[#features][Features]]
   - [[#language-server][Language Server]]
+- [[#features][Features]]
+  - [[#language-server-1][Language Server]]
 - [[#configuration][Configuration]]
 
 * Description
@@ -31,12 +32,24 @@ Adds Julia support to Doom Emacs
 * Prerequisites
 This module has no direct prerequisites.
 
+** Language Server
+
+~+lsp~ requires the a manual installation of ~lsp-julia~ as it comes with a
+packaged version of ~LanguageServer.jl~ and its dependencies.
+
+#+BEGIN_SRC elisp
+;; ~/.doom.d/packages.el
+(package! lsp-julia :recipe (:host github :repo "non-jedi/lsp-julia"))
+#+END_SRC
+
 * Features
   # An in-depth list of features, how to use them, and their dependencies.
 ** Language Server
-   ~lsp-julia~ comes with an installation of ~LanguageServer.jl~ currently compatible with Julia v1.0.5 (current LTS) and Julia v1.3.
+   ~lsp-julia~ comes with an installation of ~LanguageServer.jl~ currently
+   compatible with Julia v1.0.5 (current LTS) and Julia v1.3.
+  
 * Configuration
-~lsp-julia~ requires a variable be set for the Julia environment. This is set to v1.0 by default.
+~lsp-julia~ requires a variable be set for the Julia environment. This is set to v1.0 by default as it is the current LTS.
 
 #+BEGIN_SRC elisp
 ;; ~/.doom.d/config.el
@@ -44,6 +57,7 @@ This module has no direct prerequisites.
 #+END_SRC
 
 If you would like to use your own installation of ~LanguageServer.jl~, put the following in your personal ~config.el~.
+
 #+BEGIN_SRC elisp
 ;; ~/.doom.d/config.el
 (setq lsp-julia-package-dir nil)

--- a/modules/lang/julia/config.el
+++ b/modules/lang/julia/config.el
@@ -31,7 +31,10 @@
 
 
 (use-package! julia-repl
-  :hook (julia-repl-mode . julia-repl-use-emacsclient)
+  :preface (defvar +julia-repl-start-hook nil)
+  :hook (julia-mode . julia-repl-mode)
+  :hook (+julia-repl-start . +julia-override-repl-escape-char-h)
+  :hook (+julia-repl-start . julia-repl-use-emacsclient)
   :config
   (set-popup-rule! "^\\*julia.*\\*$" :ttl nil)
 
@@ -41,11 +44,15 @@
       :override #'julia-repl--inferior-buffer-name
       (concat julia-repl-inferior-buffer-name-base ":" (+workspace-current-name))))
 
-  (defadvice! +julia--override-repl-escape-char-a (inferior-buffer)
-    "Use C-c instead of C-x for escaping."
+  (defadvice! +julia--run-start-hook-a (inferior-buffer)
+    "Run `+julia-repl-start-hook' before displaying the REPL."
     :after #'julia-repl--setup-term
     (with-current-buffer inferior-buffer
-      (term-set-escape-char ?\C-c))))
+      (run-hooks '+julia-repl-start-hook)))
+
+  (defun +julia-override-repl-escape-char-h ()
+    "Use C-c instead of C-x for escaping."
+    (term-set-escape-char ?\C-c)))
 
 
 (use-package! lsp-julia

--- a/modules/lang/julia/config.el
+++ b/modules/lang/julia/config.el
@@ -3,28 +3,21 @@
 (use-package! julia-mode
   :interpreter "julia"
   :config
-
-  (when (featurep! +lsp)
-    (add-hook 'julia-mode-hook #'lsp!)
-    (setq lsp-julia-default-environment "~/.julia/environments/v1.0")
-    )
-
   (set-repl-handler! 'julia-mode #'+julia/open-repl)
-  (add-hook 'julia-mode-hook #'julia-repl-mode)
 
-  ;; Borrow matlab.el's fontification of math operators
-  ;; From <https://ogbe.net/emacsconfig.html>
+  ;; Borrow matlab.el's fontification of math operators. From
+  ;; <https://ogbe.net/emacsconfig.html>
   (dolist (mode '(julia-mode ess-julia-mode))
     (font-lock-add-keywords
      mode
      `((,(let ((OR "\\|"))
-           (concat "\\(" ;; stolen `matlab.el' operators first
+           (concat "\\("  ; stolen `matlab.el' operators first
                    "[<>!]=?" OR
                    "\\.[/*^']" OR
                    "==" OR
                    "=>" OR
                    "\\<xor\\>" OR
-                   "[-+*\\/^&|$]=?" OR ;; this has to come before next (updating operators)
+                   "[-+*\\/^&|$]=?" OR  ; this has to come before next (updating operators)
                    "[-!^&|*+\\/~:]" OR
                    ;; more extra julia operators follow
                    "[%$]" OR
@@ -37,24 +30,28 @@
         1 font-lock-type-face)))))
 
 
-(after! julia-repl
-  (add-hook 'julia-repl-hook #'julia-repl-use-emacsclient)
-
-  (defadvice! julia-repl--buffer-name (&optional executable-key suffix)
-    :override #'julia-repl--inferior-buffer-name
-    "Name for a Julia REPL inferior buffer. Uses workspace name for doom emacs"
-    (concat julia-repl-inferior-buffer-name-base ":" (+workspace-current-name)))
-
+(use-package! julia-repl
+  :hook (julia-repl-mode . julia-repl-use-emacsclient)
+  :config
   (set-popup-rule! "^\\*julia.*\\*$" :ttl nil)
 
-  (defadvice! after-julia-repl-advice (inferior-buffer)
+  (when (featurep! :ui workspaces)
+    (defadvice! +julia--namespace-repl-buffer-to-workspace-a (&optional executable-key suffix)
+      "Name for a Julia REPL inferior buffer. Uses workspace name for doom emacs"
+      :override #'julia-repl--inferior-buffer-name
+      (concat julia-repl-inferior-buffer-name-base ":" (+workspace-current-name))))
+
+  (defadvice! +julia--override-repl-escape-char-a (inferior-buffer)
+    "Use C-c instead of C-x for escaping."
     :after #'julia-repl--setup-term
     (with-current-buffer inferior-buffer
-      (term-set-escape-char ?\C-c)      ; override default of C-x..
-      ))
-  )
+      (term-set-escape-char ?\C-c))))
+
 
 (use-package! lsp-julia
   :when (featurep! +lsp)
   :after lsp-clients
-  )
+  :preface
+  (setq lsp-julia-default-environment "~/.julia/environments/v1.0")
+  (when (featurep! +lsp)
+    (add-hook 'julia-mode-local-vars-hook #'lsp!)))

--- a/modules/lang/julia/config.el
+++ b/modules/lang/julia/config.el
@@ -1,6 +1,5 @@
 ;;; lang/julia/config.el -*- lexical-binding: t; -*-
 
-
 (use-package! julia-mode
   :interpreter "julia"
   :config

--- a/modules/lang/julia/packages.el
+++ b/modules/lang/julia/packages.el
@@ -3,3 +3,6 @@
 
 (package! julia-mode :pin "1c122f1dff")
 (package! julia-repl :pin "5fa04de4e7")
+
+(when (featurep! +lsp)
+  (package! lsp-julia :recipe (:host github :repo "non-jedi/lsp-julia") :pin "9f158a2"))

--- a/modules/lang/julia/packages.el
+++ b/modules/lang/julia/packages.el
@@ -3,6 +3,3 @@
 
 (package! julia-mode :pin "1c122f1dff")
 (package! julia-repl :pin "5fa04de4e7")
-
-(when (featurep! +lsp)
-  (package! lsp-julia :recipe (:host github :repo "non-jedi/lsp-julia") :pin "9f158a2"))


### PR DESCRIPTION
This pull request adds a README, additional functionality for `julia-repl` and a `+lsp` flag to the Julia module.

The language server must be manually installed, as per guidelines.

I have overriden some defaults in `julia-repl`. In particular, I override:

- `julia-repl--bufer-name` to name the Julia REPL as `*julia:[workspace-name]*`. 
- The escape sequence from `C-c C-x` to `C-c C-c`. 