### PR TITLE
Restore new org-agenda bindings

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -751,7 +751,9 @@ between the two."
         :map org-agenda-mode-map
         :m "C-SPC" #'org-agenda-show-and-scroll-up
         :localleader
-        "d" #'org-agenda-deadline
+        (:prefix ("d" . "date/deadline")
+         "d" #'org-agenda-deadline
+         "s" #'org-agenda-schedule)
         (:prefix ("c" . "clock")
          "c" #'org-agenda-clock-cancel
          "g" #'org-agenda-clock-goto
@@ -761,7 +763,6 @@ between the two."
          "s" #'org-agenda-show-clocking-issues)
         "q" #'org-agenda-set-tags
         "r" #'org-agenda-refile
-        "s" #'org-agenda-schedule
         "t" #'org-agenda-todo))
 
 

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -753,12 +753,12 @@ between the two."
         :localleader
         "d" #'org-agenda-deadline
         (:prefix ("c" . "clock")
-         "c" #'org-agenda-clock-in
-         "C" #'org-agenda-clock-out
+         "c" #'org-agenda-clock-cancel
          "g" #'org-agenda-clock-goto
+         "i" #'org-agenda-clock-in
+         "o" #'org-agenda-clock-out
          "r" #'org-agenda-clockreport-mode
-         "s" #'org-agenda-show-clocking-issues
-         "x" #'org-agenda-clock-cancel)
+         "s" #'org-agenda-show-clocking-issues)
         "q" #'org-agenda-set-tags
         "r" #'org-agenda-refile
         "s" #'org-agenda-schedule


### PR DESCRIPTION
These relatively new bindings (#3082) were lost during the rebase performed in #3043. This PR restores these, and also unifies the `org-agenda` bindings for deadline/schedule with the ones from `org-mode`.