### PR TITLE
Enable visual-line-mode in org-roam-backlinks buffer

### DIFF
--- a/modules/lang/org/contrib/roam.el
+++ b/modules/lang/org/contrib/roam.el
@@ -3,6 +3,7 @@
 
 (use-package! org-roam
   :hook (org-load . org-roam-mode)
+  :hook (org-roam-backlinks-mode . turn-on-visual-line-mode)
   :commands (org-roam
              org-roam-capture
              org-roam-date


### PR DESCRIPTION
`org-roam` has a buffer that shows backlinks to the file currently displayed. If the backlink is in a multiline paragraph, `org-roam` will show it as a single line inside this buffer, making it unreadable for Doom users by default, since `truncate-lines` is `t`.

This adds a hook to enable `visual-line-mode` (soft wrapping) when in the `org-roam-backlinks` buffer.

I've made the change in my private config, but I feel like this is a good default for Doom users.

Before: 
![2020-04-13-193359_642x184_scrot](https://user-images.githubusercontent.com/15170378/79143826-308c9800-7dbe-11ea-960e-d42bb1769b5f.png)

After:
![2020-04-13-193104_637x181_scrot](https://user-images.githubusercontent.com/15170378/79143848-384c3c80-7dbe-11ea-884d-fb5fee419d72.png)
