### PR TITLE
Use lsp-format-region-or-buffer if available

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -43,7 +43,6 @@
         :desc "List errors"                         "x"   #'flycheck-list-errors)
        (:when (featurep! :tools lsp)
         :desc "LSP Code actions"                      "a"   #'lsp-execute-code-action
-        :desc "LSP Format buffer/region"              "F"   #'+default/lsp-format-region-or-buffer
         :desc "LSP Organize imports"                  "i"   #'lsp-organize-imports
         :desc "LSP Rename"                            "r"   #'lsp-rename
         (:after lsp-mode

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -360,7 +360,6 @@
        :desc "Jump to documentation"                 "k"   #'+lookup/documentation
        (:when (featurep! :tools lsp)
         :desc "LSP Execute code action"               "a"   #'lsp-execute-code-action
-        :desc "LSP Format buffer/region"              "F"   #'+default/lsp-format-region-or-buffer
         :desc "LSP Organize imports"                  "i"   #'lsp-organize-imports
         :desc "LSP Rename"                            "r"   #'lsp-rename
         (:after lsp-mode

--- a/modules/editor/format/autoload/format.el
+++ b/modules/editor/format/autoload/format.el
@@ -219,9 +219,11 @@ snippets or single lines."
 is selected)."
   (interactive)
   (call-interactively
-   (if (use-region-p)
-       #'+format/region
-     #'+format/buffer)))
+   (if (bound-and-true-p lsp-mode)
+       #'+default/lsp-format-region-or-buffer
+     (if (use-region-p)
+         #'+format/region
+       #'+format/buffer))))
 
 
 ;;


### PR DESCRIPTION
Currently the user has to select `SPC c F` for lsp format. But if
lsp-mode is enabled, the user will always want to use the LSP formatter.
So this changes the default `SPC c f` to use lsp formatter if available.
This simplifies the interface a bit so the user doesn't have to worry
about selecting the "right" format, just like how other commands get
auto bound to LSP functions.