### PR TITLE
Fix tide not working with rjsx-mode

### DIFF
--- a/modules/lang/javascript/config.el
+++ b/modules/lang/javascript/config.el
@@ -135,7 +135,8 @@
 
 (add-hook! '(js2-mode-local-vars-hook
              typescript-mode-local-vars-hook
-             web-mode-local-vars-hook)
+             web-mode-local-vars-hook
+             rjsx-mode-local-vars-hook)
   (defun +javascript-init-lsp-or-tide-maybe-h ()
     "Start `lsp' or `tide' in the current buffer.
 


### PR DESCRIPTION
Tide doesn't work with `rjsx-mode` after changing to `*-mode-local-vars-hook`.
Fixed by adding `+javascript-init-lsp-or-tide-maybe-h` for
`rjsx-mode-local-vars-hook` as well.

Signed-off-by: Huy Duong <huy.duong@employmenthero.com>