### PR TITLE
Bump :ui

### DIFF
--- a/modules/ui/doom/packages.el
+++ b/modules/ui/doom/packages.el
@@ -1,5 +1,5 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; ui/doom/packages.el
 
-(package! doom-themes :pin "254d476dd6790eaa6b563c5a4da286321ff75d38")
+(package! doom-themes :pin "34f181c290d2c9fb9628e4ec85c16e633931ede1")
 (package! solaire-mode :pin "adc8c0c60d914f6395eba0bee78feedda128b30b")


### PR DESCRIPTION
This PR bump the `doom-theme` pin so one can now use the Gruvbox Light Theme.

Also, is there a reason why this packaged is pinned to a specific version?