### PR TITLE
Fix typo in key bindings

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -22,7 +22,7 @@
     (define-key! :keymaps +default-minibuffer-maps
       "C-f"    #'forward-word
       "C-b"    #'backward-word
-      "M-f"    #'foward-char
+      "M-f"    #'forward-char
       "M-b"    #'backward-char
       "C-j"    #'next-line
       "C-k"    #'previous-line


### PR DESCRIPTION
This fixes a typo for a minibuffer keybinding.

@hlissner `*-char` and `*-word` commands in this section are generally mixed up, please let me know if I should include the fix to them as well.