### PR TITLE
Add full name to :cap

### DIFF
--- a/modules/editor/evil/+commands.el
+++ b/modules/editor/evil/+commands.el
@@ -98,7 +98,7 @@
 (evil-ex-define-cmd "tabsave"     #'+workspace:save)
 
 ;;; Org-mode
-(evil-ex-define-cmd "cap"         #'org-capture)
+(evil-ex-define-cmd "cap[ture]"   #'org-capture)
 
 ;;; ibuffer
 (when (featurep! :emacs ibuffer)


### PR DESCRIPTION
Makes it available as `:capture` which is a slightly easier to understand
name. The short alias is still available