### PR TITLE
Bump doom-themes version

### DIFF
--- a/modules/ui/doom/packages.el
+++ b/modules/ui/doom/packages.el
@@ -1,5 +1,5 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; ui/doom/packages.el
 
-(package! doom-themes :pin "34f181c290d2c9fb9628e4ec85c16e633931ede1")
+(package! doom-themes :pin "a130617060eed2e48f85f41d107af8db1357a5aa")
 (package! solaire-mode :pin "adc8c0c60d914f6395eba0bee78feedda128b30b")


### PR DESCRIPTION
Updates the Pin of [doom-themes](https://github.com/hlissner/emacs-doom-themes) to the latest, which includes a number of fixes, notably the faces for the minimap.
