### PR TITLE
Do not set `mu4e-attachment-dir` by default

### DIFF
--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -18,7 +18,6 @@
             (version< mu4e-mu-version "1.4"))
     (setq mu4e-maildir "~/.mail"
           mu4e-user-mail-address-list nil))
-  (setq mu4e-attachment-dir "~/.mail/.attachments")
   :config
   (pcase +mu4e-backend
     (`mbsync


### PR DESCRIPTION
as it will be extended to "~/.mail/~/.mail/.attachments".

Furthermore, I doubt that everyone has a specific, central directory for attachments.