### PR TITLE
Unify org-agenda-clock bindings with org-clock

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -707,12 +707,12 @@ between the two."
         :localleader
         "d" #'org-agenda-deadline
         (:prefix ("c" . "clock")
-          "c" #'org-agenda-clock-in
-          "C" #'org-agenda-clock-out
+          "c" #'org-agenda-clock-cancel
           "g" #'org-agenda-clock-goto
+          "i" #'org-agenda-clock-in
+          "o" #'org-agenda-clock-out
           "r" #'org-agenda-clockreport-mode
-          "s" #'org-agenda-show-clocking-issues
-          "x" #'org-agenda-clock-cancel)
+          "s" #'org-agenda-show-clocking-issues)
         "q" #'org-agenda-set-tags
         "r" #'org-agenda-refile
         "s" #'org-agenda-schedule


### PR DESCRIPTION
Following b40d85e9b, make the bindings for the agenda the same