### PR TITLE
Revert "Fix #3090: distinguish C-i from TAB"

### DIFF
--- a/core/core-keybinds.el
+++ b/core/core-keybinds.el
@@ -30,14 +30,6 @@ and Emacs states, and for non-evil users.")
   (setq mac-command-modifier 'super
         mac-option-modifier 'meta))
 
-;; HACK Emacs cannot distinguish C-i from TAB, which is disturbing. Instead,
-;;      let's at least make GUI Emacs aware of this distinction:
-(define-key key-translation-map [?\C-i]
-  (λ! (if (and (not (cl-position 'tab    (this-single-command-raw-keys)))
-               (not (cl-position 'kp-tab (this-single-command-raw-keys)))
-               (display-graphic-p))
-          [C-i] [?\C-i])))
-
 
 ;;
 ;;; Universal, non-nuclear escape


### PR DESCRIPTION
This reverts commit 63ab88105f7c64b9b3e59546906ec5fe5857303a.

This commit introduced breakages in file opening and completion.

Fixes #3098