### PR TITLE
Fetch org-superstar from github

### DIFF
--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -34,7 +34,9 @@
 
 (package! avy)
 (package! htmlize :pin "86f22f211e")
-(package! org-superstar :pin "4897c333a8")
+(package! org-superstar
+  :recipe (:host github :repo "integral-dw/org-superstar-mode")
+  :pin "4897c333a8")
 (package! org-yt
   :recipe (:host github :repo "TobiasZawada/org-yt")
   :pin "40cc1ac76d")


### PR DESCRIPTION
Fetch org-superstar from github, to remove the annoying error:
```bash
$ doom sync
Package error: (error Could not find package org-superstar in recipe repositories: (org-elpa melpa gnu-elpa-mirror emacsmirror-mirror))
> Synchronizing your config with Doom Emacs...
```