### PR TITLE
Add proper syntax highlighting for Python-related configuration files

### DIFF
--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -17,6 +17,9 @@ called.")
 
 (use-package! python
   :defer t
+  :mode
+  ("\\.flake8" . conf-mode)
+  ("Pipfile$" . conf-mode)
   :init
   (setq python-environment-directory doom-cache-dir
         python-indent-guess-indent-offset-verbose nil)


### PR DESCRIPTION
This pull request will add syntax highlighting for `.flake8` and `Pipfile`. Just a small QOL improvement.