### PR TITLE
Bind evil-jump-forward for <C-i> on Emacs GUI

### DIFF
--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -59,6 +59,12 @@ directives. By default, this only recognizes C directives.")
 
   (put 'evil-define-key* 'lisp-indent-function 'defun)
 
+  ;; evil binds C-i to evil-jump-forward, but we translate C-i
+  ;; to <C-i> to distinguish TAB from C-i in GUI Emacs.
+  ;; Ref commit 63ab88105f7c64b9b3e59546906ec5fe5857303a
+  (when (display-graphic-p)
+    (define-key evil-motion-state-map (kbd "<C-i>") 'evil-jump-forward))
+
   ;; stop copying each visual state move to the clipboard:
   ;; https://bitbucket.org/lyro/evil/issue/336/osx-visual-state-copies-the-region-on
   ;; grokked from:


### PR DESCRIPTION
After translating C-i to <C-i> in commit 63ab88 to distinguish C-i from
TAB, the binding for evil-jump-forward no longer works.