### PR TITLE
Add google-c-style support to lang/cc

### DIFF
--- a/modules/lang/cc/README.org
+++ b/modules/lang/cc/README.org
@@ -31,6 +31,7 @@ This module adds support for the C-family of languages: C, C++, and Objective-C.
 ** Module Flags
 + ~+lsp~ Disables irony+rtags and replaces them with LSP (ccls by default). This
   requires the =:tools lsp= module.
++ ~+google-c-style~ Prefers [[https://github.com/google/styleguide][google-c-style]] for code-formatting.
 
 ** Plugins
 + [[https://github.com/Kitware/CMake][cmake-mode]]
@@ -52,6 +53,8 @@ This module adds support for the C-family of languages: C, C++, and Objective-C.
   + [[https://github.com/Andersbakken/rtags][rtags]]
   + [[https://github.com/Andersbakken/rtags][ivy-rtags]]
   + [[https://github.com/Andersbakken/rtags][helm-rtags]]
++ =+google-c-style=
+  + [[https://github.com/google/styleguide][google-c-style]]
 
 * Prerequisites
 This module requires

--- a/modules/lang/cc/config.el
+++ b/modules/lang/cc/config.el
@@ -252,3 +252,26 @@ If rtags or rdm aren't available, fail silently instead of throwing a breaking e
                                       "-isystem/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include"
                                       "-isystem/usr/local/include"]
                           :resourceDir (string-trim (shell-command-to-string "clang -print-resource-dir")))))))
+
+
+;;
+;; Google C Style
+
+(when (featurep! +google-c-style)
+  (set-formatter! 'clang-format
+    '("clang-format"
+      ("-assume-filename=%s" (or buffer-file-name mode-result ""))
+      ("-style=Google"))
+    :modes '((c-mode ".c")
+             (c++-mode ".cpp")))
+
+  ;; Enforce Google C++ Style Guide
+  ;; See https://google.github.io/styleguide/cppguide.html
+  (setq-hook! 'c-mode-common-hook
+    tab-width 2
+    fill-column 80))
+
+(use-package! google-c-style
+  :when (featurep! +google-c-style)
+  :hook (c-mode-common . google-set-c-style)
+  :hook (c-mode-common . google-make-newline-indent))

--- a/modules/lang/cc/doctor.el
+++ b/modules/lang/cc/doctor.el
@@ -5,6 +5,10 @@
              (featurep! :tools lsp))
          "This module requires (:tools lsp)")
 
+(assert! (or (not (featurep! +google-c-style))
+             (featurep! :editor format))
+         "This module requires (:editor format)")
+
 (when (require 'rtags nil t)
   ;; rtags
   (when-let (bins (cl-remove-if #'rtags-executable-find

--- a/modules/lang/cc/packages.el
+++ b/modules/lang/cc/packages.el
@@ -30,3 +30,8 @@
       (package! ivy-rtags))
     (when (featurep! :completion helm)
       (package! helm-rtags))))
+
+(when (featurep! +google-c-style)
+  (package! google-c-style
+    :pin "35fd3f01678c63593b80c4abbf1691a79fed2dfe"
+    :recipe (:host github :repo "google/styleguide" :files ("google-c-style.el"))))


### PR DESCRIPTION
## Description

Add `+google-c-style` flag to `lang/cc` module.
https://github.com/google/styleguide/blob/gh-pages/google-c-style.el
