### PR TITLE
Allow core/test/test-core.el to run

### DIFF
--- a/core/test/test-core.el
+++ b/core/test/test-core.el
@@ -124,4 +124,4 @@
       (expect (doom-load-envvars-file doom-env-file))
       (expect (getenv "A") :to-equal "1")
       (expect (getenv "B") :to-equal "2")
-      (expect (getenv "C") :to-equal "3"))))
+      (expect (getenv "C") :to-equal "3")))))


### PR DESCRIPTION
Added missing close-paren to end of file. This was preventing
tests from core/test/test-core.el being run. Five of these
tests are currently failing:
* re initialization doom-initialize package initialization initializes
  packages if core autoload file doesn't exist
* core initialization doom-initialize package initialization autoloads
  files loads autoloads files
* core initialization doom-load-autoloads-file returns non-nil if
  successful
* core initialization doom-load-autoloads-file returns nil on failure or
  error, non-fatally

Error messages before this fix:
[snip]
End of file during parsing:
[...]/core/test/test-core.el
[snip]
Buttercup test failed
- Ignoring core/test/test-core-packages.el
[snip]

If a buttercup test file, itself, fails, that doesn't cause the
buttercup test run to fail:
https://github.com/jorgenschaefer/emacs-buttercup/issues/107