### PR TITLE
Add zen-text-scale to ui/zen/README.org

### DIFF
--- a/modules/ui/zen/README.org
+++ b/modules/ui/zen/README.org
@@ -13,6 +13,7 @@
   - [[#distractions-free-mode][Distractions-free mode]]
 - [[#configuration][Configuration]]
   - [[#enable-fullscreen-on-activation][Enable fullscreen on activation]]
+  - [[#customize-the-text-scaling-factor][Customize the text scaling factor]]
 
 * Description
 This module provides ~writeroom-mode~, which transforms Emacs into a
@@ -49,3 +50,9 @@ non-evil users yet, so use 'M-x writeroom-mode'.
 #+END_SRC
 
 Or fullscreen manually with =SPC t F= (or =F11= for non-evil users).
+** Customize the text scaling factor
+#+BEGIN_SRC elisp
+(setq zen-text-scale 1)
+#+END_SRC
+
+Provide a value of =nil= or =0= to disable text scaling.

--- a/modules/ui/zen/config.el
+++ b/modules/ui/zen/config.el
@@ -3,7 +3,7 @@
 (defvar +zen-mixed-pitch-modes '(markdown-mode org-mode org-journal-mode)
   "What major-modes to enable `mixed-pitch-mode' in with `writeroom-mode'.")
 
-(defvar +zen-text-scale 2
+(defvar zen-text-scale 2
   "The text-scaling level for `writeroom-mode'.")
 
 
@@ -16,11 +16,15 @@
   (setq writeroom-maximize-window nil)
   (remove-hook 'writeroom-global-effects 'writeroom-set-fullscreen)
 
+  ;; Allow setting `zen-text-scale' to `nil'
+  (unless zen-text-scale
+    (setq zen-text-scale 0))
+
   (add-hook! 'writeroom-mode-hook
     (defun +zen-enable-text-scaling-mode-h ()
       "Enable `mixed-pitch-mode' when in `+zen-mixed-pitch-modes'."
-      (when (/= +zen-text-scale 0)
-        (text-scale-set (if writeroom-mode +zen-text-scale 0))
+      (when (/= zen-text-scale 0)
+        (text-scale-set (if writeroom-mode zen-text-scale 0))
         (visual-fill-column-adjust))))
 
   ;; Adjust margins when text size is changed


### PR DESCRIPTION
Allow users to customize the text scaling factor for the `zen` module.

Tested manually by adding `(setq zen-text-scale nil)` to `~/.doom.d/config.el` and verifying that text scaling is disabled.