### PR TITLE
Allow +vterm/toggle to open remotely

### DIFF
--- a/modules/term/vterm/autoload.el
+++ b/modules/term/vterm/autoload.el
@@ -34,19 +34,7 @@ If prefix ARG is non-nil, recreate vterm buffer in the current project's root."
         (with-current-buffer buffer
           (unless (eq major-mode 'vterm-mode)
             (vterm-mode))
-          (when (and (featurep 'tramp)
-                     (tramp-tramp-file-p default-directory))
-            (message "default-directory is %s" default-directory)
-            (with-parsed-tramp-file-name default-directory path
-              (let ((method (cadr (assoc `tramp-login-program
-                                         (assoc path-method tramp-methods)))))
-                (vterm-send-string
-                 (concat method " "
-                         (when path-user (concat path-user "@")) path-host))
-                (vterm-send-return)
-                (vterm-send-string
-                 (concat "cd " path-localname))
-                (vterm-send-return)))))
+          (+vterm-open-remote-maybe))
         (pop-to-buffer buffer)))))
 
 ;;;###autoload
@@ -68,7 +56,8 @@ If prefix ARG is non-nil, cd into `default-directory' instead of project root."
              project-root))
          display-buffer-alist)
     (setenv "PROOT" project-root)
-    (vterm)))
+    (vterm)
+    (+vterm-open-remote-maybe)))
 
 
 (defvar +vterm--insert-point nil)

--- a/modules/term/vterm/autoload.el
+++ b/modules/term/vterm/autoload.el
@@ -34,7 +34,7 @@ If prefix ARG is non-nil, recreate vterm buffer in the current project's root."
         (with-current-buffer buffer
           (unless (eq major-mode 'vterm-mode)
             (vterm-mode))
-          (+vterm-open-remote-maybe))
+          (+vterm--change-directory-if-remote))
         (pop-to-buffer buffer)))))
 
 ;;;###autoload
@@ -57,7 +57,24 @@ If prefix ARG is non-nil, cd into `default-directory' instead of project root."
          display-buffer-alist)
     (setenv "PROOT" project-root)
     (vterm)
-    (+vterm-open-remote-maybe)))
+    (+vterm--change-directory-if-remote)))
+
+(defun +vterm--change-directory-if-remote ()
+  "When `default-directory` is remote, use the corresponding
+method to prepare vterm at the corresponding remote directory."
+  (when (and (featurep 'tramp)
+             (tramp-tramp-file-p default-directory))
+    (message "default-directory is %s" default-directory)
+    (with-parsed-tramp-file-name default-directory path
+      (let ((method (cadr (assoc `tramp-login-program
+                                 (assoc path-method tramp-methods)))))
+        (vterm-send-string
+         (concat method " "
+                 (when path-user (concat path-user "@")) path-host))
+        (vterm-send-return)
+        (vterm-send-string
+         (concat "cd " path-localname))
+        (vterm-send-return)))))
 
 
 (defvar +vterm--insert-point nil)

--- a/modules/term/vterm/autoload.el
+++ b/modules/term/vterm/autoload.el
@@ -33,7 +33,20 @@ If prefix ARG is non-nil, recreate vterm buffer in the current project's root."
       (let ((buffer (get-buffer-create buffer-name)))
         (with-current-buffer buffer
           (unless (eq major-mode 'vterm-mode)
-            (vterm-mode)))
+            (vterm-mode))
+          (when (and (featurep 'tramp)
+                     (tramp-tramp-file-p default-directory))
+            (message "default-directory is %s" default-directory)
+            (with-parsed-tramp-file-name default-directory path
+              (let ((method (cadr (assoc `tramp-login-program
+                                         (assoc path-method tramp-methods)))))
+                (vterm-send-string
+                 (concat method " "
+                         (when path-user (concat path-user "@")) path-host))
+                (vterm-send-return)
+                (vterm-send-string
+                 (concat "cd " path-localname))
+                (vterm-send-return)))))
         (pop-to-buffer buffer)))))
 
 ;;;###autoload

--- a/modules/term/vterm/config.el
+++ b/modules/term/vterm/config.el
@@ -19,6 +19,23 @@
     ;; Prevent premature horizontal scrolling
     hscroll-margin 0)
 
+  (defun +vterm-open-remote-maybe ()
+    "When `default-directory` is remote, use the corresponding
+method to prepare vterm at the corresponding remote directory."
+    (when (and (featurep 'tramp)
+               (tramp-tramp-file-p default-directory))
+      (message "default-directory is %s" default-directory)
+      (with-parsed-tramp-file-name default-directory path
+        (let ((method (cadr (assoc `tramp-login-program
+                                   (assoc path-method tramp-methods)))))
+          (vterm-send-string
+           (concat method " "
+                   (when path-user (concat path-user "@")) path-host))
+          (vterm-send-return)
+          (vterm-send-string
+           (concat "cd " path-localname))
+          (vterm-send-return)))))
+
   ;; Restore the point's location when leaving and re-entering insert mode.
   (when (featurep! :editor evil)
     (add-hook! 'vterm-mode-hook

--- a/modules/term/vterm/config.el
+++ b/modules/term/vterm/config.el
@@ -19,23 +19,6 @@
     ;; Prevent premature horizontal scrolling
     hscroll-margin 0)
 
-  (defun +vterm-open-remote-maybe ()
-    "When `default-directory` is remote, use the corresponding
-method to prepare vterm at the corresponding remote directory."
-    (when (and (featurep 'tramp)
-               (tramp-tramp-file-p default-directory))
-      (message "default-directory is %s" default-directory)
-      (with-parsed-tramp-file-name default-directory path
-        (let ((method (cadr (assoc `tramp-login-program
-                                   (assoc path-method tramp-methods)))))
-          (vterm-send-string
-           (concat method " "
-                   (when path-user (concat path-user "@")) path-host))
-          (vterm-send-return)
-          (vterm-send-string
-           (concat "cd " path-localname))
-          (vterm-send-return)))))
-
   ;; Restore the point's location when leaving and re-entering insert mode.
   (when (featurep! :editor evil)
     (add-hook! 'vterm-mode-hook


### PR DESCRIPTION
When `default-directory` is remote, prepare the toggled vterm at remote
location. The added code is taken from `multi-term-switch-buffer` in `multi-term.el`.