### PR TITLE
Add useful defaults and bindings to scheme mode

### DIFF
--- a/modules/lang/scheme/config.el
+++ b/modules/lang/scheme/config.el
@@ -4,6 +4,7 @@
   :hook ((scheme-mode . rainbow-delimiters)))
 
 (use-package! geiser
+  :defer t
   :init
   (setq geiser-active-implementations '(guile chicken mit chibi chez))
   (setq geiser-mode-start-repl-p t)

--- a/modules/lang/scheme/config.el
+++ b/modules/lang/scheme/config.el
@@ -4,11 +4,10 @@
   :hook ((scheme-mode . rainbow-delimiters)))
 
 (use-package! geiser
-  :custom
-  (geiser-active-implementations '(guile chicken mit chibi chez))
-  (geiser-mode-start-repl-p t)
-  (geiser-smart-tab-p t)
   :init
+  (setq geiser-active-implementations '(guile chicken mit chibi chez))
+  (setq geiser-mode-start-repl-p t)
+  (setq geiser-smart-tab-p t)
   (unless (featurep! :lang racket)
     (push 'racket geiser-active-implementations))
   (after! scheme                        ; built-in

--- a/modules/lang/scheme/config.el
+++ b/modules/lang/scheme/config.el
@@ -1,6 +1,7 @@
 ;;; lang/scheme/config.el -*- lexical-binding: t; -*-
 
 (use-package! scheme
+  :defer t
   :hook ((scheme-mode . rainbow-delimiters)))
 
 (use-package! geiser

--- a/modules/lang/scheme/config.el
+++ b/modules/lang/scheme/config.el
@@ -2,7 +2,8 @@
 
 (use-package! scheme
   :defer t
-  :hook ((scheme-mode . rainbow-delimiters)))
+  :hook ((scheme-mode . rainbow-delimiters-mode)
+         (scheme-mode . geiser-mode)))
 
 (use-package! geiser
   :defer t

--- a/modules/lang/scheme/config.el
+++ b/modules/lang/scheme/config.el
@@ -1,16 +1,18 @@
 ;;; lang/scheme/config.el -*- lexical-binding: t; -*-
 
 ;;;###package scheme
-(add-hook 'scheme-mode-hook #'rainbow-delimiters-mode)
-
+(use-package! scheme
+  :hook ((scheme-mode . rainbow-delimiters)))
 
 (use-package! geiser
-  :defer t
+  :custom
+  (geiser-active-implementations '(guile chicken mit chibi chez))
+  (geiser-mode-start-repl-p t)
+  (geiser-smart-tab-p t)
   :init
-  (setq geiser-active-implementations '(guile chicken mit chibi chez))
   (unless (featurep! :lang racket)
     (push 'racket geiser-active-implementations))
-  (after! scheme  ; built-in
+  (after! scheme                        ; built-in
     (set-repl-handler! 'scheme-mode '+scheme/open-repl)
     (set-eval-handler! 'scheme-mode #'geiser-eval-region)
     (set-lookup-handlers! 'scheme-mode
@@ -22,24 +24,34 @@
       ( "\\* [A-Za-z0-9_-]+ REPL \\*" :quit nil)))
   (map! :localleader
         :map scheme-mode-map
-        "'" #'geiser-mode-switch-to-repl
-        "s" #'geiser-set-scheme
+        "'"  #'geiser-mode-switch-to-repl
+        "\"" #'geiser-connect
+        "["  #'geiser-squarify
+        "\\" #'geiser-insert-lambda
+        "s"  #'geiser-set-scheme
 
         (:prefix ("e" . "eval")
           "b" #'geiser-eval-buffer
           "B" #'geiser-eval-buffer-and-go
-          "e" #'geiser-eval-definition
-          "E" #'geiser-eval-definition-and-go
+          "e" #'geiser-eval-last-sexp
+          "d" #'geiser-eval-definition
+          "D" #'geiser-eval-definition-and-go
           "r" #'geiser-eval-region
           "R" #'geiser-eval-region-and-go)
 
         (:prefix ("h" . "help")
-          "d" 'geiser-autodoc)
-        ;; TODO add more help keybindings
-
+          "d" #'geiser-autodoc
+          "<" #'geiser-xref-callers
+          ">" #'geiser-xref-callees
+          "i" #'geiser-doc-look-up-manual)
+        (:prefix ("m" . "macro")
+          "r" #'geiser-expand-region
+          "d" #'geiser-expand-definition
+          "e" #'geiser-expand-last-sexp)
         (:prefix ("r" . "repl")
           "b" #'geiser-switch-to-repl
           "q" #'geiser-repl-exit
+          "l" #'geiser-load-current-buffer
           "r" #'geiser-restart-repl
           "R" #'geiser-reload
           "c" #'geiser-repl-clear-buffer)))

--- a/modules/lang/scheme/config.el
+++ b/modules/lang/scheme/config.el
@@ -1,6 +1,5 @@
 ;;; lang/scheme/config.el -*- lexical-binding: t; -*-
 
-;;;###package scheme
 (use-package! scheme
   :hook ((scheme-mode . rainbow-delimiters)))
 


### PR DESCRIPTION
Scheme mode was pretty bare for a long time now and lacked many of
geiser's useful features like `geiser-smart-tab` and starting the geiser
repl on entering a file. This turns them on by default for the
productive schemer.

Besides that the following key bindings were remapped
+ `SPC m e e` -> `geiser-eval-last-sexp`
+ `SPC m e d` -> `geiser-eval-definition`
+ `SPC m e D` -> `geiser-eval-definition-and-go`

This brings the geiser keymaps in line with other lisp modes in doom.

Another change involves adding macro expand commands under `SPC m m` so
schemers can see what evil lurks beneath their commands.

Geiser autodoc commands have also been added under `SPC m h` for
schemers to read the docs, though they can still use `SPC c k` to do the
same thing.