### PR TITLE
 Respect global whitespace mode config if set

### DIFF
--- a/core/core-ui.el
+++ b/core/core-ui.el
@@ -138,7 +138,7 @@ size.")
 e.g. If you indent with spaces by default, tabs will be highlighted. If you
 indent with tabs, spaces at BOL are highlighted.
 
-Does nothing if `whitespace-mode' or 'global-whitespace-mode'is already 
+Does nothing if `whitespace-mode' or 'global-whitespace-mode' is already 
 active or if the current buffer is read-only or not file-visiting."
   (unless (or (eq major-mode 'fundamental-mode)
               buffer-read-only

--- a/core/core-ui.el
+++ b/core/core-ui.el
@@ -142,7 +142,7 @@ Does nothing if `whitespace-mode' or 'global-whitespace-mode' is already
 active or if the current buffer is read-only or not file-visiting."
   (unless (or (eq major-mode 'fundamental-mode)
               buffer-read-only
-              (equal global-whitespace-mode t)
+              global-whitespace-mode
               (null buffer-file-name))
     (require 'whitespace)
     (set (make-local-variable 'whitespace-style)

--- a/core/core-ui.el
+++ b/core/core-ui.el
@@ -142,6 +142,7 @@ Does nothing if `whitespace-mode' is already active or the current buffer is
 read-only or not file-visiting."
   (unless (or (eq major-mode 'fundamental-mode)
               buffer-read-only
+              (equal global-whitespace-mode t)
               (null buffer-file-name))
     (require 'whitespace)
     (set (make-local-variable 'whitespace-style)

--- a/core/core-ui.el
+++ b/core/core-ui.el
@@ -138,8 +138,8 @@ size.")
 e.g. If you indent with spaces by default, tabs will be highlighted. If you
 indent with tabs, spaces at BOL are highlighted.
 
-Does nothing if `whitespace-mode' is already active or the current buffer is
-read-only or not file-visiting."
+Does nothing if `whitespace-mode' or 'global-whitespace-mode'is already 
+active or if the current buffer is read-only or not file-visiting."
   (unless (or (eq major-mode 'fundamental-mode)
               buffer-read-only
               (equal global-whitespace-mode t)


### PR DESCRIPTION
This would offer a convenient way for people to globally opt-out of the default [indentation highlighting](https://github.com/hlissner/doom-emacs/blob/develop/docs/faq.org#why-do-i-see-ugly-indentation-highlights-for-tabs). The idea of opting into `whitespace-mode` to make it less prominent is kind of unintuitive, but I'm not sure how else it could be done; there's no way to tell if `global-whitespace-mode` was explicitly set to `nil` or just not initialized, as far as I know. Happy to take any feedback!