### PR TITLE
doom/upgrade use -y CLI flag

### DIFF
--- a/core/autoload/config.el
+++ b/core/autoload/config.el
@@ -136,6 +136,6 @@ imported into Emacs."
 (defun doom/upgrade ()
   "Run 'doom upgrade' then prompt to restart Emacs."
   (interactive)
-  (doom--if-compile (format "%s upgrade" doom-bin)
+  (doom--if-compile (format "%s -y upgrade" doom-bin)
       (when (y-or-n-p "You must restart Emacs for the upgrade to take effect.\n\nRestart Emacs?")
         (doom/restart-and-restore))))


### PR DESCRIPTION
When using the internal doom/upgrade command to upgrade using the CLI
tool, do so with the -y flag.

This is admittedly a temporary solution, but without it the CLI tool
will prompt for confirmation, which cannot easily or obviously be given
while inside Emacs.
A better solution would be to somehow integrate the prompt so that it
appears in the minibuffer as normal Emacs prompts do. But for now this
at least fixes doom/upgrade.