### PR TITLE
Update README to point to new elixir-ls org

### DIFF
--- a/modules/lang/elixir/README.org
+++ b/modules/lang/elixir/README.org
@@ -16,10 +16,10 @@
 
 * Description
 This module provides support for [[https://elixir-lang.org/][Elixir programming language]] via [[https://github.com/tonini/alchemist.el][alchemist.el]]
-or [[https://github.com/JakeBecker/elixir-ls/][elixir-ls]].
+or [[https://github.com/elixir-lsp/elixir-ls/][elixir-ls]].
 
 ** Module flags
-+ ~+lsp~ Enable LSP support. Requires [[https://github.com/JakeBecker/elixir-ls/][elixir-ls]].
++ ~+lsp~ Enable LSP support. Requires [[https://github.com/elixir-lsp/elixir-ls/][elixir-ls]].
 
 ** Plugins
 + [[https://github.com/elixir-editors/emacs-elixir][elixir-mode]]


### PR DESCRIPTION
Now that the JakeBecker project has been [moved](https://github.com/JakeBecker/elixir-ls/commit/9d4c1485e951b7ebdc0ed5b4f521451c5c99ad68), update the README.