### PR TITLE
Fix company-coq temporarily

### DIFF
--- a/modules/lang/coq/config.el
+++ b/modules/lang/coq/config.el
@@ -89,3 +89,18 @@
           "e" #'company-coq-document-error
           "E" #'company-coq-browse-error-messages
           "h" #'company-coq-doc)))
+
+;; `+company-init-backends-h' in `after-change-major-mode-hook' overrides
+;; `company-backends' set by `company-coq' package. This dirty hack fixes
+;; completion in coq-mode. TODO: remove when company backends builder is
+;; reworked.
+(defvar-local +coq--company-backends nil)
+(after! company-coq
+  (defun +coq--record-company-backends-h ()
+    (setq +coq--company-backends company-backends))
+  (defun +coq--replay-company-backends-h ()
+    (setq company-backends +coq--company-backends))
+  (add-hook! 'company-coq-mode-hook
+    (defun +coq--fix-company-coq-hack-h ()
+      (add-hook! 'after-change-major-mode-hook :local #'+coq--record-company-backends-h)
+      (add-hook! 'after-change-major-mode-hook :append :local #'+coq--replay-company-backends-h))))


### PR DESCRIPTION
This patch is slightly more general than the one I posted in discord, so I think other coq folks may be interested in having it too. I actually think it is cleaner to just have a blacklist variable for `+company-init-backends-h`, as it has already done something similar to `fundamental-mode` and `special-mode`. But you may have a better plan for this. Anyway, feel free to close it if you think this hack is too dirty to merge :)