### PR TITLE
Remove redundant quote in bound-and-true-p

### DIFF
--- a/modules/config/default/autoload/files.el
+++ b/modules/config/default/autoload/files.el
@@ -28,14 +28,14 @@
 (defun +default/browse-notes ()
   "Browse files from `org-directory'."
   (interactive)
-  (unless (bound-and-true-p 'org-directory)
+  (unless (bound-and-true-p org-directory)
     (require 'org))
   (doom-project-browse org-directory))
 ;;;###autoload
 (defun +default/find-in-notes ()
   "Find a file under `org-directory', recursively."
   (interactive)
-  (unless (bound-and-true-p 'org-directory)
+  (unless (bound-and-true-p org-directory)
     (require 'org))
   (doom-project-find-file org-directory))
 


### PR DESCRIPTION
This commit removes a quote from commit
06b3439627688e29470d573b24dba87e412026c3

Before, I got this error:

```
Debugger entered--Lisp error: (wrong-type-argument symbolp (quote org-directory))
  boundp((quote org-directory))
  (and (boundp (quote (quote org-directory))) (quote org-directory))
  (if (and (boundp (quote (quote org-directory))) (quote org-directory)) nil (require (quote org)))
  +default/find-in-notes()
  funcall-interactively(+default/find-in-notes)
  call-interactively(+default/find-in-notes nil nil)
  command-execute(+default/find-in-notes)
```