### PR TITLE
remove ob-rust

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -8,6 +8,7 @@
     (sh . shell)
     (bash . shell)
     (matlab . octave)
+    (rust . rustic-babel)
     (amm . ammonite))
   "An alist mapping languages to babel libraries. This is necessary for babel
 libraries (ob-*.el) that don't match the name of the language.

--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -94,8 +94,6 @@
     :pin "d8fd51bddb019b0eb68755255f88fc800cfe03cb"))
 (when (featurep! :lang rest)
   (package! ob-restclient :pin "f7449b2068498fe9d8ab9589e0a638148861533f"))
-(when (featurep! :lang rust)
-  (package! ob-rust :pin "6a82587598cd097e9642be916243c31f1231b24a"))
 (when (featurep! :lang scala)
   (package! ob-ammonite :pin "39937dff395e70aff76a4224fa49cf2ec6c57cca"))
 


### PR DESCRIPTION
I noticed that doom-emacs now uses rustic for org-babel so I guess ob-rust is not needed anymore.