### PR TITLE
(org +roam): use org-roam-buffer-window-parameters

### DIFF
--- a/modules/lang/org/contrib/roam.el
+++ b/modules/lang/org/contrib/roam.el
@@ -43,7 +43,7 @@
   (setq org-roam-directory (expand-file-name (or org-roam-directory "roam")
                                              org-directory)
         org-roam-verbose nil  ; https://youtu.be/fn4jIlFwuLU
-        org-roam-buffer-no-delete-other-windows t ; make org-roam buffer sticky
+        org-roam-buffer-window-parameters '((no-delete-other-windows . t)) ; make org-roam buffer sticky
         org-roam-completion-system
         (cond ((featurep! :completion helm) 'helm)
               ((featurep! :completion ivy) 'ivy)


### PR DESCRIPTION
Replaces the now obsolete org-roam-buffer-no-delete-other-windows