### PR TITLE
Allow the user to override lispyville themes

### DIFF
--- a/modules/editor/lispy/README.org
+++ b/modules/editor/lispy/README.org
@@ -28,19 +28,19 @@ lispy is active
 The default key themes that are set are as follows:
 
 #+BEGIN_SRC emacs-lisp
-(lispyville-set-key-theme
- '((operators normal)
-    c-w
-    (prettify insert)
-    (atom-movement normal visual)
-    slurp/barf-lispy
-    additional
-    additional-insert))
+'((operators normal)
+  c-w
+  (prettify insert)
+  (atom-movement normal visual)
+  slurp/barf-lispy
+  additional
+  additional-insert)
 #+END_SRC
 
-See noctuid's [[https://github.com/noctuid/lispyville/blob/master/README.org][README]] for more info on specific keybindings (starting [[https://github.com/noctuid/lispyville#operators-key-theme][here]]) of
-each key theme. Think of ~lispyville-set-key-theme~ as adding
-~parinfer-extensions~ via ~(setq parinfer-extensions '(blah blah blah))~.
+To change the key themes set ~lispyville-key-theme~. Think of
+~lispyville-key-theme~ as the equivalent of ~parinfer-extensions~. See
+lispyville's [[https://github.com/noctuid/lispyville/blob/master/README.org][README]] for more info on the specific keybindings of each key theme
+(starting [[https://github.com/noctuid/lispyville#operators-key-theme][here]]).
 
 * Prerequisites
 This module has no prerequisites.

--- a/modules/editor/lispy/config.el
+++ b/modules/editor/lispy/config.el
@@ -17,12 +17,14 @@
 (use-package! lispyville
   :when (featurep! :editor evil)
   :hook (lispy-mode . lispyville-mode)
+  :init
+  (setq lispyville-key-theme
+        '((operators normal)
+          c-w
+          (prettify insert)
+          (atom-movement normal visual)
+          slurp/barf-lispy
+          additional
+          additional-insert))
   :config
-  (lispyville-set-key-theme
-   '((operators normal)
-     c-w
-     (prettify insert)
-     (atom-movement normal visual)
-     slurp/barf-lispy
-     additional
-     additional-insert)))
+  (lispyville-set-key-theme))


### PR DESCRIPTION
Currently the list of key themes for lispyville is hardcoded in the package config. The user can add more, but there is no way to unload a theme once it has been loaded.This simple change lets users set their own keys themes by setting `lispyville-key-theme` in their private config.