### PR TITLE
Set `evil-shift-width` to `standard-indent` instead of `tab-width`

### DIFF
--- a/core/core-editor.el
+++ b/core/core-editor.el
@@ -109,8 +109,9 @@ possible."
 ;; Favor spaces over tabs. Pls dun h8, but I think spaces (and 4 of them) is a
 ;; more consistent default than 8-space tabs. It can be changed on a per-mode
 ;; basis anyway (and is, where tabs are the canonical style, like go-mode).
+(setq standard-indent 4)
 (setq-default indent-tabs-mode nil
-              tab-width 4)
+              tab-width standard-indent)
 
 ;; Make `tabify' and `untabify' only affect indentation. Not tabs/spaces in the
 ;; middle of a line.

--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -94,7 +94,7 @@ directives. By default, this only recognizes C directives.")
   (defun +evil-emacs-cursor-fn ()
     (evil-set-cursor-color +evil--emacs-cursor-color))
 
-  (setq-hook! 'after-change-major-mode-hook evil-shift-width tab-width)
+  (setq-hook! 'after-change-major-mode-hook evil-shift-width standard-indent)
 
 
   ;; --- keybind fixes ----------------------


### PR DESCRIPTION
`tab-width` represents the number of spaces that a `Tab` character counts for, while `standard-indent` represents the number of spaces required for each level of indentation. Since `shiftwidth` is solely concerned with indentation, it'd make more sense to assign it to `standard-indent`. This change would benefit people who have different settings for `tab-width` and `standard-indent`.