### PR TITLE
Prevent doom-capture frame from closing when refiling

### DIFF
--- a/modules/lang/org/autoload/org-capture.el
+++ b/modules/lang/org/autoload/org-capture.el
@@ -22,7 +22,8 @@
 ;;;###autoload
 (defun +org-capture-cleanup-frame-h ()
   "Closes the org-capture frame once done adding an entry."
-  (when (+org-capture-frame-p)
+  (when (and (+org-capture-frame-p)
+             (not org-capture-is-refiling))
     (delete-frame nil t)))
 
 ;;;###autoload

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -357,6 +357,10 @@ relative to `org-directory', unless it is an absolute path."
 (defun +org-init-capture-frame-h ()
   (add-hook 'org-capture-after-finalize-hook #'+org-capture-cleanup-frame-h)
 
+  (defadvice! +org-capture-refile-cleanup-frame (&rest _)
+    :after #'org-capture-refile
+    (+org-capture-cleanup-frame-h))
+
   (when (featurep! :ui doom-dashboard)
     (add-hook '+doom-dashboard-inhibit-functions #'+org-capture-frame-p)))
 


### PR DESCRIPTION
Prevents the frame opened by `+org-capture/open-frame` from immediately closing when refiling captured entry (`C-c C-w`).

The cause for the problem is that `org-capture-refile` performs capture finalization which triggers `org-capture-after-finalize-hook` and it causes early frame deletion.