### PR TITLE
spell: Fix missing parenthesis in config.el

### DIFF
--- a/modules/checkers/spell/config.el
+++ b/modules/checkers/spell/config.el
@@ -44,7 +44,7 @@
   (setq flyspell-issue-welcome-flag nil
         ;; Significantly speeds up flyspell, which would otherwise print
         ;; messages for every word when checking the entire buffer
-        flyspell-issue-message-flag nil)
+        flyspell-issue-message-flag nil))
 
 (use-package! flyspell ; built-in
   :defer t


### PR DESCRIPTION
Fixes:

    Warning (initialization): An error occurred while loading ‘/home/.../.emacs.d/init.el’:

    Error in a Doom module: modules/checkers/spell/config.el, (end-of-file /home/.../.emacs.d/modules/checkers/spell/config.el)