### PR TITLE
Update org-roam to fix errors

### DIFF
--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -74,9 +74,9 @@
   (package! org-tree-slide :pin "7bf09a02bd")
   (package! org-re-reveal :pin "e4460a98b6"))
 (when (featurep! +roam)
-  (package! org-roam :pin "dfb8449680")
+  (package! org-roam :pin "6e97003967")
   (when (featurep! :completion company)
-    (package! company-org-roam :pin "063581df54")))
+    (package! company-org-roam :pin "0913d86f16")))
 
 ;;; Babel
 (package! ob-async :pin "80a30b96a0")


### PR DESCRIPTION
Was running into a `company-org-reveal` not found issue. Also trying to manage it separately in `packages.el` led to https://github.com/jethrokuan/org-roam/issues/367