### PR TITLE
ido: fix up and down keybinds in file dir navigation

### DIFF
--- a/modules/completion/ido/config.el
+++ b/modules/completion/ido/config.el
@@ -33,7 +33,7 @@
 
   (map! :map (ido-common-completion-map ido-file-completion-map)
         "C-w"  #'ido-delete-backward-word-updir
-        :map ido-common-completion-map
+        :map (ido-common-completion-map ido-file-dir-completion-map)
         "C-n"  #'ido-next-match
         "C-p"  #'ido-prev-match
         [down] #'ido-next-match


### PR DESCRIPTION
This adds support for up/down/C-n/C-p for file dir navigation. For some reason the keybinds are overridden there and they don't do what I'd expect.