### PR TITLE
Add tools/taskrunner module

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -98,6 +98,7 @@
        ;;pdf               ; pdf enhancements
        ;;prodigy           ; FIXME managing external services & code builders
        ;;rgb               ; creating color strings
+       ;;taskrunner        ; taskrunner for all your projects
        ;;terraform         ; infrastructure as code
        ;;tmux              ; an API for interacting with tmux
        ;;upload            ; map local to remote projects via ssh/ftp

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -209,9 +209,13 @@
        :desc "Search project for symbol"   "." #'+default/search-project-for-symbol-at-point
        :desc "Find file in other project"  "F" #'doom/find-file-in-other-project
        :desc "Search project"              "s" #'+default/search-project
-       :desc "List project tasks"          "t" #'magit-todos-list
+       :desc "List project todos"          "t" #'magit-todos-list
        :desc "Open project scratch buffer" "x" #'doom/open-project-scratch-buffer
        :desc "Switch to project scratch buffer" "X" #'doom/switch-to-project-scratch-buffer
+       (:when (and (featurep! :tools taskrunner)
+                   (or (featurep! :completion ivy)
+                       (featurep! :completion helm)))
+        :desc "List project tasks"         "z" #'+taskrunner/project-tasks)
        ;; later expanded by projectile
        (:prefix ("4" . "in other window"))
        (:prefix ("5" . "in other frame")))

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -573,10 +573,14 @@
        :desc "Find recent project files"    "r" #'projectile-recentf
        :desc "Run project"                  "R" #'projectile-run-project
        :desc "Save project files"           "s" #'projectile-save-project-buffers
-       :desc "List project tasks"           "t" #'magit-todos-list
+       :desc "List project todos"           "t" #'magit-todos-list
        :desc "Test project"                 "T" #'projectile-test-project
        :desc "Pop up scratch buffer"        "x" #'doom/open-project-scratch-buffer
-       :desc "Switch to scratch buffer"     "X" #'doom/switch-to-project-scratch-buffer)
+       :desc "Switch to scratch buffer"     "X" #'doom/switch-to-project-scratch-buffer
+       (:when (and (featurep! :tools taskrunner)
+                   (or (featurep! :completion ivy)
+                       (featurep! :completion helm)))
+        :desc "List project tasks"          "z" #'+taskrunner/project-tasks))
 
       ;;; <leader> q --- quit/session
       (:prefix-map ("q" . "quit/session")

--- a/modules/tools/taskrunner/README.org
+++ b/modules/tools/taskrunner/README.org
@@ -1,0 +1,38 @@
+#+TITLE:   tools/taskrunner
+#+DATE:    November 9, 2019
+#+SINCE:   {replace with next tagged release version}
+#+STARTUP: inlineimages
+
+* Table of Contents :TOC_3:noexport:
+- [[#description][Description]]
+  - [[#module-flags][Module Flags]]
+  - [[#plugins][Plugins]]
+- [[#prerequisites][Prerequisites]]
+- [[#features][Features]]
+- [[#configuration][Configuration]]
+- [[#troubleshooting][Troubleshooting]]
+
+* Description
+This module integrates [[https://github.com/emacs-taskrunner/emacs-taskrunner][Taskrunner]] into Doom Emacs, which scraps runnable tasks
+from build systems like make, gradle, npm and the like.
+
+** Module Flags
+This module provides no flags.
+
+** Plugins
++ [[https://github.com/emacs-taskrunner/emacs-taskrunner][emacs-taskrunner]]
++ [[https://github.com/emacs-taskrunner/ivy-taskrunner][ivy-taskrunner]]
++ [[https://github.com/emacs-taskrunner/helm-taskrunner][helm-taskrunner]]
+
+* Prerequisites
+This module has no prereqisites.
+
+* Features
+Keybindings
+
+| Binding | Description          |
+| ~p z~   | ~List project tasks~ |
+
+* Configuration
+
+* Troubleshooting

--- a/modules/tools/taskrunner/autoload.el
+++ b/modules/tools/taskrunner/autoload.el
@@ -1,0 +1,9 @@
+;;; app/taskrunner/autoload.el -*- lexical-binding: t; -*-
+
+;;;###autoload
+(defun +taskrunner/project-tasks ()
+  "Invokes `ivy-taskrunner' or `helm-tasksrunner', depending on which is
+available."
+  (interactive)
+  (cond ((featurep! :completion ivy) (ivy-taskrunner))
+        ((featurep! :completion helm) (helm-taskrunner))))

--- a/modules/tools/taskrunner/config.el
+++ b/modules/tools/taskrunner/config.el
@@ -1,0 +1,11 @@
+;;; tools/taskrunner/config.el -*- lexical-binding: t; -*-
+
+(use-package! helm-taskrunner
+  :when (featurep! :completion helm)
+  :defer t
+  :config (helm-taskrunner-minor-mode +1))
+
+(use-package! ivy-taskrunner
+  :when (featurep! :completion ivy)
+  :defer t
+  :config (ivy-taskrunner-minor-mode +1))

--- a/modules/tools/taskrunner/packages.el
+++ b/modules/tools/taskrunner/packages.el
@@ -1,0 +1,14 @@
+;; -*- no-byte-compile: t; -*-
+;;; tools/taskrunner/packages.el
+
+(package! taskrunner :pin "716323aff410b4d864d137c9ebe4bbb5b8587f5e")
+
+(when (featurep! :completion helm)
+  (package! helm-taskrunner
+    :pin "70ef8117aafdc01a1f06151a82cecb9a2fcf4d32"
+    :recipe (:host github :repo "emacs-taskrunner/helm-taskrunner")))
+
+(when (featurep! :completion ivy)
+  (package! ivy-taskrunner
+    :pin "c731ee6279f65061ef70e79d3818ea1d9678e6da"
+    :recipe (:host github :repo "emacs-taskrunner/ivy-taskrunner")))


### PR DESCRIPTION
## Description

This is a rework for #2035.

### Changes from the original PR

- Prefer longer commit hashes to pin packages
- Fix conflicts with the latest `develop`
- Fix some indentation
- Fix arguments for `helm-taskrunner-minor-mode`, `ivy-taskrunner-minor-mode`
- Remove unnecessary file diffs
- Defer loading `taskrunner`, `helm-taskrunner`, `ivy-taskrunner`
- Move `+default/project-tasks` to taskrunner module