### PR TITLE
Remove space from mc prefix map

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -369,7 +369,7 @@
 
       ;;; <leader> m --- multiple cursors
       (:when (featurep! :editor multiple-cursors)
-       (:prefix-map ("m" . "multiple cursors")
+       (:prefix-map ("m" . "multiple-cursors")
         :desc "Edit lines"         "l"         #'mc/edit-lines
         :desc "Mark next"          "n"         #'mc/mark-next-like-this
         :desc "Unmark next"        "N"         #'mc/unmark-next-like-this


### PR DESCRIPTION
Change the space of the multiple-cursors keymap to a "-".