### PR TITLE
Fix update-fu commit hash

### DIFF
--- a/modules/emacs/undo/packages.el
+++ b/modules/emacs/undo/packages.el
@@ -3,5 +3,5 @@
 
 (if (featurep! +tree)
     (package! undo-tree :pin "5b6df03781495d8a25695d846b0cce496d3d3058")
-  (package! undo-fu :pin "24101b44fe0ea97e880fb14372ef461ac2cec1da")
+  (package! undo-fu :pin "bcf7f92a8da38c18b203aa3a1298fa554afc7b08")
   (package! undo-fu-session :pin "e2043f8350970e1a9ef06a94956a733826cdf32b"))


### PR DESCRIPTION
Somehow the commit [24101b44...](https://gitlab.com/ideasman42/emacs-undo-fu/-/commit/24101b44fe0ea97e880fb14372ef461ac2cec1da) exists in the "Activity" overview on GitLab but not in the actual [git log](https://gitlab.com/ideasman42/emacs-undo-fu/-/commits/master). 
This pr sets the hash to currently most recent commit and fixes the error thrown on `doom upgrade`.