### PR TITLE
adding new biblio module

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -123,6 +123,11 @@
       (:prefix-map ("n" . "notes")
         :desc "Search notes for symbol"        "." #'+default/search-notes-for-symbol-at-point
         :desc "Org agenda"                     "a" #'org-agenda
+        (:when (featurep! :tools biblio)
+          :desc "Bibliographic entries"        "b"
+          (cond ((featurep! :completion ivy)   #'ivy-bibtex)
+                ((featurep! :completion helm)  #'helm-bibtex)))
+
         :desc "Find file in notes"             "f" #'+default/find-in-notes
         :desc "Browse notes"                   "F" #'+default/browse-notes
         :desc "Org store link"                 "l" #'org-store-link

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -454,6 +454,11 @@
       (:prefix-map ("n" . "notes")
         :desc "Search notes for symbol"      "*" #'+default/search-notes-for-symbol-at-point
         :desc "Org agenda"                   "a" #'org-agenda
+        (:when (featurep! :tools biblio)
+          :desc "Bibliographic entries"        "b"
+          (cond ((featurep! :completion ivy)   #'ivy-bibtex)
+                ((featurep! :completion helm)  #'helm-bibtex)))
+
         :desc "Toggle org-clock"             "c" #'+org/toggle-clock
         :desc "Cancel org-clock"             "C" #'org-clock-cancel
         :desc "Open deft"                    "d" #'deft

--- a/modules/tools/biblio/config.el
+++ b/modules/tools/biblio/config.el
@@ -1,0 +1,7 @@
+;;; tools/biblio/config.el -*- lexical-binding: t; -*-
+
+(use-package! ivy-bibtex
+  :when (featurep! :completion ivy)
+  :defer t
+  :config
+  (add-to-list 'ivy-re-builders-alist '(ivy-bibtex . ivy--regex-plus)))

--- a/modules/tools/biblio/packages.el
+++ b/modules/tools/biblio/packages.el
@@ -1,0 +1,7 @@
+;; -*- no-byte-compile: t; -*-
+;;; tools/biblio/packages.el
+
+(when (featurep! :completion ivy)
+  (package! ivy-bibtex :pin "3cff6bd702"))
+(when (featurep! :completion helm)
+  (package! helm-bibtex :pin "3cff6bd702"))


### PR DESCRIPTION
Addressing #2827, this is a minimal biblio module that provides `ivy-bibtex` or `helm-bibtex` (which were recently removed from the latex module in #2838) depending on completion feature, and provides a single global keybinding.

The idea is this provides the core functionalty, and the community can iteratively build it up as appropriate.