### PR TITLE
[:ui doom] Add -solaire flag to disable solaire-mode

### DIFF
--- a/modules/ui/doom/README.org
+++ b/modules/ui/doom/README.org
@@ -26,7 +26,8 @@ This module gives Doom its signature look: powered by the =doom-one= theme
 + File-visiting buffers are slightly brighter (thanks to solaire-mode)
 
 ** Module Flags
-This module provides no flags.
++ =-solaire= disables [[https://github.com/hlissner/emacs-solaire-mode][solaire-mode]] integration (useful when you want to have a
+  single emacs daemon serve both GUI and TTY emacsen)
 
 ** Plugins
 + [[https://github.com/hlissner/emacs-doom-themes][doom-themes]]

--- a/modules/ui/doom/config.el
+++ b/modules/ui/doom/config.el
@@ -23,7 +23,7 @@
 
 
 (use-package! solaire-mode
-  :when (or (daemonp) (display-graphic-p))
+  :when (and (not (featurep! -solaire)) (or (daemonp) (display-graphic-p)))
   :hook (doom-load-theme . solaire-global-mode)
   :config
   (when (daemonp)
@@ -66,7 +66,7 @@
     ;; HACK The fringe cannot have a buffer-local remapping on Emacs <= 26, so
     ;;      we jump through hoops to reset it (globally) whenever it is likely
     ;;      that the fringe will have lost its background color.
-   
+    
     ;; Prevent color glitches when reloading either DOOM or loading a new theme
     (add-hook! '(doom-load-theme-hook doom-reload-hook) :append
                #'solaire-mode-reset)

--- a/modules/ui/doom/packages.el
+++ b/modules/ui/doom/packages.el
@@ -2,4 +2,5 @@
 ;;; ui/doom/packages.el
 
 (package! doom-themes :pin "34f181c290d2c9fb9628e4ec85c16e633931ede1")
-(package! solaire-mode :pin "adc8c0c60d914f6395eba0bee78feedda128b30b")
+(unless (featurep! -solaire)
+  (package! solaire-mode :pin "adc8c0c60d914f6395eba0bee78feedda128b30b"))


### PR DESCRIPTION
The question comes often enough that providing a flag to disable `solaire-mode` altogether might be a good solution