### PR TITLE
Add lsp-command-map to SPC-c-l

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -46,6 +46,7 @@
         :desc "LSP Format buffer/region"              "F"   #'+default/lsp-format-region-or-buffer
         :desc "LSP Organize imports"                  "i"   #'lsp-organize-imports
         :desc "LSP Rename"                            "r"   #'lsp-rename
+        :desc "LSP"                                   "l"   'lsp-command-map
         (:when (featurep! :completion ivy)
           :desc "Jump to symbol in current workspace" "j"   #'lsp-ivy-workspace-symbol
           :desc "Jump to symbol in any workspace"     "J"   #'lsp-ivy-global-workspace-symbol)

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -337,7 +337,6 @@
 
       ;;; <leader> c --- code
       (:prefix-map ("c" . "code")
-        :desc "LSP Execute code action"               "a"   #'lsp-execute-code-action
         :desc "Compile"                               "c"   #'compile
         :desc "Recompile"                             "C"   #'recompile
         :desc "Jump to definition"                    "d"   #'+lookup/definition
@@ -345,8 +344,6 @@
         :desc "Evaluate buffer/region"                "e"   #'+eval/buffer-or-region
         :desc "Evaluate & replace region"             "E"   #'+eval:replace-region
         :desc "Format buffer/region"                  "f"   #'+format/region-or-buffer
-        :desc "LSP Format buffer/region"              "F"   #'+default/lsp-format-region-or-buffer
-        :desc "LSP Organize imports"                  "i"   #'lsp-organize-imports
         (:when (featurep! :completion ivy)
           :desc "Jump to symbol in current workspace" "j"   #'lsp-ivy-workspace-symbol
           :desc "Jump to symbol in any workspace"     "J"   #'lsp-ivy-global-workspace-symbol)
@@ -354,7 +351,12 @@
           :desc "Jump to symbol in current workspace" "j"   #'helm-lsp-workspace-symbol
           :desc "Jump to symbol in any workspace"     "J"   #'helm-lsp-global-workspace-symbol)
         :desc "Jump to documentation"                 "k"   #'+lookup/documentation
-        :desc "LSP Rename"                            "r"   #'lsp-rename
+        (:when (featurep! :tools lsp)
+          :desc "LSP Execute code action"               "a"   #'lsp-execute-code-action
+          :desc "LSP Format buffer/region"              "F"   #'+default/lsp-format-region-or-buffer
+          :desc "LSP Organize imports"                  "i"   #'lsp-organize-imports
+          :desc "LSP Rename"                            "r"   #'lsp-rename
+          :desc "LSP"                                   "l"   'lsp-command-map)
         :desc "Send to repl"                          "s"   #'+eval/send-region-to-repl
         :desc "Delete trailing whitespace"            "w"   #'delete-trailing-whitespace
         :desc "Delete trailing newlines"              "W"   #'doom/delete-trailing-newlines

--- a/modules/tools/lsp/config.el
+++ b/modules/tools/lsp/config.el
@@ -66,6 +66,9 @@ working on that project after closing the last buffer.")
     :documentation #'lsp-describe-thing-at-point
     :definition #'lsp-find-definition
     :references #'lsp-find-references)
+  (map! :leader
+        (:prefix "c"
+          :desc "LSP" "l" lsp-command-map))
 
   ;; TODO Lazy load these. They don't need to be loaded all at once unless the
   ;;      user uses `lsp-install-server'.


### PR DESCRIPTION
The default lsp-mode bindings are bound to `s-l` which is impractical
for anyone using keybindings in their window manager. This makes all the
default lsp bindings available on SPC-c-l.