### PR TITLE
Configure java +lsp test runner via dap-mode

### DIFF
--- a/modules/lang/java/+lsp.el
+++ b/modules/lang/java/+lsp.el
@@ -4,10 +4,14 @@
 (use-package! lsp-java
   :after lsp-clients
   :preface
-  (setq lsp-java-server-install-dir (concat doom-etc-dir "eclipse.jdt.ls/server/")
-        lsp-java-workspace-dir (concat doom-etc-dir "java-workspace")
-        lsp-jt-root (concat doom-etc-dir "eclipse.jdt.ls/server/java-test/server/"))
+  (setq lsp-java-workspace-dir (concat doom-etc-dir "java-workspace"))
   (add-hook! java-mode-local-vars #'lsp!)
-  :config
-  ;; TODO keybinds
-  )
+  :init
+  (when (featurep! :tools debugger +lsp)
+    (setq lsp-jt-root (concat lsp-java-server-install-dir "java-test/server/")
+          dap-java-test-runner (concat lsp-java-server-install-dir "test-runner/junit-platform-console-standalone.jar"))
+    (map! :map java-mode-map
+          :localleader
+          (:prefix ("t" . "Test")
+           :desc "Run tests in class" "t" #'dap-java-run-test-class
+           :desc "Run single test method" "s" #'dap-java-run-test-method))))

--- a/modules/lang/java/+lsp.el
+++ b/modules/lang/java/+lsp.el
@@ -18,8 +18,17 @@
           (dap-java-run-test-method)
         (user-error (dap-java-run-test-class))))
 
+    (defun +java/debug-test ()
+      "Runs test at point in a debugger. If in a method, runs the test method, otherwise runs the entire test class."
+      (interactive)
+      (condition-case nil
+          (call-interactively #'dap-java-debug-test-method)
+        (user-error (call-interactively #'dap-java-debug-test-class))))
+
     (map! :map java-mode-map
           :localleader
           (:prefix ("t" . "Test")
            :desc "Run test class or method" "t" #'+java/run-test
-           :desc "Run all tests in class" "a" #'dap-java-run-test-class))))
+           :desc "Run all tests in class" "a" #'dap-java-run-test-class
+           :desc "Debug test class or method" "d" #'+java/debug-test
+           :desc "Debug all tests in class" "D" #'dap-java-debug-test-class))))

--- a/modules/lang/java/+lsp.el
+++ b/modules/lang/java/+lsp.el
@@ -10,8 +10,16 @@
   (when (featurep! :tools debugger +lsp)
     (setq lsp-jt-root (concat lsp-java-server-install-dir "java-test/server/")
           dap-java-test-runner (concat lsp-java-server-install-dir "test-runner/junit-platform-console-standalone.jar"))
+
+    (defun +java/run-test ()
+      "Runs test at point. If in a method, runs the test method, otherwise runs the entire test class."
+      (interactive)
+      (condition-case nil
+          (dap-java-run-test-method)
+        (user-error (dap-java-run-test-class))))
+
     (map! :map java-mode-map
           :localleader
           (:prefix ("t" . "Test")
-           :desc "Run tests in class" "t" #'dap-java-run-test-class
-           :desc "Run single test method" "s" #'dap-java-run-test-method))))
+           :desc "Run test class or method" "t" #'+java/run-test
+           :desc "Run all tests in class" "a" #'dap-java-run-test-class))))

--- a/modules/lang/java/+lsp.el
+++ b/modules/lang/java/+lsp.el
@@ -6,11 +6,7 @@
   :preface
   (setq lsp-java-workspace-dir (concat doom-etc-dir "java-workspace"))
   (add-hook! java-mode-local-vars #'lsp!)
-  :init
   (when (featurep! :tools debugger +lsp)
-    (setq lsp-jt-root (concat lsp-java-server-install-dir "java-test/server/")
-          dap-java-test-runner (concat lsp-java-server-install-dir "test-runner/junit-platform-console-standalone.jar"))
-
     (defun +java/run-test ()
       "Runs test at point. If in a method, runs the test method, otherwise runs the entire test class."
       (interactive)
@@ -31,4 +27,8 @@
            :desc "Run test class or method" "t" #'+java/run-test
            :desc "Run all tests in class" "a" #'dap-java-run-test-class
            :desc "Debug test class or method" "d" #'+java/debug-test
-           :desc "Debug all tests in class" "D" #'dap-java-debug-test-class))))
+           :desc "Debug all tests in class" "D" #'dap-java-debug-test-class)))
+  :init
+  (when (featurep! :tools debugger +lsp)
+    (setq lsp-jt-root (concat lsp-java-server-install-dir "java-test/server/")
+          dap-java-test-runner (concat lsp-java-server-install-dir "test-runner/junit-platform-console-standalone.jar"))))

--- a/modules/lang/java/README.org
+++ b/modules/lang/java/README.org
@@ -142,7 +142,7 @@ automatically.
 To update the server, perform =SPC u M-x lsp-install-server=.
 
 Note that if you change Java version you may need to remove the LSP server and
-reinstall it. You can do this by removing
-=~/.emacs.d/.local/etc/lsp/eclipse.jdt.ls= then running =lsp-install-server=.
+install it again. You can do this with =M-x +lsp/uninstall-server= followed by
+=M-x lsp-install-server=.
 
 Enable the =:tools (debugger +lsp)= module to get test runner support.

--- a/modules/lang/java/README.org
+++ b/modules/lang/java/README.org
@@ -13,10 +13,12 @@
   - [[#oracle-jdk-11][Oracle JDK 11]]
     - [[#ubuntu-1][Ubuntu]]
     - [[#fedora-1][Fedora]]
+  - [[#multiple-java-versions][Multiple Java Versions]]
 - [[#features][Features]]
   - [[#lsp-features][=+lsp= features]]
   - [[#meghanada-features][=+meghanada= features]]
 - [[#configuration][Configuration]]
+  - [[#lsp][=+lsp=]]
 
 * Description
 This module adds [[https://www.java.com][java]] support to Doom Emacs, including =android-mode= and
@@ -29,6 +31,9 @@ This module adds [[https://www.java.com][java]] support to Doom Emacs, including
 The =+lsp= and =+meghanada= packages are mutually exclusive and do not work
 together. At the time of writing the =+meghanada= is already configured whereas
 =+lsp= needs to manual configuring.
+
+The =lsp= test runner requires that =:tools (debugger +lsp)= is enabled, as this
+provides =dap-mode=.
 
 * Prerequisites
 This module requires the Java SDK.
@@ -72,6 +77,23 @@ source /etc/profile.d/jdk11.sh
 java -version
 #+END_SRC
 
+** Multiple Java Versions
+It is common to need support for multiple Java versions. You can use a generic
+tool like [[https://github.com/shyiko/jabba][jabba]] to install and manage multiple Java versions on any OS.
+
+To switch between Java versions in Doom, you can use [[https://github.com/direnv/direnv][direnv]] and the [[file:~/.emacs.d/modules/tools/direnv/README.org::+TITLE: tools/direnv][direnv module]]. To set a
+Java version for a particular project, create a =.envrc= pointing to the Java
+installation in the root of the project:
+
+#+BEGIN_SRC conf-unix
+PATH_add ~/.jabba/jdk/adopt@1.11.0-3
+JAVA_HOME=~/.jabba/jdk/adopt@1.11.0-3
+#+END_SRC
+
+And then run =direnv allow .= in the project directory. If the =direnv= module
+is enabled, then Doom will automatically source this environment before
+executing the LSP server.
+
 * Features
 ** =+lsp= features
 According to [[https://github.com/emacs-lsp/lsp-java]] it adds
@@ -111,4 +133,16 @@ According to [[https://github.com/mopemope/meghanada-emacs/]] it adds
 + Search references
 + Full-featured text search
 
-* TODO Configuration
+* Configuration
+** =+lsp=
+Install the eclipse server by executing =M-x lsp-install-server= and selecting
+=jdtls=. After that any newly opened =java= files should start the LSP server
+automatically.
+
+To update the server, perform =SPC u M-x lsp-install-server=.
+
+Note that if you change Java version you may need to remove the LSP server and
+reinstall it. You can do this by removing
+=~/.emacs.d/.local/etc/lsp/eclipse.jdt.ls= then running =lsp-install-server=.
+
+Enable the =:tools (debugger +lsp)= module to get test runner support.

--- a/modules/lang/java/README.org
+++ b/modules/lang/java/README.org
@@ -33,7 +33,7 @@ together. At the time of writing the =+meghanada= is already configured whereas
 =+lsp= needs to manual configuring.
 
 The =lsp= test runner requires that =:tools (debugger +lsp)= is enabled, as this
-provides =dap-mode=.
+provides =dap-mode= which contains the Java test runner.
 
 * Prerequisites
 This module requires the Java SDK.

--- a/modules/lang/java/autoload.el
+++ b/modules/lang/java/autoload.el
@@ -71,3 +71,9 @@ root)."
     (user-error "This buffer has no filepath; cannot guess its class name"))
   (or (file-name-sans-extension (file-name-base (buffer-file-name)))
       "ClassName"))
+
+;;;###autoload
+(defun +java/run-tests ()
+  "Run tests at point. If in a method, runs the test method, otherwise runs the entire test class."
+
+  )

--- a/modules/lang/java/autoload.el
+++ b/modules/lang/java/autoload.el
@@ -71,9 +71,3 @@ root)."
     (user-error "This buffer has no filepath; cannot guess its class name"))
   (or (file-name-sans-extension (file-name-base (buffer-file-name)))
       "ClassName"))
-
-;;;###autoload
-(defun +java/run-tests ()
-  "Run tests at point. If in a method, runs the test method, otherwise runs the entire test class."
-
-  )


### PR DESCRIPTION
This configures dap-mode appropriately so the user can run tests
directly from Doom. It adds two test bindings similar to
other major modes:
* `SPC m t t` runs the test class or method at point.
* `SPC m t a` runs all tests in the current class regardless of point.
* `SPC m t d` debugs the test class or method at point using dap-mode.
* `SPC m t D` debugs all tests in the current class regardless of point.

I also expanded the README with more details about configuring `+lsp`.
