### PR TITLE
Wrap flyspell-correct-at-point in feature check

### DIFF
--- a/modules/checkers/spell/config.el
+++ b/modules/checkers/spell/config.el
@@ -87,6 +87,7 @@ e.g. proselint and langtool."
 
 (use-package! flyspell-correct
   :commands flyspell-correct-at-point flyspell-correct-previous
+  :general ([remap ispell-word] #'flyspell-correct-at-point)
   :config
   (cond ((and (featurep! :completion helm)
               (require 'flyspell-correct-helm nil t)))

--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -497,7 +497,6 @@ To change these keys see `+evil-repeat-keys'."
         :n "gr" #'elfeed-search-update--force
         :n "gR" #'elfeed-search-fetch))
 
-      :nv "z="    #'flyspell-correct-at-point
       ;; custom evil keybinds
       :nv "zn"    #'+evil:narrow-buffer
       :n  "zN"    #'doom/widen-indirectly-narrowed-buffer


### PR DESCRIPTION
`flyspell-correct-at-point` is not defined unless the the `spell` module is enabled.