### PR TITLE
Update CLI help text to reflect removal of `rebuild` command

### DIFF
--- a/core/cli/byte-compile.el
+++ b/core/cli/byte-compile.el
@@ -11,7 +11,7 @@
 
 Accepts :core and :private as special arguments, which target Doom's core files
 and your private config files, respectively. To recompile your packages, use
-'doom rebuild' instead."
+'doom build' instead."
   (doom-cli-byte-compile targets recompile-p))
 
 (defcli! clean ()


### PR DESCRIPTION
AIUI 873fc5c0db4876d9e1f347fa6cbd2a3a1933df69 removed the `rebuild` alias for `build`