### PR TITLE
Autoload all 4 org decrypt/encrypt user commands

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -778,7 +778,7 @@ compelling reason, so..."
 
 
 (use-package! org-crypt ; built-in
-  :commands org-encrypt-entries
+  :commands org-encrypt-entries org-encrypt-entry org-decrypt-entries org-decrypt-entry
   :hook (org-reveal-start . org-decrypt-entry)
   :config
   (add-hook! 'org-mode-hook


### PR DESCRIPTION
currently if someone wants to use them, it has to manually autoload
them first in user `config.el` with `(unless (fboundp ...) (autoload ...))`