### PR TITLE
Bump helm-bibtex and ivy-bibtex

### DIFF
--- a/modules/tools/biblio/config.el
+++ b/modules/tools/biblio/config.el
@@ -1,5 +1,12 @@
 ;;; tools/biblio/config.el -*- lexical-binding: t; -*-
 
+(use-package! bibtex-completion
+  :defer t
+  :config
+  (setq bibtex-completion-additional-search-fields '(keywords)
+        bibtex-completion-pdf-field "file"));; This tell bibtex-completion to look at the File field of the bibtex to figure out which pdf to open
+
+
 (use-package! ivy-bibtex
   :when (featurep! :completion ivy)
   :defer t

--- a/modules/tools/biblio/packages.el
+++ b/modules/tools/biblio/packages.el
@@ -1,6 +1,7 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; tools/biblio/packages.el
 
+(package! bibtex-completion :pin "b14b628261")
 (when (featurep! :completion ivy)
   (package! ivy-bibtex :pin "3cff6bd702"))
 (when (featurep! :completion helm)

--- a/modules/tools/biblio/packages.el
+++ b/modules/tools/biblio/packages.el
@@ -3,6 +3,6 @@
 
 (package! bibtex-completion :pin "b14b628261")
 (when (featurep! :completion ivy)
-  (package! ivy-bibtex :pin "3cff6bd702"))
+  (package! ivy-bibtex :pin "b14b628261"))
 (when (featurep! :completion helm)
-  (package! helm-bibtex :pin "3cff6bd702"))
+  (package! helm-bibtex :pin "b14b628261"))


### PR DESCRIPTION
helm-bibtex split out bibtex-completion into a separate package
in MELPA. Add an explicit pin of bibtex-completion and bump the versions
of {helm,ivy}-bibtex to match.