### PR TITLE
Add Poetry support

### DIFF
--- a/docs/modules.org
+++ b/docs/modules.org
@@ -129,7 +129,7 @@ Modules that bring support for a language or group of languages to Emacs.
 + [[file:../modules/lang/php/README.org][php]] =+lsp= - TODO
 + plantuml - TODO
 + purescript - TODO
-+ [[file:../modules/lang/python/README.org][python]] =+lsp +pyenv +conda= - TODO
++ [[file:../modules/lang/python/README.org][python]] =+lsp +pyenv +conda +poetry= - TODO
 + qt - TODO
 + racket - TODO
 + [[file:../modules/lang/rest/README.org][rest]] - TODO

--- a/modules/lang/python/README.org
+++ b/modules/lang/python/README.org
@@ -25,6 +25,8 @@ Adds Python support to Doom Emacs.
 + ~+lsp~ Language Server Protocol support
 + ~+pyenv~ Python virtual environment support via [[https://github.com/pyenv/pyenv][pyenv]]
 + ~+conda~ Python virtual environment support via [[https://conda.io/en/latest/][Conda]]
++ ~+poetry~ Python packaging, dependency management, and virtual environment
+  support via [[https://python-poetry.org/][Poetry]]
 + ~+cython~ Cython files support via [[https://github.com/cython/cython/blob/master/Tools/cython-mode.el][Cython-mode]]
 
 ** Plugins
@@ -41,6 +43,8 @@ Adds Python support to Doom Emacs.
   + [[https://github.com/necaris/conda.el][conda]]*
 + ~+pyenv~
   + [[https://github.com/pythonic-emacs/pyenv-mode][pyenv]]*
++ ~+poetry~
+  + [[https://github.com/galaunay/poetry.el][poetry]]*
 + ~+lsp~ and ~:tools lsp~
   + [[https://github.com/emacs-lsp/lsp-mode][lsp]]
   + [[https://github.com/emacs-lsp/lsp-python-ms][lsp-python-ms]]*
@@ -67,6 +71,7 @@ This module has no direct prerequisites. Here are some of its soft dependencies.
 + Python virtual environments install instructions at:
   + [[https://github.com/pyenv/pyenv][pyenv]]
   + [[https://conda.io/en/latest/][Conda]]
+  + [[https://python-poetry.org/][Poetry]]
 
 + ~pipenv~ requires [[https://pipenv.readthedocs.io/en/latest/][pipenv]]
 

--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -280,6 +280,11 @@ called.")
                'append))
 
 
+(use-package! poetry
+  :when (featurep! +poetry)
+  :after python)
+
+
 (use-package! lsp-python-ms
   :when (featurep! +lsp)
   :after lsp-clients

--- a/modules/lang/python/doctor.el
+++ b/modules/lang/python/doctor.el
@@ -20,6 +20,10 @@
   (unless (executable-find "conda")
     (warn! "Couldn't find conda in your PATH")))
 
+(when (featurep! +poetry)
+  (if (not (executable-find "poetry"))
+      (warn! "Couldn't find poetry in your PATH")))
+
 (when (featurep! +cython)
   (unless (executable-find "cython")
     (warn! "Couldn't find cython. cython-mode will not work.")))

--- a/modules/lang/python/packages.el
+++ b/modules/lang/python/packages.el
@@ -24,6 +24,8 @@
   (package! pyenv-mode :pin "aec6f2aa28"))
 (when (featurep! +conda)
   (package! conda :pin "335474e409"))
+(when (featurep! +poetry)
+  (package! poetry :pin "6dcc9d22ca"))
 
 ;; Testing frameworks
 (package! nose :pin "f852829751")


### PR DESCRIPTION
Poetry is a tool for managing Python projects. There's a very nice wrapper around that tool called [poetry.el](https://github.com/galaunay/poetry.el). I think it's worth adding a module flag for it.