### PR TITLE
Use default god-exempt-major-modes in :editor god module

### DIFF
--- a/modules/editor/god/config.el
+++ b/modules/editor/god/config.el
@@ -3,26 +3,5 @@
 (use-package! god-mode
   :hook (doom-after-init-modules . god-mode-all)
   :config
-  (pushnew! god-exempt-major-modes
-            'Custom-mode
-            'Info-mode
-            'ag-mode
-            'calculator-mode
-            'calendar-mode
-            'cider-test-report-mode
-            'compilation-mode
-            'debugger-mode
-            'edebug-mode
-            'ediff-mode
-            'eww-mode
-            'geben-breakpoint-list-mode
-            'ibuffer-mode
-            'org-agenda-mode
-            'pdf-outline-buffer-mode
-            'recentf-dialog-mode
-            'sldb-mode
-            'sly-db-mode
-            'wdired-mode)
-
   (add-hook 'post-command-hook #'+god--configure-cursor-and-modeline-h)
   (add-hook 'overwrite-mode-hook #'+god--toggle-on-overwrite-h))

--- a/modules/editor/god/packages.el
+++ b/modules/editor/god/packages.el
@@ -1,4 +1,4 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; editor/god/packages.el
 
-(package! god-mode :pin "b82ce18ae4")
+(package! god-mode :pin "1eb6ef3a4f")


### PR DESCRIPTION
In this change:
* Bump version pin of `god-mode`
* Use default value of `god-exempt-major-modes`  as commit https://github.com/emacsorphanage/god-mode/commit/567eb3bd1f15bfd2920a47434415828405de4bfb includes all the modes (previously) in `god/config.el`