### PR TITLE
[WIP] - RFQ on adding or-ref and org-noter

### DIFF
--- a/modules/lang/org/README.org
+++ b/modules/lang/org/README.org
@@ -68,6 +68,8 @@ https://www.mfoot.com/blog/2015/11/22/literate-emacs-configuration-with-org-mode
 + =+present= Enables integration with reveal.js, beamer and org-tree-slide, so
   Emacs can be used for presentations.
 + =+roam= Enables org-roam integration.
++ =+noter= Enables org-noter integration. Keeps notes in sync with a document.
+  Requires [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Document-View.html][pdf-tools]] or [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Document-View.html][DocView]] or [[https://github.com/wasamasa/nov.el][nov.el]] to be enabled.
 
 ** Plugins
 + [[https://github.com/hniksic/emacs-htmlize][htmlize]]
@@ -117,6 +119,10 @@ https://www.mfoot.com/blog/2015/11/22/literate-emacs-configuration-with-org-mode
   + [[https://gitlab.com/oer/org-re-reveal][org-re-reveal]]
 + =+roam=
   + [[https://github.com/jethrokuan/org-roam][org-roam]]
++ =:lang latex=
+  + [[https://github.com/jkitchin/org-ref][org-ref]]
++ =+noter=
+  + [[https://github.com/weirdNox/org-noter][org-noter]]
 
 ** Hacks
 + The window is recentered when following links.

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -907,6 +907,8 @@ compelling reason, so..."
   (if (featurep! +pomodoro)  (load! "contrib/pomodoro"))
   (if (featurep! +present)   (load! "contrib/present"))
   (if (featurep! +roam)      (load! "contrib/roam"))
+  (if (featurep! +noter)      (load! "contrib/noter"))
+  (if (featurep! :lang latex) (load! "contrib/ref"))
 
   ;; Add our general hooks after the submodules, so that any hooks the
   ;; submodules add run after them, and can overwrite any defaults if necessary.

--- a/modules/lang/org/contrib/noter.el
+++ b/modules/lang/org/contrib/noter.el
@@ -1,0 +1,22 @@
+;;; lang/org/contrib/noter.el -*- lexical-binding: t; -*-
+;;;###if (featurep! +noter)
+
+
+;; org-noter
+(use-package! org-noter
+  :preface
+  ;; Allow the user to preempt this and set the document search path
+  ;; If not set then use `org-directory'
+  (defvar org-noter-notes-search-path nil)
+  :init
+  (map! :leader
+        ;;; <leader> n --- notes
+        (:prefix-map ("n" . "notes")
+          (:prefix-map ("r" . "ref")
+            :desc "Org Noter"      "n" #'org-noter))) ;;TODO Define a set of useful commands
+
+  :config
+  (setq org-noter-auto-save-last-location t
+        org-noter-separate-notes-from-heading t)
+  (unless org-noter-notes-search-path
+    (setq org-noter-notes-search-path org-directory)))

--- a/modules/lang/org/contrib/ref.el
+++ b/modules/lang/org/contrib/ref.el
@@ -1,0 +1,9 @@
+;;; lang/org/contrib/ref.el -*- lexical-binding: t; -*-
+;;;###if (featurep! :lang latex)
+
+
+(use-package! org-ref
+  :init
+  (setq org-ref-bibliography-notes org-directory
+        org-ref-default-bibliography '(expand-file-name "library.bib" org-directory)
+        org-ref-pdf-directory "~/Documents/Papers"))

--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -77,6 +77,10 @@
   (package! org-roam :pin "6e97003967")
   (when (featurep! :completion company)
     (package! company-org-roam :pin "0913d86f16")))
+(when (featurep! :lang latex)
+  (package! org-ref :pin "5bb9be2232"))
+(when (featurep! +noter)
+  (package! org-noter :pin "9ead81d42d"))
 
 ;;; Babel
 (package! ob-async :pin "80a30b96a0")


### PR DESCRIPTION
https://github.com/hlissner/doom-emacs/pull/2861

With the above change in for review would it make more sense to put org-ref and org-noter to the biblio feature set rather than including it in org?

Signed-off-by: Brian McGillion <brian@ssrc.tii.ae>