### PR TITLE
Add helm-descbinds

### DIFF
--- a/modules/completion/helm/config.el
+++ b/modules/completion/helm/config.el
@@ -41,7 +41,8 @@ be negative.")
         [remap projectile-switch-project] #'helm-projectile-switch-project
         [remap projectile-switch-to-buffer] #'helm-projectile-switch-to-buffer
         [remap recentf-open-files]        #'helm-recentf
-        [remap yank-pop]                  #'helm-show-kill-ring)
+        [remap yank-pop]                  #'helm-show-kill-ring
+        [remap describe-bindings]         #'helm-descbinds)
   :config
   (helm-mode +1)
   ;; helm is too heavy for `find-file-at-point'
@@ -189,3 +190,9 @@ be negative.")
         (lambda (buf &optional _resume) (pop-to-buffer buf)))
   (global-set-key [remap swiper] #'swiper-helm)
   (add-to-list 'swiper-font-lock-exclude #'+doom-dashboard-mode nil #'eq))
+
+
+(use-package! helm-descbinds
+  :after helm-mode
+  :config
+  (helm-descbinds-mode +1))

--- a/modules/completion/helm/packages.el
+++ b/modules/completion/helm/packages.el
@@ -16,3 +16,4 @@
   (package! posframe :pin "c15800a838"))
 (when (featurep! :lang org)
   (package! helm-org :pin "b7a18dfc17"))
+(package! helm-descbinds :pin "b725159823")


### PR DESCRIPTION
This package allows for easier navigation of the assigned bindings.
The inbuilt describe-bindings (C-h b b) feature is remapped to the helm
equivalent.

Signed-off-by: Brian McGillion <brian@ssrc.tii.ae>