### PR TITLE
Add Dash docsets + Xwidget integration

### DIFF
--- a/modules/tools/lookup/README.org
+++ b/modules/tools/lookup/README.org
@@ -40,6 +40,7 @@ or synonyms.
 + ~+dictionary~ Enable word definition and thesaurus lookup functionality.
   + ~+offline~ Install and prefer offline dictionary/thesaurus.
 + ~+docsets~ Enable integration with Dash.app docsets.
+  + ~+xwidget~ Enable integration with [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Embedded-WebKit-Widgets.html][Embedded Webkit Widgets]].
 
 ** Plugins
 + [[https://github.com/jacktasia/dumb-jump][dumb-jump]]

--- a/modules/tools/lookup/config.el
+++ b/modules/tools/lookup/config.el
@@ -181,16 +181,18 @@ See https://github.com/magit/ghub/issues/81"
       (funcall orig-fn url)))
 
   ;; Dash docset + Xwidget integration
-  (when (and (featurep! +xwidget) (display-graphic-p))
+  (when (featurep! +xwidget)
     (defun +lookup/dash-docs-xwidget-webkit-browse-url (url &optional new-session)
-      (setq xwidget-webkit-last-session-buffer +lookup--dash-docs-xwidget-webkit-last-session-buffer)
-      (save-window-excursion
-        (xwidget-webkit-browse-url url new-session))
-      (with-popup-rules!
-        '((set-popup-rule! "^\\*xwidget" :vslot -11 :size 0.35 :select nil))
-        (pop-to-buffer xwidget-webkit-last-session-buffer))
-      (setq +lookup--dash-docs-xwidget-webkit-last-session-buffer xwidget-webkit-last-session-buffer
-            xwidget-webkit-last-session-buffer nil))
+      (if (not (display-graphic-p))
+          (eww url new-session)
+        (setq xwidget-webkit-last-session-buffer +lookup--dash-docs-xwidget-webkit-last-session-buffer)
+        (save-window-excursion
+          (xwidget-webkit-browse-url url new-session))
+        (with-popup-rules!
+          '((set-popup-rule! "^\\*xwidget" :vslot -11 :size 0.35 :select nil))
+          (pop-to-buffer xwidget-webkit-last-session-buffer))
+        (setq +lookup--dash-docs-xwidget-webkit-last-session-buffer xwidget-webkit-last-session-buffer
+              xwidget-webkit-last-session-buffer nil)))
     (setq dash-docs-browser-func #'+lookup/dash-docs-xwidget-webkit-browse-url))
 
   (cond ((featurep! :completion helm)

--- a/modules/tools/lookup/config.el
+++ b/modules/tools/lookup/config.el
@@ -178,6 +178,26 @@ See https://github.com/magit/ghub/issues/81"
     (let ((gnutls-algorithm-priority "NORMAL:-VERS-TLS1.3"))
       (funcall orig-fn url)))
 
+  ;; Dash docset + Xwidget integration
+  (when (and (featurep! :tools lookup +xwidget) (display-graphic-p))
+    (setq dash-docs-browser-func #'xwidget-webkit-browse-url)
+
+    (set-popup-rule! "^\\*xwidget" :vslot -11 :size 0.35 :select nil)
+
+    (defun +xwidget--webkit-goto-url-a (&rest _)
+      (pop-to-buffer xwidget-webkit-last-session-buffer))
+    (advice-add #'xwidget-webkit-goto-url :after #'+xwidget--webkit-goto-url-a)
+
+    (defun +xwidget--webkit-new-session-a (orig-fun &rest args)
+      (save-window-excursion
+        (apply orig-fun args))
+      (pop-to-buffer xwidget-webkit-last-session-buffer))
+    (advice-add #'xwidget-webkit-new-session :around #'+xwidget--webkit-new-session-a)
+
+    (when (featurep! :editor evil +everywhere)
+      (add-transient-hook! 'xwidget-webkit-mode-hook
+        (+evil-collection-init 'xwidget))))
+
   (cond ((featurep! :completion helm)
          (require 'helm-dash nil t))
         ((featurep! :completion ivy)

--- a/modules/tools/lookup/config.el
+++ b/modules/tools/lookup/config.el
@@ -193,10 +193,6 @@ See https://github.com/magit/ghub/issues/81"
             xwidget-webkit-last-session-buffer nil))
     (setq dash-docs-browser-func #'+lookup/dash-docs-xwidget-webkit-browse-url))
 
-  (when (featurep! :editor evil +everywhere)
-    (add-transient-hook! 'xwidget-webkit-mode-hook
-      (+evil-collection-init 'xwidget)))
-
   (cond ((featurep! :completion helm)
          (require 'helm-dash nil t))
         ((featurep! :completion ivy)

--- a/modules/tools/lookup/config.el
+++ b/modules/tools/lookup/config.el
@@ -182,7 +182,7 @@ See https://github.com/magit/ghub/issues/81"
 
   ;; Dash docset + Xwidget integration
   (when (featurep! +xwidget)
-    (defun +lookup/dash-docs-xwidget-webkit-browse-url (url &optional new-session)
+    (defun +lookup-dash-docs-xwidget-webkit-browse-url-fn (url &optional new-session)
       (if (not (display-graphic-p))
           (eww url new-session)
         (setq xwidget-webkit-last-session-buffer +lookup--dash-docs-xwidget-webkit-last-session-buffer)
@@ -193,7 +193,7 @@ See https://github.com/magit/ghub/issues/81"
           (pop-to-buffer xwidget-webkit-last-session-buffer))
         (setq +lookup--dash-docs-xwidget-webkit-last-session-buffer xwidget-webkit-last-session-buffer
               xwidget-webkit-last-session-buffer nil)))
-    (setq dash-docs-browser-func #'+lookup/dash-docs-xwidget-webkit-browse-url))
+    (setq dash-docs-browser-func #'+lookup-dash-docs-xwidget-webkit-browse-url-fn))
 
   (cond ((featurep! :completion helm)
          (require 'helm-dash nil t))


### PR DESCRIPTION
## Description

Add Dash docsets + Xwidget integration. We can see Dash docsets in Embedded Webkit Widgets.

<img width="375" alt="Screen Shot 2020-05-07 at 1 05 29" src="https://user-images.githubusercontent.com/11665236/81200557-13cf3300-8fff-11ea-8dfb-5f290234f3ac.png">
