### PR TITLE
better popup for rspec

### DIFF
--- a/modules/lang/ruby/config.el
+++ b/modules/lang/ruby/config.el
@@ -136,10 +136,10 @@
   :mode ("/\\.rspec\\'" . text-mode)
   :init
   (setq rspec-use-spring-when-possible nil)
-  (set-popup-rule! "^\\*\\(rspec-\\)?compilation" :size 0.3 :ttl nil :select t)
   (when (featurep! :editor evil)
     (add-hook 'rspec-mode-hook #'evil-normalize-keymaps))
   :config
+  (set-popup-rule! "^\\*\\(rspec-\\)?compilation" :size 0.3 :ttl nil :select t)
   (setq rspec-use-rvm (executable-find "rvm"))
   (map! :localleader
         :prefix "t"

--- a/modules/lang/ruby/config.el
+++ b/modules/lang/ruby/config.el
@@ -136,6 +136,7 @@
   :mode ("/\\.rspec\\'" . text-mode)
   :init
   (setq rspec-use-spring-when-possible nil)
+  (set-popup-rule! "^\\*\\(rspec-\\)?compilation" :size 0.3 :ttl nil :select t)
   (when (featurep! :editor evil)
     (add-hook 'rspec-mode-hook #'evil-normalize-keymaps))
   :config


### PR DESCRIPTION
Without this tweak, its impossible to see the rspec results without manually up the page.

before
![Captura de tela de 2020-05-20 02-19-27](https://user-images.githubusercontent.com/9551316/82407882-b5637500-9a40-11ea-93d5-2cd2ddb58aa3.png)

after:
![2020-05-20_02-20](https://user-images.githubusercontent.com/9551316/82407908-c1e7cd80-9a40-11ea-8609-f94941b95451.png)
