### PR TITLE
Fix scoop install instructions

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -318,7 +318,7 @@ be enabled.
 #+end_quote
 
 #+BEGIN_SRC sh
-scoop enable extras
+scoop bucket add extras
 scoop install git emacs ripgrep fd llvm
 #+END_SRC
 


### PR DESCRIPTION
Just tried installing on Windows, you need to use "scoop bucket add extras" not "scoop enable extras"