### PR TITLE
Autoload workspace--generate-id

### DIFF
--- a/modules/ui/workspaces/autoload/workspaces.el
+++ b/modules/ui/workspaces/autoload/workspaces.el
@@ -20,6 +20,7 @@
 (defun +workspace--protected-p (name)
   (equal name persp-nil-name))
 
+;;;###autoload
 (defun +workspace--generate-id ()
   (or (cl-loop for name in (+workspace-list-names)
                when (string-match-p "^#[0-9]+$" name)


### PR DESCRIPTION
# Problem case
I would like to replace the `SPC TAB n` mapping with a function that prompts for a name as I'm very dumb and will forget what #3 refers to almost immediately.

## Solution

```lisp
(defun j/+workspace/new (&optional name clone-p)
  "Prompt for a workspace name before creating the workspace"
  (interactive "iP")
  (let ((name (read-string "Workspace name: "
                (or name
                  (format "#%s" (+workspace--generate-id))))))
    (when name
      (+workspace/new name clone-p))))

(after! persp-mode
  (map! :leader
    "TAB n" #'j/+workspace/new
    "TAB N" #'+workspace/new))
```

## Issue
After restarting emacs and I press `SPC TAB n` I get an error that +workspace--generate-id is not defined. Looking at the source suggests it's only loaded if one of the autoloaded functions are called first.

## Why
If it is autoloaded, the workspace--generate-id function will become available lazily as per usual emacs magic.

## Workarounds or other options 
_ranked most acceptable to least acceptable_

🙂 Kill this PR and repackage what my function offers as a default (if desired, discord emoji vote?)
😐 Call an autoloaded function after persp-mode is loaded to ensure gen id is loaded
🙁 Duplicate the workspace--generate-id function
😭 Give into the futility of existence and the ceaseless weight of time slowly sinking its teeth into our scrawny little life necks

## Known trade-offs
I'm just getting my feet with emacs lisp. I think the `--` between the ns and the function signifies it's meant to be internal so this maybe promoting a compromise in the code quality.

1. We can autoload it as is (less chance of introducing bugs)
2. Rename to suggest public use and  (more chance of introducing bugs)

## Estimated Importance
❄️ 1/10 - Low priority
- seeing as it hasn't come up before it's probably not affecting most people
- nothing is broken, technically works as is described on tin if you were to read the tin
- only unexpected because I'm dumb and didn't look at the meta before implementing
