### PR TITLE
lang/org: add support for pivotaltracker, trello and sidebar [WIP]

### DIFF
--- a/modules/lang/org/+jira.el
+++ b/modules/lang/org/+jira.el
@@ -1,0 +1,5 @@
+;;; lang/org/+jira.el -*- lexical-binding: t; -*-
+;;;###if (featurep! +jira)
+
+(use-package! ox-jira
+  :defer-incrementally org)

--- a/modules/lang/org/+pt.el
+++ b/modules/lang/org/+pt.el
@@ -1,0 +1,13 @@
+;;; lang/org/+pt.el -*- lexical-binding: t; -*-
+;;;###if (featurep! +pt)
+
+(use-package! org-pivotal
+  :defer t
+  :init
+  (map! :after org
+        :map org-mode-map
+        :localleader
+        (:prefix-map ("S" . "Sync")
+          (:prefix-map ("p" . "PT")
+            :desc "Push story"   "p" #'org-pivotal-push-story
+            :desc "Pull stories" "l" #'org-pivotal-pull-stories))))

--- a/modules/lang/org/+sidebar.el
+++ b/modules/lang/org/+sidebar.el
@@ -1,0 +1,12 @@
+;;; lang/org/+sidebar.el -*- lexical-binding: t; -*-
+;;;###if (featurep! +sidebar)
+
+(use-package! org-sidebar
+  :defer t
+  :init
+  (map! :after org
+        :map org-mode-map
+        :localleader
+        (:prefix-map ("u" . "UI toggle")
+          :desc "Toggle sidebar"      "s" #'org-sidebar-toggle
+          :desc "Toggle sidebar tree" "t" #'org-sidebar-tree-toggle)))

--- a/modules/lang/org/+trello.el
+++ b/modules/lang/org/+trello.el
@@ -1,0 +1,17 @@
+;;; lang/org/+trello.el -*- lexical-binding: t; -*-
+;;;###if (featurep! +trello)
+
+(add-to-list 'auto-mode-alist '("\\.trello\\'" . org-mode))
+
+(use-package! org-trello
+  :defer t
+  :init
+  (map! :after org
+        :map org-mode-map
+        :localleader
+        (:prefix ("S" . "Sync")
+          (:prefix ("t" . "Trello")
+            :desc "Install metadata" "i" #'org-trello-install-board-metadata
+            :desc "Update metadata"  "u" #'org-trello-update-board-metadata
+            :desc "Push buffer"      "p" #'+org-trello/push-buffer
+            :desc "Pull buffer"      "l" #'+org-trello/pull-buffer))))

--- a/modules/lang/org/autoload/trello.el
+++ b/modules/lang/org/autoload/trello.el
@@ -1,0 +1,21 @@
+;;; lang/org/autoload/trello.el -*- lexical-binding: t; -*-
+
+;;;###autoload
+(defun +org-trello/pull-buffer ()
+  (interactive)
+  (org-trello-sync-buffer 1))
+
+;;;###autoload
+(defun org-trello/push-buffer ()
+  (interactive)
+  (org-trello-sync-buffer))
+
+;;;###autoload
+(defun org-trello/pull-card ()
+  (interactive)
+  (org-trello-sync-card 1))
+
+;;;###autoload
+(defun org-trello/push-card ()
+  (interactive)
+  (org-trello-sync-card))

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -906,7 +906,10 @@ compelling reason, so..."
   (if (featurep! +jupyter)   (load! "contrib/jupyter"))
   (if (featurep! +pomodoro)  (load! "contrib/pomodoro"))
   (if (featurep! +present)   (load! "contrib/present"))
+  (if (featurep! +pt)        (load! "+pt"))
   (if (featurep! +roam)      (load! "contrib/roam"))
+  (if (featurep! +sidebar)   (load! "+sidebar"))
+  (if (featurep! +trello)    (load! "+trello"))
 
   ;; Add our general hooks after the submodules, so that any hooks the
   ;; submodules add run after them, and can overwrite any defaults if necessary.

--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -102,12 +102,14 @@
   (package! ob-ammonite :pin "39937dff39"))
 
 ;;; Export
-(when (featurep! +pandoc)
-  (package! ox-pandoc :pin "aa37dc7e94"))
 (when (featurep! +hugo)
   (package! ox-hugo
     :recipe (:host github :repo "kaushalmodi/ox-hugo" :nonrecursive t)
     :pin "1c1e3ec467"))
+(when (featurep! +jira)
+  (package! ox-jira))
+(when (featurep! +pandoc)
+  (package! ox-pandoc :pin "aa37dc7e94"))
 (when (featurep! :lang rst)
   (package! ox-rst :pin "9158bfd180"))
 

--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -25,8 +25,8 @@
 ;; code.orgmode.org runs on a potato.
 (package! org-mode
   :recipe (:host github
-           :repo "emacs-straight/org-mode"
-           :files ("*.el" "lisp/*.el" "contrib/lisp/*.el"))
+                 :repo "emacs-straight/org-mode"
+                 :files ("*.el" "lisp/*.el" "contrib/lisp/*.el"))
   :pin "b9935765f7")
 ;; ...And prevent other packages from pulling org; org-plus-contrib satisfies
 ;; the dependency already: https://github.com/raxod502/straight.el/issues/352
@@ -77,6 +77,8 @@
   (package! org-roam :pin "6e97003967")
   (when (featurep! :completion company)
     (package! company-org-roam :pin "0913d86f16")))
+(when (featurep! +sidebar)
+  (package! org-sidebar))
 
 ;;; Babel
 (package! ob-async :pin "80a30b96a0")
@@ -108,3 +110,10 @@
     :pin "1c1e3ec467"))
 (when (featurep! :lang rst)
   (package! ox-rst :pin "9158bfd180"))
+
+;;; Sync
+(when (featurep! +pt)
+  (package! org-pivotal))
+
+(when (featurep! +trello)
+  (package! org-trello))


### PR DESCRIPTION
It's WIP because I would like confirmation on the direction before doing all the documentation.

Couple of things:

1. take up "localleader S" for Sync (trello and pt)
2. take up "localleader u" for "UI toggle" (sidebar)
3. instead of sticking the features under contrib, they are in the root prefixed with a + like the manual says. I'm guessing the contrib bit is a holdover from the early days.
4. versions not `:pin`ned yet


Questions:
1. Should I move the other contrib things into +name instead?
