### PR TITLE
Add set -euo pipefail to sh-mode file template

### DIFF
--- a/modules/editor/file-templates/templates/sh-mode/__
+++ b/modules/editor/file-templates/templates/sh-mode/__
@@ -1,3 +1,4 @@
 #!/usr/bin/env `(if (equal (file-name-extension buffer-file-name) "zsh") "zsh" "bash")`
+set -euo pipefail
 
 $0


### PR DESCRIPTION
Adds a line with set -euo pipefail to the sh-mode file template, which improves the erroring of bash scripts.
As described by https://ashishb.net/all/the-first-two-statements-of-your-bash-script-should-be/