### PR TITLE
Add the needed migemo variants to the requirements for Japanese input.

### DIFF
--- a/modules/input/japanese/README.org
+++ b/modules/input/japanese/README.org
@@ -35,6 +35,9 @@ This module provides no flags.
   a single long line without wanted spaced (when exporting org-mode to html).
 
 * TODO Prerequisites
++ For incremental search with Migemo, one of the following is required:
+  + [[https://github.com/koron/cmigemo][cmigemo]], which is recommended, or
+  + [[http://0xcc.net/migemo/][CVS Head Migemo]]
 * TODO Features
 * TODO Configuration
 * TODO Troubleshooting


### PR DESCRIPTION
I have found that openSUSE's repos don't contain cmigemo, so may as well add the link to the README for Japanese input.

Aside from that everything seems to work out of the box.