### PR TITLE
Make some improvements to java +lsp

### DIFF
--- a/modules/lang/java/+lsp.el
+++ b/modules/lang/java/+lsp.el
@@ -9,17 +9,10 @@
 (add-hook! java-mode-local-vars #'lsp!)
 (map! :map java-mode-map
       :localleader
-      :desc "Update the Eclipse LSP server" "U" #'+java/update-lsp-server
-      :desc "Open the test browser" "T" #'lsp-jt-browser)
-
-;; TODO: This fails on the first java buffer opened - complains about the LSP server not having executeCode capabilities.
-(defun java--lsp-jt-lens-mode-hook ()
-  (when (derived-mode-p 'java-mode) (lsp-jt-lens-mode)))
+      :desc "Update the Eclipse LSP server" "U" #'+java/update-lsp-server)
 
 (use-package! lsp-java
   :after (lsp-clients dap-mode)
-  :hook (lsp-mode . java--lsp-jt-lens-mode-hook)
   :preface
   (setq lsp-java-server-install-dir (concat doom-etc-dir "eclipse.jdt.ls/server/")
-        lsp-java-workspace-dir (concat doom-etc-dir "java-workspace")
-        lsp-jt-root (concat doom-etc-dir "eclipse.jdt.ls/server/java-test/server")))
+        lsp-java-workspace-dir (concat doom-etc-dir "java-workspace")))

--- a/modules/lang/java/+lsp.el
+++ b/modules/lang/java/+lsp.el
@@ -5,7 +5,8 @@
   :after (lsp-clients dap-mode)
   :preface
   (setq lsp-java-server-install-dir (concat doom-etc-dir "eclipse.jdt.ls/server/")
-        lsp-java-workspace-dir (concat doom-etc-dir "java-workspace"))
+        lsp-java-workspace-dir (concat doom-etc-dir "java-workspace")
+        lsp-jt-root (concat doom-etc-dir "eclipse.jdt.ls/server/java-test/server/"))
   (add-hook! java-mode-local-vars #'lsp!)
   :config
   ;; TODO keybinds

--- a/modules/lang/java/+lsp.el
+++ b/modules/lang/java/+lsp.el
@@ -1,18 +1,12 @@
 ;;; lang/java/+lsp.el -*- lexical-binding: t; -*-
 ;;;###if (featurep! +lsp)
 
-;;;###autoload
-(defun +java/update-lsp-server ()
-  (interactive)
-  (lsp--install-server-internal (gethash 'jdtls lsp-clients) t))
-
-(add-hook! java-mode-local-vars #'lsp!)
-(map! :map java-mode-map
-      :localleader
-      :desc "Update the Eclipse LSP server" "U" #'+java/update-lsp-server)
-
 (use-package! lsp-java
   :after (lsp-clients dap-mode)
   :preface
   (setq lsp-java-server-install-dir (concat doom-etc-dir "eclipse.jdt.ls/server/")
-        lsp-java-workspace-dir (concat doom-etc-dir "java-workspace")))
+        lsp-java-workspace-dir (concat doom-etc-dir "java-workspace"))
+  (add-hook! java-mode-local-vars #'lsp!)
+  :config
+  ;; TODO keybinds
+  )

--- a/modules/lang/java/+lsp.el
+++ b/modules/lang/java/+lsp.el
@@ -2,7 +2,7 @@
 ;;;###if (featurep! +lsp)
 
 (use-package! lsp-java
-  :after (lsp-clients dap-mode)
+  :after lsp-clients
   :preface
   (setq lsp-java-server-install-dir (concat doom-etc-dir "eclipse.jdt.ls/server/")
         lsp-java-workspace-dir (concat doom-etc-dir "java-workspace")

--- a/modules/lang/java/+lsp.el
+++ b/modules/lang/java/+lsp.el
@@ -1,13 +1,25 @@
 ;;; lang/java/+lsp.el -*- lexical-binding: t; -*-
 ;;;###if (featurep! +lsp)
 
+;;;###autoload
+(defun +java/update-lsp-server ()
+  (interactive)
+  (lsp--install-server-internal (gethash 'jdtls lsp-clients) t))
+
+(add-hook! java-mode-local-vars #'lsp!)
+(map! :map java-mode-map
+      :localleader
+      :desc "Update the Eclipse LSP server" "U" #'+java/update-lsp-server
+      :desc "Open the test browser" "T" #'lsp-jt-browser)
+
+;; TODO: This fails on the first java buffer opened - complains about the LSP server not having executeCode capabilities.
+(defun java--lsp-jt-lens-mode-hook ()
+  (when (derived-mode-p 'java-mode) (lsp-jt-lens-mode)))
+
 (use-package! lsp-java
-  :after lsp-clients
-  :hook (java-mode-local-vars . lsp!)
+  :after (lsp-clients dap-mode)
+  :hook (lsp-mode . java--lsp-jt-lens-mode-hook)
   :preface
   (setq lsp-java-server-install-dir (concat doom-etc-dir "eclipse.jdt.ls/server/")
-        lsp-java-workspace-dir (concat doom-etc-dir "java-workspace"))
-  :config
-  ;; TODO keybinds
-  ;; TODO treemacs integration (?)
-  )
+        lsp-java-workspace-dir (concat doom-etc-dir "java-workspace")
+        lsp-jt-root (concat doom-etc-dir "eclipse.jdt.ls/server/java-test/server")))


### PR DESCRIPTION
This is a first pass at making `+lsp` more functional:

* Fix lsp not starting automatically when opening java-mode buffers.
Placing it in the lsp-java hook does not work.
* Fix root path for lsp-jt.
