### PR TITLE
Disable lsp-mode project guessing with projectile

### DIFF
--- a/modules/tools/lsp/config.el
+++ b/modules/tools/lsp/config.el
@@ -15,9 +15,8 @@ working on that project after closing the last buffer.")
   :commands lsp-install-server
   :init
   (setq lsp-session-file (concat doom-etc-dir "lsp-session"))
-  ;; Don't prompt the user for the project root every time we open a new
-  ;; lsp-worthy file, instead, try to guess it with projectile.
-  (setq lsp-auto-guess-root t)
+  ;; Disable automatic project guessing with projectile
+  (setq lsp-auto-guess-root nil)
   ;; Auto-kill LSP server after last workspace buffer is killed.
   (setq lsp-keep-workspace-alive nil)
   ;; Let `flycheck-check-syntax-automatically' determine this.


### PR DESCRIPTION
I think this particular setting should be left off by default just like it is off in the original project.
When your project follows projectile conventions, it's great, but if for some reason your lsp root and projectile root are different it causes really annoying issues.

If this setting is off and lsp-mode can't find the root it just asks the user, whereas if it's left on, as it is now, if lsp-mode can't find the root it just throws an error and offers no solutions. I couldn't get my particular setup to work for quite a while until I disabled it, then everything started working perfectly.

Even lsp-mode source code clearly indicates that this setting should only be used by users who  know what they're doing and understand how lsp-mode works internally, therefore it doesn't seem to be a good default.

> Do *not* use this setting unless you are familiar with `lsp-mode'
internals and you are sure that all of your projects are
following `projectile'/`project.el' conventions."