### PR TITLE
tools/lookup: Support lookup handlers for implementations and type definition

### DIFF
--- a/modules/tools/lookup/config.el
+++ b/modules/tools/lookup/config.el
@@ -3,6 +3,8 @@
 ;; "What am I looking at?" This module helps you answer this question.
 ;;
 ;;   + `+lookup/definition': a jump-to-definition that should 'just work'
+;;   + `+lookup/implementations': find a symbol's implementations in the current
+;;                                project
 ;;   + `+lookup/references': find a symbol's references in the current project
 ;;   + `+lookup/file': open the file referenced at point
 ;;   + `+lookup/online'; look up a symbol on online resources
@@ -46,6 +48,15 @@ Used by `+lookup/online'.")
   "Functions for `+lookup/definition' to try, before resorting to `dumb-jump'.
 Stops at the first function to return non-nil or change the current
 window/point.
+
+If the argument is interactive (satisfies `commandp'), it is called with
+`call-interactively' (with no arguments). Otherwise, it is called with one
+argument: the identifier at point. See `set-lookup-handlers!' about adding to
+this list.")
+
+(defvar +lookup-implementations-functions ()
+  "Function for `+lookup/implementations' to try. Stops at the first function to
+return non-nil or change the current window/point.
 
 If the argument is interactive (satisfies `commandp'), it is called with
 `call-interactively' (with no arguments). Otherwise, it is called with one

--- a/modules/tools/lookup/config.el
+++ b/modules/tools/lookup/config.el
@@ -63,6 +63,15 @@ If the argument is interactive (satisfies `commandp'), it is called with
 argument: the identifier at point. See `set-lookup-handlers!' about adding to
 this list.")
 
+(defvar +lookup-type-definition-functions ()
+  "Functions for `+lookup/type-definition' to try. Stops at the first function to
+return non-nil or change the current window/point.
+
+If the argument is interactive (satisfies `commandp'), it is called with
+`call-interactively' (with no arguments). Otherwise, it is called with one
+argument: the identifier at point. See `set-lookup-handlers!' about adding to
+this list.")
+
 (defvar +lookup-references-functions
   '(+lookup-xref-references-backend-fn
     +lookup-project-search-backend-fn)

--- a/modules/tools/lsp/config.el
+++ b/modules/tools/lsp/config.el
@@ -54,6 +54,7 @@ working on that project after closing the last buffer.")
   (set-lookup-handlers! 'lsp-mode :async t
     :documentation #'lsp-describe-thing-at-point
     :definition #'lsp-find-definition
+    :implementations #'lsp-find-implementation
     :references #'lsp-find-references)
 
   ;; TODO Lazy load these. They don't need to be loaded all at once unless the
@@ -189,6 +190,7 @@ auto-killed (which is a potentially expensive process)."
   (when (featurep! +peek)
     (set-lookup-handlers! 'lsp-ui-mode :async t
       :definition 'lsp-ui-peek-find-definitions
+      :implementations 'lsp-ui-peek-find-implementation
       :references 'lsp-ui-peek-find-references)))
 
 

--- a/modules/tools/lsp/config.el
+++ b/modules/tools/lsp/config.el
@@ -55,6 +55,7 @@ working on that project after closing the last buffer.")
     :documentation #'lsp-describe-thing-at-point
     :definition #'lsp-find-definition
     :implementations #'lsp-find-implementation
+    :type-definition #'lsp-find-type-definition
     :references #'lsp-find-references)
 
   ;; TODO Lazy load these. They don't need to be loaded all at once unless the


### PR DESCRIPTION
## Description

Support lookup handlers for implementations and type definition.
I didn't still add key bindings for them.

https://github.com/hlissner/doom-emacs/issues/2579