### PR TITLE
Add lsp and repl to +light modeline

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -110,7 +110,7 @@
                                      (+modeline-format-icon 'faicon "terminal" "" face label -0.0575)
                                      " "))
           (add-to-list 'global-mode-string
-                       'cider-modeline-icon
+                       '(t (:eval cider-modeline-icon))
                        'append)))))
 
   ;; The CIDER welcome message obscures error messages that the above code is

--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -94,6 +94,25 @@
         (evil-make-overriding-map cider--debug-mode-map 'normal)
         (evil-normalize-keymaps))))
 
+  (when (featurep! :ui modeline +light)
+    (defvar-local cider-modeline-icon nil)
+
+    (add-hook! '(cider-connected-hook
+                 cider-disconnected-hook
+                 cider-mode-hook)
+      (defun +clojure--cider-update-modeline ()
+        "Update modeline with cider connection state."
+        (let* ((connected (cider-connected-p))
+               (face (if connected 'success 'warning))
+               (label (if connected "Cider connected" "Cider disconnected")))
+          (setq cider-modeline-icon (concat
+                                     " "
+                                     (+modeline-format-icon 'faicon "terminal" "" face label -0.0575)
+                                     " "))
+          (add-to-list 'global-mode-string
+                       'cider-modeline-icon
+                       'append)))))
+
   ;; The CIDER welcome message obscures error messages that the above code is
   ;; supposed to be make visible.
   (setq cider-repl-display-help-banner nil)

--- a/modules/tools/lsp/+lsp.el
+++ b/modules/tools/lsp/+lsp.el
@@ -130,7 +130,28 @@ server getting expensively restarted when reverting buffers."
                (or doom-debug-p
                    (not (eq +lsp-prompt-to-install-server 'quiet)))))
           (doom-shut-up-a #'lsp--info "No language server available for %S"
-                          major-mode))))))
+                          major-mode)))))
+
+  (when (featurep! :ui modeline +light)
+    (defvar-local lsp-modeline-icon nil)
+
+    (add-hook! '(lsp-before-initialize-hook
+                 lsp-after-initialize-hook
+                 lsp-after-uninitialized-functions
+                 lsp-before-open-hook
+                 lsp-after-open-hook)
+      (defun +lsp-update-modeline (&rest _)
+        "Update modeline with lsp state."
+        (let* ((workspaces (lsp-workspaces))
+               (face (if workspaces 'success 'warning))
+               (label (if workspaces "LSP Connected" "LSP Disconnected")))
+          (setq lsp-modeline-icon (concat
+                                   " "
+                                   (+modeline-format-icon 'faicon "rocket" "" face label -0.0575)
+                                   " "))
+          (add-to-list 'global-mode-string
+                       '(t (:eval lsp-modeline-icon))
+                       'append))))))
 
 
 (use-package! lsp-ui

--- a/modules/ui/modeline/+light.el
+++ b/modules/ui/modeline/+light.el
@@ -485,44 +485,6 @@ lines are selected, or the NxM dimensions of a block selection.")
   (add-hook 'deactivate-mark-hook #'+modeline-remove-selection-segment-h))
 
 
-;;; `+modeline-repl'
-(progn
-  (def-modeline-var! +modeline-repl nil
-    "Display REPL connection status icon."
-    :local t)
-
-  (add-hook! '(cider-connected-hook
-               cider-disconnected-hook
-               cider-mode-hook)
-    (defun +modeline-repl-cider-update ()
-      "Update repl connection to cider connection state."
-      (let* ((connected (cider-connected-p))
-             (face (if connected 'success 'warning))
-             (label (if connected "Cider connected" "Cider disconnected")))
-        (setq +modeline-repl
-              (+modeline-format-icon 'faicon "terminal" "" face label -0.0575))))))
-
-
-;;; `+modeline-lsp'
-(progn
-  (def-modeline-var! +modeline-lsp nil
-    "Display LSP connection status icon for the current buffer."
-    :local t)
-
-  (add-hook! '(lsp-before-initialize-hook
-               lsp-after-initialize-hook
-               lsp-after-uninitialized-functions
-               lsp-before-open-hook
-               lsp-after-open-hook)
-    (defun +modeline-lsp-update (&rest _)
-      "Update lsp state."
-      (let* ((workspaces (lsp-workspaces))
-             (face (if workspaces 'success 'warning))
-             (label (if workspaces "LSP Connected" "LSP Disconnected")))
-        (setq +modeline-lsp
-              (+modeline-format-icon 'faicon "rocket" "" face label -0.0575))))))
-
-
 ;;; `+modeline-encoding'
 (def-modeline-var! +modeline-encoding
   `(:eval
@@ -555,11 +517,6 @@ lines are selected, or the NxM dimensions of a block selection.")
     +modeline-position)
   `(""
     mode-line-misc-info
-    "  "
-    +modeline-repl
-    "  "
-    +modeline-lsp
-    "  "
     +modeline-modes
     (vc-mode ("  "
               ,(all-the-icons-octicon "git-branch" :v-adjust 0.0)

--- a/modules/ui/modeline/+light.el
+++ b/modules/ui/modeline/+light.el
@@ -485,6 +485,24 @@ lines are selected, or the NxM dimensions of a block selection.")
   (add-hook 'deactivate-mark-hook #'+modeline-remove-selection-segment-h))
 
 
+;;; `+modeline-repl'
+(progn
+  (def-modeline-var! +modeline-repl nil
+    "Display REPL connection status icon."
+    :local t)
+
+  (add-hook! '(cider-connected-hook
+               cider-disconnected-hook
+               cider-mode-hook)
+    (defun +modeline-repl-cider-update ()
+      "Update repl connection to cider connection state."
+      (let* ((connected (cider-connected-p))
+             (face (if connected 'success 'warning))
+             (label (if connected "Cider connected" "Cider disconnected")))
+        (setq +modeline-repl
+              (+modeline-format-icon 'faicon "terminal" "" face label -0.0575))))))
+
+
 ;;; `+modeline-lsp'
 (progn
   (def-modeline-var! +modeline-lsp nil
@@ -537,6 +555,8 @@ lines are selected, or the NxM dimensions of a block selection.")
     +modeline-position)
   `(""
     mode-line-misc-info
+    "  "
+    +modeline-repl
     "  "
     +modeline-lsp
     "  "

--- a/modules/ui/modeline/+light.el
+++ b/modules/ui/modeline/+light.el
@@ -109,14 +109,22 @@ side of the modeline, and whose CDR is the right-hand side.")
                                  (if (eq idx len) "\"};" "\",\n")))))
         'xpm t :ascent 'center)))))
 
-(defun +modeline-format-icon (icon label &optional face help-echo voffset)
-  (propertize (concat (all-the-icons-material
-                       icon
-                       :face face
-                       :height 1.1
-                       :v-adjust (or voffset -0.225))
-                      (propertize label 'face face))
-              'help-echo help-echo))
+(defun +modeline-format-icon (icon-set icon label &optional face help-echo voffset)
+  "Build from ICON-SET the ICON with LABEL.
+Using optionals attributes FACE, HELP-ECHO and VOFFSET."
+  (let ((icon-set-fn (pcase icon-set
+                       ('octicon #'all-the-icons-octicon)
+                       ('faicon #'all-the-icons-faicon)
+                       ('material #'all-the-icons-material)
+                       ('alltheicon #'all-the-icons-alltheicon)
+                       ('fileicon #'all-the-icons-fileicon))))
+    (propertize (concat (funcall icon-set-fn
+                                 icon
+                                 :face face
+                                 :height 1.1
+                                 :v-adjust (or voffset -0.225))
+                        (propertize label 'face face))
+                'help-echo help-echo)))
 
 (defun set-modeline! (name &optional default)
   "Set the modeline to NAME.
@@ -410,7 +418,7 @@ Requires `anzu', also `evil-anzu' if using `evil-mode' for compatibility with
                    (let ((error (or .error 0))
                          (warning (or .warning 0))
                          (info (or .info 0)))
-                     (+modeline-format-icon "do_not_disturb_alt"
+                     (+modeline-format-icon 'material "do_not_disturb_alt"
                                             (number-to-string (+ error warning info))
                                             (cond ((> error 0)   'error)
                                                   ((> warning 0) 'warning)
@@ -420,10 +428,11 @@ Requires `anzu', also `evil-anzu' if using `evil-mode' for compatibility with
                                                     warning
                                                     info))))
                (+modeline-format-icon "check" "" 'success)))
-            (`running     (+modeline-format-icon "access_time" "*" 'mode-line-inactive "Running..."))
-            (`errored     (+modeline-format-icon "sim_card_alert" "!" 'error "Errored!"))
-            (`interrupted (+modeline-format-icon "pause" "!" 'mode-line-inactive "Interrupted"))
-            (`suspicious  (+modeline-format-icon "priority_high" "!" 'error "Suspicious"))))))
+            (`running     (+modeline-format-icon'material "access_time" "*" 'mode-line-inactive "Running..."))
+            (`errored     (+modeline-format-icon'material "sim_card_alert" "!" 'error "Errored!"))
+            (`interrupted (+modeline-format-icon'material "pause" "!" 'mode-line-inactive "Interrupted"))
+            (`suspicious  (+modeline-format-icon'material "priority_high" "!" 'error "Suspicious"))))))
+
 
 
 ;;; `+modeline-selection-info'
@@ -476,6 +485,26 @@ lines are selected, or the NxM dimensions of a block selection.")
   (add-hook 'deactivate-mark-hook #'+modeline-remove-selection-segment-h))
 
 
+;;; `+modeline-lsp'
+(progn
+  (def-modeline-var! +modeline-lsp nil
+    "Display LSP connection status icon for the current buffer."
+    :local t)
+
+  (add-hook! '(lsp-before-initialize-hook
+               lsp-after-initialize-hook
+               lsp-after-uninitialized-functions
+               lsp-before-open-hook
+               lsp-after-open-hook)
+    (defun +modeline-lsp-update (&rest _)
+      "Update lsp state."
+      (let* ((workspaces (lsp-workspaces))
+             (face (if workspaces 'success 'warning))
+             (label (if workspaces "LSP Connected" "LSP Disconnected")))
+        (setq +modeline-lsp
+              (+modeline-format-icon 'faicon "rocket" "" face label -0.0575))))))
+
+
 ;;; `+modeline-encoding'
 (def-modeline-var! +modeline-encoding
   `(:eval
@@ -508,6 +537,9 @@ lines are selected, or the NxM dimensions of a block selection.")
     +modeline-position)
   `(""
     mode-line-misc-info
+    "  "
+    +modeline-lsp
+    "  "
     +modeline-modes
     (vc-mode ("  "
               ,(all-the-icons-octicon "git-branch" :v-adjust 0.0)


### PR DESCRIPTION
This PR improves `+light` modeline:
* Checks for LSP status 
* Checks CIDER if enabled for clojure buffers.

I used the same :rocket: icon from `doom-modeline`, but if you think that makes sense change to another, let me know it.
![image](https://user-images.githubusercontent.com/7820865/83907814-686be800-a73c-11ea-831b-4430025aa66c.png)

Just following the [idea from doom modeline](https://github.com/seagle0128/doom-modeline/issues/347), when CIDER is available/connected/disconnected we show an icon:
![image](https://user-images.githubusercontent.com/7820865/83921417-ad9c1400-a754-11ea-990c-dbe955e31322.png)
