### PR TITLE
Add .jinja2 file extension to supported web files.

### DIFF
--- a/modules/lang/web/+html.el
+++ b/modules/lang/web/+html.el
@@ -13,6 +13,7 @@
   :mode "\\.vue\\'"
   :mode "\\.twig\\'"
   :mode "\\.jinja\\'"
+  :mode "\\.jinja2\\'"
   :mode "wp-content/themes/.+/.+\\.php\\'"
   :mode "templates/.+\\.php\\'"
   ;; REVIEW We associate TSX files with `web-mode' because `typescript-mode'

--- a/modules/lang/web/+html.el
+++ b/modules/lang/web/+html.el
@@ -12,8 +12,7 @@
   :mode "\\.svelte\\'"
   :mode "\\.vue\\'"
   :mode "\\.twig\\'"
-  :mode "\\.jinja\\'"
-  :mode "\\.jinja2\\'"
+  :mode "\\.jinja2?\\'"
   :mode "wp-content/themes/.+/.+\\.php\\'"
   :mode "templates/.+\\.php\\'"
   ;; REVIEW We associate TSX files with `web-mode' because `typescript-mode'


### PR DESCRIPTION
Seeing that the `web` lang module already supports .jinja files, I don't think it's a far cry to add the .jinja2 extension to the list.
It's not super fancy but better than no major mode support.
Working with limited lisp experience to expand the highlighting functionality. :shrug: 