### PR TITLE
Upgrade rustic to fix performance regression

### DIFF
--- a/modules/lang/rust/packages.el
+++ b/modules/lang/rust/packages.el
@@ -1,6 +1,6 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; lang/rust/packages.el
 
-(package! rustic :pin "32a962ab2d3f87bde0e12c4e8975fe73d8ba8579")
+(package! rustic :pin "52b632d161b64bdca3f35e35180af63b668ce9fb")
 (unless (featurep! +lsp)
   (package! racer :pin "a0bdf778f01e8c4b8a92591447257422ac0b455b"))


### PR DESCRIPTION
The `rustic-syntax-propertize` function in rustic (set as
`syntax-propertize-function` in emacs) had a performance regression
(reported in https://github.com/brotzeit/rustic/issues/107) that
caused emacs to effectively lock up every time the viewport changed.
This was fixed upstream in rust-mode by @phillord in
https://github.com/rust-lang/rust-mode/commit/bfe40565753295a4cf8403f4124710acd2827d21,
and ported to rustic by @brotzeit in
https://github.com/brotzeit/rustic/pull/108.

I've confirmed that this version of rustic seems to resolve the issue.