### PR TITLE
lookup: Update docs

### DIFF
--- a/modules/tools/lookup/README.org
+++ b/modules/tools/lookup/README.org
@@ -82,7 +82,7 @@ export PATH="/usr/local/opt/sqlite/bin:$PATH"
 ** Arch Linux
 #+BEGIN_SRC sh
 sudo pacman -S sqlite ripgrep
-sudo yay -S wordnet-cli
+yay -S wordnet-cli
 #+END_SRC
 
 ** NixOS


### PR DESCRIPTION
As the branch name suggests, using `sudo` with `yay` is an anti-pattern and so this fixes that.