### PR TITLE
Minimap Module

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -33,6 +33,7 @@
        hl-todo           ; highlight TODO/FIXME/NOTE/DEPRECATED/HACK/REVIEW
        ;;hydra
        ;;indent-guides     ; highlighted indent columns
+       ;;minimap           ; show a map of the code on the side
        modeline          ; snazzy, Atom-inspired modeline, plus API
        ;;nav-flash         ; blink cursor line after big motions
        ;;neotree           ; a project drawer, like NERDTree for vim
@@ -47,7 +48,6 @@
        ;;window-select     ; visually switch windows
        workspaces        ; tab emulation, persistence & separate workspaces
        ;;zen               ; distraction-free coding or writing
-       ;;minimap           ; show a map of the code on the side
 
        :editor
        (evil +everywhere); come to the dark side, we have cookies

--- a/init.example.el
+++ b/init.example.el
@@ -47,6 +47,7 @@
        ;;window-select     ; visually switch windows
        workspaces        ; tab emulation, persistence & separate workspaces
        ;;zen               ; distraction-free coding or writing
+       ;;minimap           ; show a map of the code on the side
 
        :editor
        (evil +everywhere); come to the dark side, we have cookies

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -259,6 +259,8 @@
         :desc "Flycheck"                   "f" #'flycheck-mode)
        (:when (featurep! :ui indent-guides)
         :desc "Indent guides"              "i" #'highlight-indent-guides-mode)
+       (:when (featurep! :ui minimap)
+        :desc "Minimap mode"               "m" #'minimap-mode)
        (:when (featurep! :lang org +present)
         :desc "org-tree-slide mode"        "p" #'+org-present/start)
        :desc "Read-only mode"               "r" #'read-only-mode
@@ -267,9 +269,7 @@
        (:when (featurep! :lang org +pomodoro)
         :desc "Pomodoro timer"             "t" #'org-pomodoro)
        (:when (featurep! :ui zen)
-        :desc "Zen mode"                   "z" #'writeroom-mode)
-       (:when (featurep! :ui minimap)
-        :desc "Minimap mode"               "m" #'minimap-mode))
+        :desc "Zen mode"                   "z" #'writeroom-mode))
 
       ;;; <leader> v --- versioning
       (:prefix-map ("v" . "versioning")

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -267,7 +267,9 @@
        (:when (featurep! :lang org +pomodoro)
         :desc "Pomodoro timer"             "t" #'org-pomodoro)
        (:when (featurep! :ui zen)
-        :desc "Zen mode"                   "z" #'writeroom-mode))
+        :desc "Zen mode"                   "z" #'writeroom-mode)
+       (:when (featurep! :ui minimap)
+        :desc "Minimap mode"               "m" #'minimap-mode))
 
       ;;; <leader> v --- versioning
       (:prefix-map ("v" . "versioning")

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -655,7 +655,8 @@
        :desc "Soft line wrapping"           "w" #'visual-line-mode
        (:when (featurep! :editor word-wrap)
         :desc "Soft line wrapping"         "w" #'+word-wrap-mode)
-       :desc "Zen mode"                     "z" #'writeroom-mode))
+       :desc "Zen mode"                     "z" #'writeroom-mode
+       :desc "Minimap"                      "m" #'minimap-mode))
 
 (after! which-key
   (let ((prefix-re (regexp-opt (list doom-leader-key doom-leader-alt-key))))

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -645,6 +645,8 @@
         :desc "Indent guides"              "i" #'highlight-indent-guides-mode)
        :desc "Indent style"                 "I" #'doom/toggle-indent-style
        :desc "Line numbers"                 "l" #'doom/toggle-line-numbers
+       (:when (featurep! :ui zen)
+        :desc "Minimap"                      "m" #'minimap-mode)
        (:when (featurep! :lang org +present)
         :desc "org-tree-slide mode"        "p" #'org-tree-slide-mode)
        :desc "Read-only mode"               "r" #'read-only-mode
@@ -655,8 +657,8 @@
        :desc "Soft line wrapping"           "w" #'visual-line-mode
        (:when (featurep! :editor word-wrap)
         :desc "Soft line wrapping"         "w" #'+word-wrap-mode)
-       :desc "Zen mode"                     "z" #'writeroom-mode
-       :desc "Minimap"                      "m" #'minimap-mode))
+       (:when (featurep! :ui zen)
+        :desc "Zen mode"                     "z" #'writeroom-mode)))
 
 (after! which-key
   (let ((prefix-re (regexp-opt (list doom-leader-key doom-leader-alt-key))))

--- a/modules/ui/minimap/README.org
+++ b/modules/ui/minimap/README.org
@@ -1,0 +1,48 @@
+#+TITLE:   Minimap
+#+DATE:    May 8, 2020
+#+SINCE:   v2.0
+#+STARTUP: inlineimages nofold
+
+* Table of Contents :TOC_3:noexport:
+- [[#description][Description]]
+  - [[#maintainers][Maintainers]]
+  - [[#module-flags][Module Flags]]
+  - [[#plugins][Plugins]]
+  - [[#hacks][Hacks]]
+- [[#features][Features]]
+- [[#configuration][Configuration]]
+- [[#troubleshooting][Troubleshooting]]
+  - [[#scrolling-is-slowlaggy][Scrolling is slow/laggy]]
+  - [[#minimap-doesnt-close-when-disabled][Minimap doesn't close when disabled]]
+
+* Description
+This module adds a minimap to the right side of Emacs, similar to the feature
+found in many other editors.
+
+** Maintainers
++ [[https://github.com/rushsteve1][@rushsteve1]] (Author)
+
+** Module Flags
+This module provides no flags.
+
+** Plugins
++ [[https://elpa.gnu.org/packages/minimap.html][minimap.el]]
+
+** Hacks
++ The colors used by the minimap are terrible so are overridden with
+  =custom-set-faces!= using colors out of the current DOOM theme.
+ 
+* Features
+A minimap which provides an overview of the current buffer to the side,
+displaying the currently visible region and the current line. You can left-click
+and drag to scroll along the buffer, or right-click anywhere to jump to there.
+
+* Configuration
+There are a number of options provided by the =minimap.el= package this module
+is based on. The easiest way to see all of them is =SPC h v minimap=.
+
+* Troubleshooting
+** Scrolling is slow/laggy
+Disable the minimap using =SPC t m=
+
+** TODO Minimap doesn't close when disabled

--- a/modules/ui/minimap/README.org
+++ b/modules/ui/minimap/README.org
@@ -1,6 +1,6 @@
-#+TITLE:   Minimap
+#+TITLE:   :ui minimap
 #+DATE:    May 8, 2020
-#+SINCE:   v2.0
+#+SINCE:   v3.0.0
 #+STARTUP: inlineimages nofold
 
 * Table of Contents :TOC_3:noexport:
@@ -8,7 +8,6 @@
   - [[#maintainers][Maintainers]]
   - [[#module-flags][Module Flags]]
   - [[#plugins][Plugins]]
-  - [[#hacks][Hacks]]
 - [[#features][Features]]
 - [[#configuration][Configuration]]
 - [[#troubleshooting][Troubleshooting]]
@@ -28,10 +27,6 @@ This module provides no flags.
 ** Plugins
 + [[https://elpa.gnu.org/packages/minimap.html][minimap.el]]
 
-** Hacks
-+ The colors used by the minimap are terrible so are overridden with
-  =custom-set-faces!= using colors out of the current DOOM theme.
- 
 * Features
 A minimap which provides an overview of the current buffer to the side,
 displaying the currently visible region and the current line. You can left-click

--- a/modules/ui/minimap/config.el
+++ b/modules/ui/minimap/config.el
@@ -1,0 +1,14 @@
+;;; ~/Nextcloud/Dotfiles/doom/minimap/config.el -*- lexical-binding: t; -*-
+
+(use-package! minimap
+  :hook doom-load-theme-hook
+  :config
+  (setq minimap-window-location 'right
+        minimap-update-delay 0
+        minimap-width-fraction 0.09
+        minimap-minimum-width 15)
+  (custom-set-faces!
+    `(minimap-current-line-face
+      :background ,(doom-color 'selection))
+    `(minimap-active-region-background
+      :background ,(doom-color 'vertical-bar))))

--- a/modules/ui/minimap/config.el
+++ b/modules/ui/minimap/config.el
@@ -1,4 +1,4 @@
-;;; ~/Nextcloud/Dotfiles/doom/minimap/config.el -*- lexical-binding: t; -*-
+;;; ui/minimap/config.el -*- lexical-binding: t; -*-
 
 (use-package! minimap
   :hook doom-load-theme-hook

--- a/modules/ui/minimap/config.el
+++ b/modules/ui/minimap/config.el
@@ -6,9 +6,4 @@
   (setq minimap-window-location 'right
         minimap-update-delay 0
         minimap-width-fraction 0.09
-        minimap-minimum-width 15)
-  (custom-set-faces!
-    `(minimap-current-line-face
-      :background ,(doom-color 'selection))
-    `(minimap-active-region-background
-      :background ,(doom-color 'vertical-bar))))
+        minimap-minimum-width 15))

--- a/modules/ui/minimap/config.el
+++ b/modules/ui/minimap/config.el
@@ -1,7 +1,7 @@
 ;;; ui/minimap/config.el -*- lexical-binding: t; -*-
 
 (use-package! minimap
-  :hook doom-load-theme-hook
+  :defer t
   :config
   (setq minimap-window-location 'right
         minimap-update-delay 0

--- a/modules/ui/minimap/packages.el
+++ b/modules/ui/minimap/packages.el
@@ -1,4 +1,4 @@
 ;; -*- no-byte-compile: t; -*-
-;;; ~/Nextcloud/Dotfiles/doom/minimap/packages.el
+;;; ui/minimap/packages.el
 
-(package! minimap)
+(package! minimap :pin "5765245dee97a3c8818fd5cd3db1eca7247fcbbc")

--- a/modules/ui/minimap/packages.el
+++ b/modules/ui/minimap/packages.el
@@ -1,0 +1,4 @@
+;; -*- no-byte-compile: t; -*-
+;;; ~/Nextcloud/Dotfiles/doom/minimap/packages.el
+
+(package! minimap)


### PR DESCRIPTION
Created a new Minimap module based on `minimap.el` from ELPA. The module sets some DOOM-specific config, and better defaults. Also added keybindings for it.

Some things that can be worked on/improved:
- Fix positioning when window split
- Sometimes it doesn't close when `minimap-mode` is disabled
- Adding more major-modes that the minimap will show in, or showing it in all modes (it is currently at the default which is showing in any mode derived from `prog-mode`)