### PR TITLE
magit: Enable goto-address-mode in process buffer

### DIFF
--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -21,6 +21,7 @@
         ;; add up with each invokation, especially on Catalina (macOS) or
         ;; Windows, so we resolve it once.
         magit-git-executable (executable-find magit-git-executable))
+  (add-hook 'magit-process-mode-hook #'goto-address-mode)
 
   (defadvice! +magit-revert-repo-buffers-deferred-a (&rest _)
     :after '(magit-checkout magit-branch-and-checkout)


### PR DESCRIPTION
This way, URL returned by remote are clickable. e.g.:

```
  0 git … push -v fork refs/heads/magit-goto-address\:refs/heads/magit-goto-address
Poussée vers git@github.com:bersace/doom-emacs.git
Écriture des objets: 100% (6/6), 1.10 KiB | 1.10 MiB/s, fait.
Total 6 (delta 4), réutilisés 0 (delta 0)
remote: Resolving deltas: 100% (4/4), completed with 4 local objects.        
remote: 
remote: Create a pull request for 'magit-goto-address' on GitHub by visiting:        
remote:      https://github.com/bersace/doom-emacs/pull/new/magit-goto-address        
remote: 
To github.com:bersace/doom-emacs.git
 * [new branch]          magit-goto-address -> magit-goto-address
updating local tracking ref 'refs/remotes/fork/magit-goto-address'
```

This is how it shows :

![image](https://user-images.githubusercontent.com/542613/83755111-5c652500-a66d-11ea-81af-9d8c5e7e06f0.png)
