### PR TITLE
add support for magit-delta

### DIFF
--- a/modules/tools/magit/README.org
+++ b/modules/tools/magit/README.org
@@ -25,10 +25,12 @@ This module has no dedicated maintainers.
 ** Module Flags
 + =+forge= Enable Forge; a porcelain for managing issues and PRs from within
   Emacs. Will take a while on first run to build emacsql-sqlite.
++ =+delta= Enable magit-delta; syntax-highlighted diffs with [[https://github.com/dandavison/delta][delta]]
 
 ** Plugins
 + [[https://github.com/magit/magit][magit]]
 + [[https://github.com/magit/forge][forge]]* (=+forge=)
++ [[https://github.com/dandavison/magit-delta][magit-delta]]* (=+delta=)
 + [[https://github.com/jtatarik/magit-gitflow][magit-gitflow]]
 + [[https://github.com/alphapapa/magit-todos][magit-todos]]
 + [[https://github.com/charignon/github-review][github-review]]

--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -139,6 +139,17 @@ ensure it is built when we actually use Forge."
             (add-hook hook #'forge-bug-reference-setup)))))))
 
 
+(use-package! magit-delta
+  :after magit
+  :when (featurep! +delta)
+  :preface
+  (setq
+    magit-delta-default-dark-theme "OneHalfDark"
+    magit-delta-default-light-theme "OneHalfLight")
+  :config
+  (magit-delta-mode))
+
+
 (use-package! github-review
   :after magit
   :config

--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -142,11 +142,10 @@ ensure it is built when we actually use Forge."
 (use-package! magit-delta
   :after magit
   :when (featurep! +delta)
-  :preface
+  :config
   (setq
     magit-delta-default-dark-theme "OneHalfDark"
     magit-delta-default-light-theme "OneHalfLight")
-  :config
   (magit-delta-mode))
 
 

--- a/modules/tools/magit/doctor.el
+++ b/modules/tools/magit/doctor.el
@@ -1,0 +1,6 @@
+;; -*- lexical-binding: t; no-byte-compile: t; -*-
+;;; tools/magit/doctor.el
+
+(assert! (or (not (featurep! +delta))
+             (executable-find "delta"))
+         "Couldn't find delta; magit-delta won't work")

--- a/modules/tools/magit/packages.el
+++ b/modules/tools/magit/packages.el
@@ -8,7 +8,7 @@
     (package! xterm-color :pin "d53a39a5af72cd340ebf686e59a37289b4cb6e8c")
     (package! magit-delta
       :recipe (:host github :repo "dandavison/magit-delta" :files ("magit-delta.el") )
-      :pin "a3081b030c1bc21a1c0ec4367a8b08a2a5f031f3"))
+      :pin "f429bf64bb398890b7c584d70660dd202e39824a"))
   (package! magit-gitflow :pin "cc41b561ec6eea947fe9a176349fb4f771ed865b")
   (package! magit-todos :pin "a0e5d1f3c7dfcb4f18c1b0d57f1746a4872df5c6")
   (package! github-review :pin "50c6bcc7cf4d7193577b3f74eea4dd72f2b7795b")

--- a/modules/tools/magit/packages.el
+++ b/modules/tools/magit/packages.el
@@ -4,6 +4,11 @@
 (when (package! magit :pin "b1b2683f6012ff3bc29bd9cbe562246477f1523f")
   (when (featurep! +forge)
     (package! forge :pin "09bf8adc9c9afb492632e612f51f39e1cc15fca0"))
+  (when (featurep! +delta)
+    (package! xterm-color :pin "d53a39a5af72cd340ebf686e59a37289b4cb6e8c")
+    (package! magit-delta
+      :recipe (:host github :repo "dandavison/magit-delta" :files ("magit-delta.el") )
+      :pin "a3081b030c1bc21a1c0ec4367a8b08a2a5f031f3"))
   (package! magit-gitflow :pin "cc41b561ec6eea947fe9a176349fb4f771ed865b")
   (package! magit-todos :pin "a0e5d1f3c7dfcb4f18c1b0d57f1746a4872df5c6")
   (package! github-review :pin "50c6bcc7cf4d7193577b3f74eea4dd72f2b7795b")

--- a/modules/tools/magit/packages.el
+++ b/modules/tools/magit/packages.el
@@ -5,10 +5,7 @@
   (when (featurep! +forge)
     (package! forge :pin "09bf8adc9c9afb492632e612f51f39e1cc15fca0"))
   (when (featurep! +delta)
-    (package! xterm-color :pin "d53a39a5af72cd340ebf686e59a37289b4cb6e8c")
-    (package! magit-delta
-      :recipe (:host github :repo "dandavison/magit-delta" :files ("magit-delta.el") )
-      :pin "f429bf64bb398890b7c584d70660dd202e39824a"))
+    (package! magit-delta :pin "d988abd99882c6b89f21f2746f721a4d7ece6ad4"))
   (package! magit-gitflow :pin "cc41b561ec6eea947fe9a176349fb4f771ed865b")
   (package! magit-todos :pin "a0e5d1f3c7dfcb4f18c1b0d57f1746a4872df5c6")
   (package! github-review :pin "50c6bcc7cf4d7193577b3f74eea4dd72f2b7795b")


### PR DESCRIPTION
This adds colorful syntax-highlighted diffs in magit-status buffers, thanks to [delta](https://github.com/dandavison/delta) and [magit-delta](https://github.com/dandavison/magit-delta)

This adds a `+delta` flag to the magit module.