### PR TITLE
tools/lsp: Improve eglot support

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -55,7 +55,6 @@
          :desc "Jump to symbol in any workspace"     "J"   #'helm-lsp-global-workspace-symbol))
        (:when (featurep! :tools lsp +eglot)
         :desc "LSP Execute code action"              "a" #'eglot-code-actions
-        :desc "LSP Format buffer/region"             "F" #'eglot-format
         :desc "LSP Rename"                           "r" #'eglot-rename
         :desc "LSP Find declaration"                 "j" #'eglot-find-declaration
         :desc "LSP Find implementation"              "J" #'eglot-find-implementation))

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -34,6 +34,7 @@
        :desc "Evaluate buffer/region"                "e"   #'+eval/buffer-or-region
        :desc "Evaluate & replace region"             "E"   #'+eval/region-and-replace
        :desc "Format buffer/region"                  "f"   #'+format/region-or-buffer
+       :desc "Find implementations"                  "J"   #'+lookup/implementations
        :desc "Jump to documentation"                 "k"   #'+lookup/documentation
        :desc "Send to repl"                          "s"   #'+eval/send-region-to-repl
        :desc "Delete trailing whitespace"            "w"   #'delete-trailing-whitespace
@@ -56,8 +57,7 @@
        (:when (featurep! :tools lsp +eglot)
         :desc "LSP Execute code action"              "a" #'eglot-code-actions
         :desc "LSP Rename"                           "r" #'eglot-rename
-        :desc "LSP Find declaration"                 "j" #'eglot-find-declaration
-        :desc "LSP Find implementation"              "J" #'eglot-find-implementation))
+        :desc "LSP Find declaration"                 "j" #'eglot-find-declaration))
 
       ;;; <leader> f --- file
       (:prefix-map ("f" . "file")

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -34,9 +34,10 @@
        :desc "Evaluate buffer/region"                "e"   #'+eval/buffer-or-region
        :desc "Evaluate & replace region"             "E"   #'+eval/region-and-replace
        :desc "Format buffer/region"                  "f"   #'+format/region-or-buffer
-       :desc "Find implementations"                  "J"   #'+lookup/implementations
+       :desc "Find implementations"                  "i"   #'+lookup/implementations
        :desc "Jump to documentation"                 "k"   #'+lookup/documentation
        :desc "Send to repl"                          "s"   #'+eval/send-region-to-repl
+       :desc "Find type definition"                  "t"   #'+lookup/type-definition
        :desc "Delete trailing whitespace"            "w"   #'delete-trailing-whitespace
        :desc "Delete trailing newlines"              "W"   #'doom/delete-trailing-newlines
        :desc "List errors"                           "x"   #'flymake-show-diagnostics-buffer
@@ -44,7 +45,7 @@
         :desc "List errors"                         "x"   #'flycheck-list-errors)
        (:when (and (featurep! :tools lsp) (not (featurep! :tools lsp +eglot)))
         :desc "LSP Code actions"                      "a"   #'lsp-execute-code-action
-        :desc "LSP Organize imports"                  "i"   #'lsp-organize-imports
+        :desc "LSP Organize imports"                  "o"   #'lsp-organize-imports
         :desc "LSP Rename"                            "r"   #'lsp-rename
         (:after lsp-mode
          :desc "LSP"                                   "l"   lsp-command-map)

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -358,7 +358,6 @@
            :desc "LSP"                                   "l"   lsp-command-map))
         (:when (featurep! :tools lsp +eglot)
           :desc "LSP Execute code action" "a" #'eglot-code-actions
-          :desc "LSP Format buffer/region" "F" #'eglot-format
           :desc "LSP Rename" "r" #'eglot-rename
           :desc "LSP Find declaration" "j" #'eglot-find-declaration
           :desc "LSP Find implementation" "J" #'eglot-find-implementation)

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -346,7 +346,7 @@
       (:prefix-map ("c" . "code")
        (:when (and (featurep! :tools lsp) (not (featurep! :tools lsp +eglot)))
           :desc "LSP Execute code action" "a" #'lsp-execute-code-action
-          :desc "LSP Organize imports" "i" #'lsp-organize-imports
+          :desc "LSP Organize imports" "o" #'lsp-organize-imports
           (:when (featurep! :completion ivy)
             :desc "Jump to symbol in current workspace" "j"   #'lsp-ivy-workspace-symbol
             :desc "Jump to symbol in any workspace"     "J"   #'lsp-ivy-global-workspace-symbol)
@@ -367,9 +367,10 @@
         :desc "Evaluate buffer/region"                "e"   #'+eval/buffer-or-region
         :desc "Evaluate & replace region"             "E"   #'+eval:replace-region
         :desc "Format buffer/region"                  "f"   #'+format/region-or-buffer
-        :desc "Find implementations"                  "J"   #'+lookup/implementations
+        :desc "Find implementations"                  "i"   #'+lookup/implementations
         :desc "Jump to documentation"                 "k"   #'+lookup/documentation
         :desc "Send to repl"                          "s"   #'+eval/send-region-to-repl
+        :desc "Find type definition"                  "t"   #'+lookup/type-definition
         :desc "Delete trailing whitespace"            "w"   #'delete-trailing-whitespace
         :desc "Delete trailing newlines"              "W"   #'doom/delete-trailing-newlines
         :desc "List errors"                           "x"   #'flymake-show-diagnostics-buffer

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -344,7 +344,7 @@
 
       ;;; <leader> c --- code
       (:prefix-map ("c" . "code")
-        (:unless (featurep! :tools lsp +eglot)
+       (:when (and (featurep! :tools lsp) (not (featurep! :tools lsp +eglot)))
           :desc "LSP Execute code action" "a" #'lsp-execute-code-action
           :desc "LSP Organize imports" "i" #'lsp-organize-imports
           (:when (featurep! :completion ivy)

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -359,8 +359,7 @@
         (:when (featurep! :tools lsp +eglot)
           :desc "LSP Execute code action" "a" #'eglot-code-actions
           :desc "LSP Rename" "r" #'eglot-rename
-          :desc "LSP Find declaration" "j" #'eglot-find-declaration
-          :desc "LSP Find implementation" "J" #'eglot-find-implementation)
+          :desc "LSP Find declaration" "j" #'eglot-find-declaration)
         :desc "Compile"                               "c"   #'compile
         :desc "Recompile"                             "C"   #'recompile
         :desc "Jump to definition"                    "d"   #'+lookup/definition
@@ -368,6 +367,7 @@
         :desc "Evaluate buffer/region"                "e"   #'+eval/buffer-or-region
         :desc "Evaluate & replace region"             "E"   #'+eval:replace-region
         :desc "Format buffer/region"                  "f"   #'+format/region-or-buffer
+        :desc "Find implementations"                  "J"   #'+lookup/implementations
         :desc "Jump to documentation"                 "k"   #'+lookup/documentation
         :desc "Send to repl"                          "s"   #'+eval/send-region-to-repl
         :desc "Delete trailing whitespace"            "w"   #'delete-trailing-whitespace

--- a/modules/tools/lsp/+eglot.el
+++ b/modules/tools/lsp/+eglot.el
@@ -17,6 +17,8 @@
   :config
   (set-popup-rule! "^\\*eglot-help" :size 0.35 :quit t :select t)
   (set-lookup-handlers! 'eglot--managed-mode
+    :implementations #'eglot-find-implementation
+    :type-definition #'eglot-find-typeDefinition
     :documentation #'+eglot/documentation-lookup-handler)
   (when (featurep! :checkers syntax)
     (after! flycheck


### PR DESCRIPTION
# Changes

* Fix evil key bindings for LSP shown even when lsp module is not enabled
* Make `SPC c f` use eglot LSP formatter when `+format-with-lsp` is `t` (like lsp-mode)
* Bind general implementation lookup handler

# TODOs

* [x] ~Fix some modules overrides eglot's lookup handlers (e.g. Go)~
-> I do another PR:
   https://github.com/hlissner/doom-emacs/issues/3251