### PR TITLE
Add a few Email docs

### DIFF
--- a/modules/email/mu4e/README.org
+++ b/modules/email/mu4e/README.org
@@ -80,7 +80,7 @@ environment.systemPackages = with pkgs; [
 ];
 #+END_SRC
 
-[[https://github.com/Emiller88/dotfiles/blob/master/modules/shell/mail.nix][An example of setting up mbsync with home-manager]]
+[[https://github.com/Emiller88/dotfiles/blob/5eaabedf1b141c80a8d32e1b496055231476f65e/modules/shell/mail.nix][An example of setting up mbsync and mu with home-manager]]
 
 ** openSUSE
 Remove ~#~ in ~#sync_program=offlineimap~ to choose ~offlineimap~ instead of

--- a/modules/email/notmuch/README.org
+++ b/modules/email/notmuch/README.org
@@ -1,0 +1,110 @@
+#+TITLE:   email/notmuch
+#+DATE:    July 31, 2018
+#+SINCE:   v2.0.9
+#+STARTUP: inlineimages
+
+* Table of Contents :TOC:
+- [[#description][Description]]
+  - [[#module-flags][Module Flags]]
+  - [[#plugins][Plugins]]
+- [[#prerequisites][Prerequisites]]
+  - [[#macos][MacOS]]
+  - [[#arch-linux][Arch Linux]]
+  - [[#nixos][NixOS]]
+  - [[#opensuse][openSUSE]]
+  - [[#debianubuntu][Debian/Ubuntu]]
+- [[#features][Features]]
+- [[#configuration][Configuration]]
+  - [[#gmailier][Gmailier]]
+  - [[#offlineimap][offlineimap]]
+  - [[#mbsync][mbsync]]
+  - [[#notmuch][notmuch]]
+- [[#troubleshooting][Troubleshooting]]
+
+* Description
+This module makes Emacs an email client, using ~notmuch~.
+
+** Module Flags
++ This module install no module flags.
+
+
+** Plugins
++ [[https://notmuchmail.org/][notmuch]]
++ [[https://github.com/org-mime/org-mime][org-mime]]
+
+* Prerequisites
+This module requires:
+
++ Either ~gmailieer~ (default), ~mbsync~ or ~offlineimap~ (to sync mail with)
++ ~notmuch~, to index and tag your downloaded messages.
++ ~afew~, optionally to initially tag your downloaded messages.
+
+** TODO MacOS
+
+** TODO Arch Linux
+** NixOS
+#+BEGIN_SRC nix
+environment.systemPackages = with pkgs; [
+    notmuch
+    # And one of the following
+    gmailieer
+    isync
+    offlineimap
+];
+#+END_SRC
+
+[[https://github.com/Emiller88/dotfiles/blob/319841bd3b89e59b01d169137cceee3183aba4fc/modules/shell/mail.nix][An example of setting up mbsync and notmuch with home-manager]]
+
+** TODO openSUSE
+** TODO Debian/Ubuntu
+* TODO Features
+
+* Configuration
+** TODO Gmailier
+** offlineimap
+This module uses =Gmailier= by default. To use =offlineimap=, change ~+notmuch-sync-backend~:
+
+#+BEGIN_SRC emacs-lisp
+(setq +notmuch-sync-backend 'offlineimap)
+#+END_SRC
+
+Next, you need to write a configuration file for =offlineimap=. Mine can be found
+[[https://github.com/hlissner/dotfiles/tree/master/shell/mu][in my dotfiles repository]]. It is configured to download mail to ~\~/.mail~. I
+use [[https://www.passwordstore.org/][unix pass]] to securely store my login credentials. You can find a *very*
+detailed configuration [[https://github.com/OfflineIMAP/offlineimap/blob/master/offlineimap.conf][here]].
+
+Next you can download your email with ~offlineimap -o~. This may take a while,
+especially if you have thousands of mails.
+
+You can now proceed with the [[*mu and mu4e][mu and mu4e]] section.
+
+** mbsync
+This module uses =Gmailier= by default. To use =mbsync=, change ~+notmuch-sync-backend~:
+
+#+BEGIN_SRC emacs-lisp
+(setq +notmuch-sync-backend 'mbsync)
+#+END_SRC
+
+The steps needed to set up =mu4e= with =mbsync= are very similar to the ones for
+[[*offlineimap][offlineimap]].
+
+Start with writing a ~\~/.mbsyncrc~. An example for GMAIL can be found on
+[[http://pragmaticemacs.com/emacs/migrating-from-offlineimap-to-mbsync-for-mu4e/][pragmaticemacs.com]]. A non-GMAIL example is available as a gist [[https://gist.github.com/agraul/60977cc497c3aec44e10591f94f49ef0][here]]. The [[http://isync.sourceforge.net/mbsync.html][manual
+page]] contains all needed information to set up your own.
+
+Next you can download your email with ~mbsync --all~. This may take a while, but
+should be quicker than =offlineimap= ;).
+
+You can now proceed with the [[*mu and mu4e][mu and mu4e]] section.
+
+** notmuch
+You should have your email downloaded already. If you have not, you need to set
+=Gmailier=, =offlineimap= or =mbsync= up before you proceed.
+
+Before you can use =notmuch=, you need to index your email initially.
+
+#+BEGIN_SRC sh
+notmuch new
+#+END_SRC
+
+* Troubleshooting

--- a/modules/email/notmuch/README.org
+++ b/modules/email/notmuch/README.org
@@ -1,6 +1,6 @@
 #+TITLE:   email/notmuch
-#+DATE:    July 31, 2018
-#+SINCE:   v2.0.9
+#+DATE:    May 5, 2019
+#+SINCE:   v2.0
 #+STARTUP: inlineimages
 
 * Table of Contents :TOC:


### PR DESCRIPTION
Made the links to my mail config permalinks since I moved to `mu4e` and add an initial `notmuch` README. I couldn't remember the git magic to find where a module was created, so the date and version are wrong.