### PR TITLE
Fix minimap package declaration

### DIFF
--- a/modules/ui/minimap/packages.el
+++ b/modules/ui/minimap/packages.el
@@ -1,4 +1,8 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; ui/minimap/packages.el
 
-(package! minimap :pin "5765245dee97a3c8818fd5cd3db1eca7247fcbbc")
+(package! minimap
+  :recipe (:host github
+           :repo "emacs-straight/minimap"
+           :files ("minimap.el"))
+  :pin "d8850be6fb7b3dbff0cd9b5a04d10a6dcc527326")


### PR DESCRIPTION
The previous pin was based on the ELPA git revision, not the emacs-straight
mirror.
This changes it to explicitly use the emacs-straight mirror (which it should
have been doing anyway) and changes the pin to match.