### PR TITLE
Bump :tools lsp

### DIFF
--- a/modules/tools/lsp/packages.el
+++ b/modules/tools/lsp/packages.el
@@ -2,7 +2,10 @@
 ;;; tools/lsp/packages.el
 
 (if (featurep! +eglot)
-    (package! eglot :pin "ac9239bed5e3bfbf057382d1a75cdfa23f2caddd")
+    (progn
+      (package! eglot :pin "ac9239bed5e3bfbf057382d1a75cdfa23f2caddd")
+      (package! project :recipe (:host github :repo "emacs-straight/project")
+        :pin "da0333a697b18f0a863c1b1523d2fc7991b31174"))
   (package! lsp-mode :pin "d5f0410a88edcbcc183f5877a63b4896fd4f9941")
   (package! lsp-ui :pin "c3e7a3759b52fe0f9c6f0f6668f1d6d88e4f784a")
   (when (featurep! :completion ivy)


### PR DESCRIPTION
Forcefully install the gnu-elpa-mirror recipe of project makes it move
emacsmirror/project@0d31141 (0.1.3) -> emacs-straight/project@da0333a (0.3.0)

Fixes #3269