### PR TITLE
Add org-noter package

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -128,7 +128,9 @@
           :desc "Bibliographic entries"        "b"
           (cond ((featurep! :completion ivy)   #'ivy-bibtex)
                 ((featurep! :completion helm)  #'helm-bibtex)))
-
+        (:when (featurep! :lang org +noter)
+          :desc "Org noter"                    "e" #'org-noter)
+      
         :desc "Find file in notes"             "f" #'+default/find-in-notes
         :desc "Browse notes"                   "F" #'+default/browse-notes
         :desc "Org store link"                 "l" #'org-store-link

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -128,6 +128,10 @@
           :desc "Bibliographic entries"        "b"
           (cond ((featurep! :completion ivy)   #'ivy-bibtex)
                 ((featurep! :completion helm)  #'helm-bibtex)))
+
+        :desc "Toggle org-clock"               "c" #'+org/toggle-clock
+        :desc "Cancel org-clock"               "C" #'org-clock-cancel
+        :desc "Open deft"                      "d" #'deft
         (:when (featurep! :lang org +noter)
           :desc "Org noter"                    "e" #'org-noter)
       

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -464,6 +464,9 @@
         :desc "Toggle org-clock"             "c" #'+org/toggle-clock
         :desc "Cancel org-clock"             "C" #'org-clock-cancel
         :desc "Open deft"                    "d" #'deft
+        (:when (featurep! :lang org +noter)
+          :desc "Org noter"                  "e" #'org-noter)
+
         :desc "Find file in notes"           "f" #'+default/find-in-notes
         :desc "Browse notes"                 "F" #'+default/browse-notes
         :desc "Org store link"               "l" #'org-store-link

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -472,6 +472,7 @@
         :desc "Org store link"               "l" #'org-store-link
         :desc "Tags search"                  "m" #'org-tags-view
         :desc "Org capture"                  "n" #'org-capture
+        :desc "Goto capture"                 "N" #'org-capture-goto-target
         :desc "Active org-clock"             "o" #'org-clock-goto
         :desc "Todo list"                    "t" #'org-todo-list
         :desc "Search notes"                 "s" #'+default/org-notes-search

--- a/modules/lang/org/README.org
+++ b/modules/lang/org/README.org
@@ -18,6 +18,7 @@
   - [[#built-in-custom-link-types][Built-in custom link types]]
 - [[#configuration][Configuration]]
   - [[#changing-org-directory][Changing ~org-directory~]]
+  - [[#changing-org-noter-notes-search-path][Changing ~org-noter-notes-search-path~]]
 
 * Description
 This module adds org-mode support to Doom Emacs, along with a number of
@@ -68,6 +69,8 @@ https://www.mfoot.com/blog/2015/11/22/literate-emacs-configuration-with-org-mode
 + =+present= Enables integration with reveal.js, beamer and org-tree-slide, so
   Emacs can be used for presentations.
 + =+roam= Enables org-roam integration.
++ =+noter= Enables org-noter integration. Keeps notes in sync with a document.
+  Requires [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Document-View.html][pdf-tools]] (=:tools pdf=) or [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Document-View.html][DocView]] or [[https://github.com/wasamasa/nov.el][nov.el]] to be enabled.
 
 ** Plugins
 + [[https://github.com/hniksic/emacs-htmlize][htmlize]]
@@ -121,6 +124,9 @@ https://www.mfoot.com/blog/2015/11/22/literate-emacs-configuration-with-org-mode
 + =+roam=
   + [[https://github.com/jethrokuan/org-roam][org-roam]]
   + [[https://github.com/jethrokuan/company-org-roam][company-org-roam]]
++ =+noter=
+  + [[https://github.com/weirdNox/org-noter][org-noter]]
+
 
 ** Hacks
 + The window is recentered when following links.
@@ -222,4 +228,11 @@ To modify ~org-directory~ it must be set /before/ =org= has loaded:
 #+BEGIN_SRC emacs-lisp
 ;; ~/.doom.d/config.el
 (setq org-directory "~/new/org/location/")
+#+END_SRC
+** Changing ~org-noter-notes-search-path~
+To modify ~org-noter-notes-search-path~ set:
+
+#+BEGIN_SRC emacs-lisp
+;; ~/.doom.d/config.el
+(setq org-noter-notes-search-path '("~/notes/path/"))
 #+END_SRC

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -965,6 +965,7 @@ compelling reason, so..."
   (if (featurep! +pomodoro)  (load! "contrib/pomodoro"))
   (if (featurep! +present)   (load! "contrib/present"))
   (if (featurep! +roam)      (load! "contrib/roam"))
+  (if (featurep! +noter)     (load! "contrib/noter"))
 
   ;; Add our general hooks after the submodules, so that any hooks the
   ;; submodules add run after them, and can overwrite any defaults if necessary.

--- a/modules/lang/org/contrib/noter.el
+++ b/modules/lang/org/contrib/noter.el
@@ -1,0 +1,14 @@
+;;; lang/org/contrib/noter.el -*- lexical-binding: t; -*-
+;;;###if (featurep! +noter)
+
+(use-package! org-noter
+  :defer t
+  :preface
+  ;; Allow the user to preempt this and set the document search path
+  ;; If not set then use `org-directory'
+  (defvar org-noter-notes-search-path nil)
+  :config
+  (setq org-noter-auto-save-last-location t
+        org-noter-separate-notes-from-heading t)
+  (unless org-noter-notes-search-path
+    (setq org-noter-notes-search-path org-directory)))

--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -75,6 +75,8 @@
   (package! org-roam :pin "e33c144298")
   (when (featurep! :completion company)
     (package! company-org-roam :pin "0913d86f16")))
+(when (featurep! +noter)
+  (package! org-noter :pin "9ead81d42d"))
 
 ;;; Babel
 (package! ob-async :pin "80a30b96a0")


### PR DESCRIPTION
This package allows the creation of notes on a document (pdf, EPub,
etc.) which will be kept in sync with the document. Providing context
sensitive annotations that are managed in plaintext.