### PR TITLE
[WIP] Add DAP key bindings

### DIFF
--- a/modules/tools/debugger/autoload/debugger.el
+++ b/modules/tools/debugger/autoload/debugger.el
@@ -68,6 +68,14 @@ for what debugger to use. If the prefix ARG is set, prompt anyway."
              (kill-buffer buf))))
         ((user-error "No debugging session to quit"))))
 
+;;;###autoload
+  (defun +debugger/dap-eval ()
+    "Evaluate the expression at point or selected region."
+    (interactive)
+    (if (use-region-p)
+        (dap-eval-region)
+      (dap-eval-thing-at-point)))
+
 ;; TODO debugger breakpoint commands
 ;; ;;;###autoload
 ;; (defun +debugger/toggle-breakpoint ()

--- a/modules/tools/debugger/config.el
+++ b/modules/tools/debugger/config.el
@@ -117,6 +117,35 @@
       (when IS-WINDOWS
         (require 'dap-edge))))
 
+  (map! :map dap-mode-map
+        :leader
+        (:prefix-map ("d" . "debug")
+          :desc "Debug"          "d" #'dap-debug
+          :desc "Next"           "n" #'dap-next
+          :desc "Step in"        "i" #'dap-step-in
+          :desc "Step out"       "o" #'dap-step-out
+          :desc "Continue"       "c" #'dap-continue
+          :desc "Restart frame"  "r" #'dap-restart-frame
+          :desc "Disconnect"     "Q" #'dap-disconnect
+          :desc "Evaluate"       "e" #'+debugger/dap-eval
+          :desc "Add expression" "a" #'dap-ui-expressions-add
+
+          (:prefix ("s" . "switch")
+            :desc "Session"          "s" #'dap-switch-session
+            :desc "Thread"           "t" #'dap-switch-thread
+            :desc "Stack frame"      "f" #'dap-switch-stack-frame
+            :desc "List locals"      "l" #'dap-ui-locals
+            :desc "List breakpoints" "b" #'dap-ui-breakpoints
+            :desc "List sessions"    "S" #'dap-ui-sessions)
+
+          (:prefix ("b" . "breakpoints")
+            :desc "Toggle"            "b" #'dap-breakpoint-toggle
+            :desc "Delete"            "d" #'dap-breakpoint-delete
+            :desc "Add"               "a" #'dap-breakpoint-add
+            :desc "Set condition"     "c" #'dap-breakpoint-condition
+            :desc "Set hit condition" "h" #'dap-breakpoint-hit-condition
+            :desc "Set log message"   "l" #'dap-breakpoint-log-message)))
+
   (dap-mode 1))
 
 


### PR DESCRIPTION
## Description

https://github.com/hlissner/doom-emacs/issues/2808

## TODOs

- [ ] Add a key binding to remove all breakpoints
- [ ] `dap-ui-expressions-add` fails without a region
- [ ] Add a key binding to remove an expression
- [ ] Move the key binding for `dap-debug` to somewhere
- [ ] Add key bindings to edit run configuration, run last/recent run configuration.
- [ ] Add a key binding to open REPL
- [ ] Allow to toggle DAP windows