### PR TITLE
Fixing the rg-based query construction for doom--help-searchprompt

### DIFF
--- a/core/autoload/help.el
+++ b/core/autoload/help.el
@@ -633,7 +633,7 @@ config blocks in your private config."
     (user-error "Can't find ripgrep on your system"))
   (if (fboundp 'counsel-rg)
       (let ((counsel-rg-base-command
-             (concat counsel-rg-base-command " "
+             (concat (s-join " " counsel-rg-base-command) " "
                      (mapconcat #'shell-quote-argument dirs " "))))
         (counsel-rg query nil "-Lz" prompt))
     ;; TODO Add helm support?


### PR DESCRIPTION
`counsel-rg-base-command` is a list, so concat needs it to string-join first.

As the comment says above, deadgrep is probably the way to go in the future. This is a quick fix for now.