### PR TITLE
Add gdscript module

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -122,6 +122,7 @@
        ;;faust             ; dsp, but you get to keep your soul
        ;;fsharp           ; ML stands for Microsoft's Language
        ;;fstar             ; (dependent) types and (monadic) effects and Z3
+       ;;gdscript          ; the language you waited for
        ;;(go +lsp)         ; the hipster dialect
        ;;(haskell +dante)  ; a language that's lazier than I am
        ;;hy                ; readability of scheme w/ speed of python

--- a/modules/lang/gdscript/README.org
+++ b/modules/lang/gdscript/README.org
@@ -1,0 +1,51 @@
+#+TITLE:   lang/gdscript
+#+DATE:    May 27, 2020
+#+SINCE:   v2.0.9
+
+* Table of Contents                                                     :TOC:
+- [[#description][Description]]
+  - [[#module-flags][Module Flags]]
+  - [[#plugins][Plugins]]
+- [[#prerequisites][Prerequisites]]
+- [[#features][Features]]
+- [[#configuration][Configuration]]
+- [[#appendix][Appendix]]
+  - [[#commands][Commands]]
+
+* Description
+
+This module adds support for GDScript, the scripting language of the [[http://godotengine.org/][Godot]] game engine, to Doom Emacs, powered by [[https://github.com/GDQuest/emacs-gdscript-mode][gdscript-mode]].
+
+** Module Flags
++ =+lsp= Enables LSP support for gdscript-mode. This requires the =:tools lsp= module to be enabled
+  and you need to open your project in Godot ~3.2.1~ or above to run the language server.
+
+** Plugins
+This module provides no plugins.
+
+* Prerequisites
+
+To format your GDScript code, you need to install [[https://github.com/Scony/godot-gdscript-toolkit/][gdtoolkit]]:
+
+#+BEGIN_SRC shell
+# On Windows
+pip install gdtoolkit
+
+# On MacOS and Linux
+pip3 install gdtoolkit
+#+END_SRC
+
+* Features
+
+The language server support for GDScript is built into by lsp-mode. As long as you have the ~lsp~ module installed, you should be able to use the language server.
+
+Godot's language server is built into the game engine, so you need to open your project in Godot ~3.2.1~ or above for the GDScript language server to be available.
+
+/Note that the GDScript language server has known issues causing some errors with lsp-mode. They should be addressed in future releases./
+
+* Configuration
+This module provides no configuration.
+
+* Appendix
+** Commands
+Press ~SPC m~ (local leader key) to explore available commands.

--- a/modules/lang/gdscript/config.el
+++ b/modules/lang/gdscript/config.el
@@ -1,0 +1,29 @@
+;;; lang/gdscript/config.el -*- lexical-binding: t; -*-
+
+(after! projectile
+  (add-to-list 'projectile-project-root-files "project.godot"))
+
+(use-package! gdscript-mode
+  :defer t
+  :config
+  (set-lookup-handlers! 'gdscript-mode
+    :documentation #'gdscript-docs-browse-symbol-at-point)
+  (map! :localleader
+        :map gdscript-mode-map
+
+        (:prefix ("r" . "run")
+         "e" #'gdscript-godot-open-project-in-editor
+         "p" #'gdscript-godot-run-project
+         "d" #'gdscript-godot-run-project-debug
+         "s" #'gdscript-godot-run-current-scene)
+
+        (:prefix ("h" . "help")
+         "b" #'gdscript-docs-browse-api
+         "f" #'gdscript-docs-browse-symbol-at-point)
+
+        (:prefix ("f" . "format")
+         "b" #'gdscript-format-buffer
+         "r" #'gdscript-format-region))
+
+  (when (featurep! +lsp)
+    (add-hook 'gdscript-mode-local-vars-hook #'lsp!)))

--- a/modules/lang/gdscript/packages.el
+++ b/modules/lang/gdscript/packages.el
@@ -1,0 +1,4 @@
+;; -*- no-byte-compile: t; -*-
+;;; lang/gdscript/packages.el
+
+(package! gdscript-mode :pin "a52e91c3a63fb17983b71faad2f1e82a56e5875a")


### PR DESCRIPTION
This commit adds the gdscript language module. It's a simple one as we packed all functionality in the gdscript-mode module, and lsp-support is built into lsp-mode.

Would it make sense to e.g. add an automatic lsp mode hook when the lsp module is available? or should there be a `+lsp` for that?

Closes #3229 