### PR TITLE
Encrypt and change location of org-gcal-token-file

### DIFF
--- a/modules/app/calendar/config.el
+++ b/modules/app/calendar/config.el
@@ -49,5 +49,3 @@
   ;; hack to avoid the deferred.el error
   (defun org-gcal--notify (title mes)
     (message "org-gcal::%s - %s" title mes)))
-
-;; (use-package! alert)

--- a/modules/app/calendar/config.el
+++ b/modules/app/calendar/config.el
@@ -42,10 +42,12 @@
              org-gcal-fetch
              org-gcal-post-at-point
              org-gcal-delete-at-point)
+  :init
+  (defvar org-gcal-dir (concat doom-cache-dir "org-gcal/"))
+  (defvar org-gcal-token-file (concat org-gcal-dir "token.gpg"))
   :config
   ;; hack to avoid the deferred.el error
   (defun org-gcal--notify (title mes)
     (message "org-gcal::%s - %s" title mes)))
-
 
 ;; (use-package! alert)

--- a/modules/app/calendar/packages.el
+++ b/modules/app/calendar/packages.el
@@ -3,4 +3,4 @@
 
 (package! calfw :pin "03abce97620a4a7f7ec5f911e669da9031ab9088")
 (package! calfw-org :pin "03abce97620a4a7f7ec5f911e669da9031ab9088")
-(package! org-gcal :pin "1667aba7c0a33e3c23c3a47fc04e89670684eddc")
+(package! org-gcal :pin "2ee2b31547e6f4e33db70fb812d552e55d612fd6")


### PR DESCRIPTION
Looks like `org-gcal` stores sensitive data in `~/.emacs.d/org-gcal` (by default) without encryption. 
Here's a few changes to make it a bit more secure. :lock: 

* Move `org-gcal-token-file` to `doom-cache-dir`
* Encrypt `org-gcal-token-file` using GPG
* If old file exists, move it to new location with encryption
* Bump `org-gcal` pin

Any feedback is more than welcome! 