### PR TITLE
Change path separator on Windows when using fd

### DIFF
--- a/core/core-projects.el
+++ b/core/core-projects.el
@@ -146,8 +146,9 @@ c) are not valid projectile projects."
    ;; .gitignore. This is recommended in the projectile docs.
    ((executable-find doom-projectile-fd-binary)
     (setq projectile-generic-command
-          (format "%s . -0 -H -E .git --color=never --type file --type symlink --follow"
-                  doom-projectile-fd-binary)
+          (concat (format "%s . -0 -H -E .git --color=never --type file --type symlink --follow"
+                          doom-projectile-fd-binary)
+                  (if IS-WINDOWS " --path-separator=/"))
           projectile-git-command projectile-generic-command
           projectile-git-submodule-command nil
           ;; ensure Windows users get fd's benefits

--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -265,9 +265,9 @@ evil-ex-specific constructs, so we disable it solely in evil-ex."
     :override #'counsel--find-return-list
     (cl-destructuring-bind (find-program . args)
         (cond ((executable-find doom-projectile-fd-binary)
-               (cons doom-projectile-fd-binary
-                     (list "--color=never" "-E" ".git"
-                           "--type" "file" "--type" "symlink" "--follow")))
+               (append (list doom-projectile-fd-binary
+                             "--color=never" "-E" ".git" "--type" "file" "--type" "symlink" "--follow")
+                       (if IS-WINDOWS '("--path-separator=/"))))
               ((executable-find "rg")
                (append (list "rg" "--files" "--follow" "--color=never" "--hidden" "--no-messages")
                        (cl-loop for dir in projectile-globally-ignored-directories


### PR DESCRIPTION
Show slash instead of backslash