### PR TITLE
mu4e: Adjust config to mu4e 1.4

### DIFF
--- a/modules/email/mu4e/README.org
+++ b/modules/email/mu4e/README.org
@@ -12,11 +12,12 @@
   - [[#arch-linux][Arch Linux]]
   - [[#nixos][NixOS]]
   - [[#opensuse][openSUSE]]
-  - [[Debian/Ubuntu]]
+  - [[#debianubuntu][Debian/Ubuntu]]
 - [[#features][Features]]
 - [[#configuration][Configuration]]
   - [[#offlineimap][offlineimap]]
   - [[#mbsync][mbsync]]
+  - [[#mu-and-mu4e][mu and mu4e]]
 - [[#troubleshooting][Troubleshooting]]
   - [[#no-such-file-or-directory-mu4e][=No such file or directory, mu4e=]]
   - [[#void-function-org-time-add-error-on-gentoo][~(void-function org-time-add)~ error on Gentoo]]
@@ -105,20 +106,53 @@ sudo apt-get install maildir-utils # mu
 
 * Configuration
 ** offlineimap
-This module uses =mbsync= by default. To change this, change ~+mu4e-backend~:
+This module uses =mbsync= by default. To use =offlineimap=, change ~+mu4e-backend~:
 
 #+BEGIN_SRC emacs-lisp
 (setq +mu4e-backend 'offlineimap)
 #+END_SRC
 
-Then you must set up offlineimap and index your mail:
+Next, you need to write a configuration file for =offlineimap=. Mine can be found
+[[https://github.com/hlissner/dotfiles/tree/master/shell/mu][in my dotfiles repository]]. It is configured to download mail to ~\~/.mail~. I
+use [[https://www.passwordstore.org/][unix pass]] to securely store my login credentials. You can find a *very*
+detailed configuration [[https://github.com/OfflineIMAP/offlineimap/blob/master/offlineimap.conf][here]].
 
-1. Write a ~\~/.offlineimaprc~. Mine can be found [[https://github.com/hlissner/dotfiles/tree/master/shell/mu][in my dotfiles repository]]. It
-   is configured to download mail to ~\~/.mail~. I use [[https://www.passwordstore.org/][unix pass]] to securely
-   store my login credentials. You can find a *very* detailed configuration
-   [[https://github.com/OfflineIMAP/offlineimap/blob/master/offlineimap.conf][here]].
-2. Download your email: ~offlineimap -o~ (may take a while)
-3. Index it with mu: ~mu index --maildir ~/.mail~
+Next you can download your email with ~offlineimap -o~. This may take a while,
+especially if you have thousands of mails.
+
+You can now proceed with the [[*mu and mu4e][mu and mu4e]] section.
+
+** mbsync
+The steps needed to set up =mu4e= with =mbsync= are very similar to the ones for
+[[*offlineimap][offlineimap]].
+
+Start with writing a ~\~/.mbsyncrc~. An example for GMAIL can be found on
+[[http://pragmaticemacs.com/emacs/migrating-from-offlineimap-to-mbsync-for-mu4e/][pragmaticemacs.com]]. A non-GMAIL example is available as a gist [[https://gist.github.com/agraul/60977cc497c3aec44e10591f94f49ef0][here]]. The [[http://isync.sourceforge.net/mbsync.html][manual
+page]] contains all needed information to set up your own.
+
+Next you can download your email with ~mbsync --all~. This may take a while, but
+should be quicker than =offlineimap= ;).
+
+You can now proceed with the [[*mu and mu4e][mu and mu4e]] section.
+
+** mu and mu4e
+You should have your email downloaded already. If you have not, you need to set
+=offlineimap= or =mbsync= up before you proceed.
+
+Before you can use =mu4e= or the cli program =mu=, you need to index your email
+initially. How to do that differs a little depending on the version of =mu= you
+use. You can check your version with ~mu --version~.
+
+For =mu= *>=1.4* you need to run two commands:
+#+BEGIN_SRC sh
+mu init --maildir ~/.mail --my-address email@example.com
+mu index
+#+END_SRC
+
+=mu= *<1.4* only requires one command:
+#+BEGIN_SRC sh
+mu index --maildir ~/.mail
+#+END_SRC
 
 Then configure Emacs to use your email address:
 
@@ -130,12 +164,11 @@ Then configure Emacs to use your email address:
     (mu4e-trash-folder      . "/Lissner.net/Trash")
     (mu4e-refile-folder     . "/Lissner.net/All Mail")
     (smtpmail-smtp-user     . "henrik@lissner.net")
-    (user-mail-address      . "henrik@lissner.net")
+    (user-mail-address      . "henrik@lissner.net")    ;; only needed for mu < 1.4
     (mu4e-compose-signature . "---\nHenrik Lissner"))
   t)
 #+END_SRC
 
-** TODO mbsync
 * Troubleshooting
 ** =No such file or directory, mu4e=
 You will get =No such file or directory, mu4e= errors if you don't run ~doom

--- a/modules/email/mu4e/autoload/email.el
+++ b/modules/email/mu4e/autoload/email.el
@@ -6,7 +6,7 @@
 list of cons cells (VARIABLE . VALUE) -- you may want to modify:
 
  + `user-full-name' (this or the global `user-full-name' is required)
- + `user-mail-address' (required)
+ + `user-mail-address' (required in mu4e < 1.4)
  + `smtpmail-smtp-user' (required for sending mail from Emacs)
 
 OPTIONAL:
@@ -19,8 +19,9 @@ OPTIONAL:
 DEFAULT-P is a boolean. If non-nil, it marks that email account as the
 default/fallback account."
   (after! mu4e
-    (when-let (address (cdr (assq 'user-mail-address letvars)))
-      (add-to-list 'mu4e-user-mail-address-list address))
+    (when (version< mu4e-mu-version "1.4")
+      (when-let (address (cdr (assq 'user-mail-address letvars)))
+        (add-to-list 'mu4e-user-mail-address-list address)))
     (setq mu4e-contexts
           (cl-loop for context in mu4e-contexts
                    unless (string= (mu4e-context-name context) label)

--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -14,9 +14,11 @@
   :commands mu4e mu4e-compose-new
   :init
   (provide 'html2text) ; disable obsolete package
-  (setq mu4e-maildir "~/.mail"
-        mu4e-attachment-dir "~/.mail/.attachments"
-        mu4e-user-mail-address-list nil)
+  (require 'mu4e-meta)
+  (when (version< mu4e-mu-version "1.4")
+    (setq mu4e-maildir "~/.mail"
+          mu4e-user-mail-address-list nil))
+  (setq mu4e-attachment-dir "~/.mail/.attachments")
   :config
   (pcase +mu4e-backend
     (`mbsync
@@ -104,8 +106,9 @@
 (use-package! org-mu4e
   :hook (mu4e-compose-mode . org-mu4e-compose-org-mode)
   :config
-  (setq org-mu4e-link-query-in-headers-mode nil
-        org-mu4e-convert-to-html t)
+  (setq org-mu4e-convert-to-html t)
+  (when (version< mu4e-mu-version "1.4")
+    (setq org-mu4e-link-query-in-headers-mode nil))
 
   ;; Only render to html once. If the first send fails for whatever reason,
   ;; org-mu4e would do so each time you try again.


### PR DESCRIPTION
### Description
`mu4e` 1.4 brings quite a few changes, including the deprecation of previously used variables. These are now guarded by a version comparison. `org-mu4e` is not needed for linking anymore, `org-mu4e-link-query-in-headers-mode` was renamed. It's new version defaults to `nil` and is therefore not set anymore -- I am not sure if the default was changed or setting it was not strictly needed previously.

### ToDos
- [x] Adjust `set-email-account!`
- [x] Update README