### PR TITLE
Add org-ref and org-roam-bibtex to :tools/biblio

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -85,7 +85,7 @@
 
        :tools
        ;;ansible
-       ;;biblio            ; Writes a PhD for you (citation needed)
+       ;;biblio            ; A collection of bibliographic reference tools
        ;;debugger          ; FIXME stepping through code, to help you add bugs
        ;;direnv
        ;;docker

--- a/modules/tools/biblio/README.org
+++ b/modules/tools/biblio/README.org
@@ -8,6 +8,7 @@
   - [[#maintainers][Maintainers]]
   - [[#module-flags][Module Flags]]
   - [[#plugins][Plugins]]
+  - [[#note-about-org-ref][Note about org-ref]]
 - [[#prerequisites][Prerequisites]]
   - [[#pdf-viewing][PDF viewing]]
   - [[#bibtex-completion][Bibtex completion]]
@@ -17,7 +18,11 @@
     - [[#processor-configuration][Processor configuration]]
     - [[#other-configuration-options][Other configuration options]]
   - [[#path-configuration][Path configuration]]
+    - [[#bibtex-completion-helm-bibtex-ivy-bibtex][bibtex-completion (helm-bibtex, ivy-bibtex)]]
+    - [[#org-ref][org-ref]]
   - [[#templates][Templates]]
+    - [[#bibtex-completion-1][Bibtex-completion]]
+    - [[#org-roam-bibtex-1][org-roam-bibtex]]
 - [[#troubleshooting][Troubleshooting]]
 
 * Description
@@ -41,6 +46,14 @@ This module provides no flags.
   + [[https://github.com/tmalsburg/helm-bibtex][helm-bibtex]]
 + ~:completion ivy~
   + [[https://github.com/tmalsburg/helm-bibtex][ivy-bibtex]]
++ ~:lang org~
+  + [[https://github.com/jkitchin/org-ref][org-ref]]
++ ~:lang org +roam~
+  + [[https://github.com/Zaeph/org-roam-bibtex][org-roam-bibtex]]
+** Note about org-ref
+Although org-ref supports both ivy and helm, certain functionality e.g. the ability to drag-n-drop a pdf into a bib file in order to have org-ref automatically generate a new bibtex entry will pull in helm, as it is hard coded to support that.
+
+For this reason many of the options are not enabled by default, if you wish to enable the other functions see: [[https://github.com/jkitchin/org-ref#some-other-useful-libraries-in-org-ref][org-ref additional libraries]]
 
 * Prerequisites
 There are no hard dependencies for this module.
@@ -56,8 +69,8 @@ For vertico, helm, or ivy bibtex completion you should enable =:completion verti
 
 * Features
 Both [[https://github.com/tmalsburg/helm-bibtex][helm-bibtex]] (includes helm-bibtex, ivy-bibtex and bibtex-completion code)
-and [[https://github.com/bdarcus/bibtex-actions][citar]] provide an extensive range of features so it is best to check their
-respective sites for a full list of features.
+[[org-ref]], and [[https://github.com/bdarcus/bibtex-actions][citar]] provide an extensive range of features so it is best to check
+their respective sites for a full list of features.
 
 On a high-level you can expect:
 + bibliography management
@@ -112,6 +125,9 @@ directory for your CSL styles:
 (setq org-cite-csl-styles-dir "~/Zotero/styles")
 #+END_SRC
 
+** org-roam-bibtex
+This package integrates org-ref and bibtex-completion into [[https://github.com/jethrokuan/org-roam][org-roam]] mode, which can be enabled via =lang org +roam=. For academics and those working extensively with documents which they need to keep detailed notes on for cross-referencing.
+
 ** Path configuration
 
 You must set the path variable for either =citar= (if using =vertico=
@@ -139,13 +155,66 @@ enhanced functionality:
        citar-notes-paths '("/path/to/your/notes/"))
 #+END_src
 
+
+It is of course possible to set the variables directly through their respective packages as shown below, in which case you can ignore the ~+biblio...~ versions. See [[*bibtex-completion (helm-bibtex, ivy-bibtex)][bibtex-completion]] and [[*org-ref][org-ref]] configurations below.
+
+#+BEGIN_src emacs-lisp
+(setq! +biblio-pdf-library-dir "/path/to/bibrary/"
+       +biblio-default-bibliography-files '("/path/to/bibliography.bib")
+       +biblio-notes-path "/path/to/notes/")
+#+END_src
+
+Unless ~+biblio-notes-path~ ends in a ~/~ it is assumed to be a single file and not a directory.
+
+Each of the variables overlays the corresponding variables in the following way
++ ~+biblio-default-bibliography-files~
+  - ~bibtex-completion-library-path~
+  - ~org-ref-pdf-directory~
++ ~+biblio-default-bibliography-files~
+  - ~reftex-default-bibliography~
+  - ~bibtex-completion-bibliography~
+  - ~org-ref-default-bibliography~
++ ~+biblio-notes-path~
+  - ~+bibibtex-completion-notes-path~
+  - ~org-ref-bibliography-notes~
+  - ~org-ref-notes-directory~
+
+*** bibtex-completion (helm-bibtex, ivy-bibtex)
+These packages share the same common backend ~bibtex-completion~
+#+BEGIN_src emacs-lisp
+(after! bibtex-completion
+  (setq! bibtex-completion-bibliography "/path/to/bib/"
+        bibtex-completion-library-path "/path/to/Papers/"
+        bibtex-completion-notes-path "/path/to/your/notes/"))
+#+END_src
+*** org-ref
+#+BEGIN_src emacs-lisp
+(after! org-ref
+  (setq! org-ref-bibliography-notes "/path/to/notes/"
+        org-ref-default-bibliography "/path/to/bib"
+        org-ref-pdf-directory "/path/to/papers/"
+        reftex-default-bibliography org-ref-default-bibliography))
+
 ** Templates
 
 This module provides reasonable default templates for the packages. However, if
 you wish to change them, refer to the respective packages' documentation for in-depth
 instructions.
 
-* Troubleshooting
-# Common issues and their solution, or places to look for help.
+*** Bibtex-completion
+#+BEGIN_src emacs-lisp
+(after! bibtex-completion
+  (setq!  bibtex-completion-notes-template-multiple-files
+         "${title} : (${=key=})\n Some more format options"))
+#+END_src
 
-Refer to the respective package repositories.
+*** org-roam-bibtex
+To change the default template you can change it according to [[https://github.com/Zaeph/org-roam-bibtex][org-roam-bibtex]]
+#+BEGIN_src emacs-lisp
+(after! org-roam-bibtex
+  (setq org-roam-bibtex-preformat-keywords '("some" "key" "words"))
+  (setq org-roam-bibtex-template '(("Some template"))))
+#+END_src
+
+* Troubleshooting
+# Common issues and their solution, or places to look for help

--- a/modules/tools/biblio/config.el
+++ b/modules/tools/biblio/config.el
@@ -1,6 +1,36 @@
 ;;; tools/biblio/config.el -*- lexical-binding: t; -*-
 
 ;;
+
+;; Internal function to set the various paths used in the
+;; reference packages.
+(defun +biblio-set-paths-fn (&optional symbol value)
+  (when symbol
+    (set-default symbol value))
+  (when value
+    (cond ((eq symbol '+biblio-pdf-library-dir)
+           (when (featurep! :lang org)
+             (setq org-ref-pdf-directory value))
+           (setq bibtex-completion-library-path value))
+          ((eq symbol '+biblio-default-bibliography-files)
+           (when (featurep! :lang org)
+             (setq reftex-default-bibliography value
+                   org-ref-default-bibliography value))
+           (setq bibtex-completion-bibliography value)))))
+
+(defcustom +biblio-pdf-library-dir nil
+  "Directory where pdf files are stored. Must end with a slash."
+  :type 'string
+  :set #'+biblio-set-paths-fn)
+
+(defcustom +biblio-default-bibliography-files nil
+  "A list of default bibtex files to use."
+  :type '(repeat :tag "List of bibtex files" file)
+  :set #'+biblio-set-paths-fn)
+
+(defvar +biblio-notes-path nil)
+
+
 ;;; `org-cite'
 
 (use-package! oc
@@ -41,15 +71,102 @@
   :when (or (featurep! :completion ivy)
             (featurep! :completion helm))
   :defer t
-  :config
+  :preface
+  ;; Allow the user to set a template of their own via (setq). if the user does
+  ;; not set one fall back to the +biblio variants which have a reasonable
+  ;; fallback.
+  (defvar bibtex-completion-notes-template-multiple-files nil)
+   :config
+
+  (when (featurep! :completion ivy)
+    (add-to-list 'ivy-re-builders-alist '(ivy-bibtex . ivy--regex-plus)))
+
   (setq bibtex-completion-additional-search-fields '(keywords)
-        ;; Tell bibtex-completion to look at the File field of the bibtex to
-        ;; figure out which pdf to open:
-        bibtex-completion-pdf-field "file"))
+        ;; This tell bibtex-completion to look at the File field of the bibtex
+        ;; to figure out which pdf to open
+        bibtex-completion-pdf-field "file")
+  ;; orb will define handlers for note taking so not needed to use the
+  ;; ones set for bibtex-completion
+  (unless (featurep! :lang org +roam2)
 
+    (setq bibtex-completion-notes-path +biblio-notes-path)
+    (unless bibtex-completion-notes-template-multiple-files
+      (setq bibtex-completion-notes-template-multiple-files
+            "${title} : (${=key=})
 
-(use-package! ivy-bibtex
-  :when (featurep! :completion ivy)
-  :defer t
+- tags ::
+- keywords :: ${keywords}
+
+\n* ${title}\n  :PROPERTIES:\n  :Custom_ID: ${=key=}\n  :URL: ${url}\n  :AUTHOR: ${author-or-editor}\n  :NOTER_DOCUMENT: /${file}\n  :NOTER_PAGE: \n  :END:\n\n"))))
+
+;; TODO which set of keys that should be bound for commonly used functions
+;; see https://github.com/jkitchin/org-ref/blob/master/org-ref-core.el#L3998
+(use-package! org-ref
+  :when (featurep! :lang org +ref)
+  :after org
+  :preface
+  ;; This need to be set before the package is loaded, because org-ref will
+  ;; automatically `require' an associated package during its loading.
+  (setq org-ref-completion-library (cond ((featurep! :completion ivy)  #'org-ref-ivy-cite)
+                                         ((featurep! :completion helm) #'org-ref-helm-bibtex)
+                                         (t                            #'org-ref-reftex)))
   :config
-  (add-to-list 'ivy-re-builders-alist '(ivy-bibtex . ivy--regex-plus)))
+;;  (add-to-list 'ivy-re-builders-alist '(ivy-bibtex . ivy--regex-plus))
+
+  ;; Although the name is helm-bibtex, it is actually a bibtex-completion function
+  ;; it is the legacy naming of the project helm-bibtex that causes confusion.
+  (setq org-ref-open-pdf-function 'org-ref-get-pdf-filename-helm-bibtex)
+  ;; orb will define handlers for note taking so not needed to use the
+  ;; ones set for bibtex-completion
+  (unless (featurep! :lang org +roam2)
+    ;; determine how org ref should handle the users notes path (dir, or file)
+    (if (directory-name-p +biblio-notes-path)
+        (setq org-ref-notes-directory +biblio-notes-path)
+      (setq org-ref-bibliography-notes +biblio-notes-path))
+    ;; Allow org-ref to use the same template mechanism as {helm,ivy}-bibtex for
+    ;; multiple files if the user has chosen to spread their notes.
+    (setq org-ref-notes-function (if (and org-ref-notes-directory (directory-name-p org-ref-notes-directory))
+                                     #'org-ref-notes-function-many-files
+                                   #'org-ref-notes-function-one-file))))
+
+
+(use-package! org-roam-bibtex
+  :when (featurep! :lang org +roam2)
+  :after org-roam
+  :preface
+  ;; if the user has not set a template mechanism set a reasonable one of them
+  ;; The package already tests for nil itself so we define a dummy tester
+  (defvar orb-preformat-keywords
+    '("title" "url" "file" "author-or-editor" "keywords" "citekey" "pdf"))
+  ;;:hook (org-roam-mode . org-roam-bibtex-mode)
+  :custom
+  (orb-note-actions-interface (cond ((featurep! :completion ivy)  'ivy)
+                                    ((featurep! :completion helm) 'helm)
+                                    ((t                           'default))))
+  :config
+  (setq orb-insert-interface (cond ((featurep! :completion ivy)  'ivy-bibtex)
+                                   ((featurep! :completion helm) 'helm-bibtex)
+                                   ((t                           'generic))))
+  (setq orb-process-file-keyword t
+        orb-file-field-extensions '("pdf"))
+
+  (add-to-list 'org-roam-capture-templates
+               '("b" "Bibliography note" plain
+                 "%?
+- keywords :: %^{keywords}
+- related ::
+
+* %^{title}
+:PROPERTIES:
+:Custom_ID: %^{citekey}
+:URL: %^{url}
+:AUTHOR: %^{author-or-editor}
+:NOTER_DOCUMENT: %^{file}
+:NOTER_PAGE:
+:END:\n\n"
+                 :if-new (file+head "${citekey}.org" ":PROPERTIES:
+:ROAM_REFS: cite:${citekey}
+:END:
+#+TITLE: ${title}\n")
+                 :unnarrowed t))
+  (require 'org-ref))

--- a/modules/tools/biblio/packages.el
+++ b/modules/tools/biblio/packages.el
@@ -9,5 +9,8 @@
   (package! helm-bibtex :pin "aa775340ba691d2322948bfdc6a88158568a1399"))
 (when (featurep! :completion vertico)
   (package! citar :pin "51b30f2e4091a41243ae62cfbac53e7a579f3168"))
-
 (package! citeproc :pin "538fed794c29acf81efee8a2674268bd3d7cc471")
+(when (featurep! :lang org +ref)
+  (package! org-ref :pin "429733150548a847966685680bca0a20ec3b1ad9"))
+(when (featurep! :lang org +roam2)
+  (package! org-roam-bibtex :pin "cf811abf273ad28d32caad3a93318f92da034556"))


### PR DESCRIPTION
org-ref allows for easy citation management and provides numerous interfaces to online publishing and reference management tools.

org-roam-bibtex provides deep integration of bibtex-completion and {ivy,helm}-bibtex into the org-roam workflow.