### PR TITLE
Update hook to match rename from refactoring

### DIFF
--- a/modules/lang/csharp/config.el
+++ b/modules/lang/csharp/config.el
@@ -32,7 +32,7 @@
 
   ;; Kill the omnisharp server once the last csharp-mode buffer is killed
   (add-hook! 'omnisharp-mode-hook
-    (add-hook 'kill-buffer-hook #'+csharp-cleanup-omnisharp-server-h nil t))
+    (add-hook 'kill-buffer-hook #'+csharp-kill-omnisharp-server-h nil t))
 
   (map! :localleader
         :map omnisharp-mode-map


### PR DESCRIPTION
If you have omnisharp & csharp set up, and you close a cs file, you'll get `Symbol's function definition is void: +csharp-cleanup-omnisharp-server-h`.

This is because 169f9a6121d8e0c75c0b27c2566f050477828dce moved its definition to csharp/autoload.el, but also renamed it to +csharp-kill-omnisharp-server-h.

This PR updates the hook to match the new name.