### PR TITLE
switching org-roam-completion to use 'default

### DIFF
--- a/modules/lang/org/contrib/roam.el
+++ b/modules/lang/org/contrib/roam.el
@@ -36,11 +36,7 @@
   (setq org-roam-directory (expand-file-name (or org-roam-directory "")
                                              org-directory)
         org-roam-verbose nil  ; https://youtu.be/fn4jIlFwuLU
-        org-roam-completion-system
-        (cond ((featurep! :completion helm) 'helm)
-              ((featurep! :completion ivy) 'ivy)
-              ((featurep! :completion ido) 'ido)
-              ('default)))
+        org-roam-completion-system 'default)
 
   ;; HACK Hide the mode line in the org-roam buffer, since it serves no purpose.
   ;;      This makes it easier to distinguish among other org buffers.

--- a/modules/lang/org/contrib/roam.el
+++ b/modules/lang/org/contrib/roam.el
@@ -36,7 +36,14 @@
   (setq org-roam-directory (expand-file-name (or org-roam-directory "")
                                              org-directory)
         org-roam-verbose nil  ; https://youtu.be/fn4jIlFwuLU
-        org-roam-completion-system 'default)
+        org-roam-completion-system
+        (cond ((featurep! :completion helm) 'helm)
+              ((featurep! :completion ivy) 'ivy)
+              ((featurep! :completion ido) 'ido)
+              ('default))
+        org-roam-completion-fuzzy-match
+        (or (featurep! :completion helm +fuzzy)
+            (featurep! :completion ivy +fuzzy)))
 
   ;; HACK Hide the mode line in the org-roam buffer, since it serves no purpose.
   ;;      This makes it easier to distinguish among other org buffers.


### PR DESCRIPTION
I do not understand why this is the case, but the conditional setup for the completion system was causing fuzzy completion to fail in ivy. This fixes that.