### PR TITLE
Enable projectile integration for pipenv.el

### DIFF
--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -198,7 +198,7 @@ called.")
 (use-package! pipenv
   :commands pipenv-project-p
   :hook (python-mode . pipenv-mode)
-  :init (setq pipenv-with-projectile nil)
+  :init
   :config
   (set-eval-handler! 'python-mode
     '((:command . (lambda () python-shell-interpreter))


### PR DESCRIPTION
Previously it was disabled by setting pipenv-with-projectile
to nil as described here:

https://github.com/pwalsh/pipenv.el#projectile

Relevant to #1666