### PR TITLE
unset geiser-mode-start-repl-p

### DIFF
--- a/modules/lang/scheme/config.el
+++ b/modules/lang/scheme/config.el
@@ -9,7 +9,6 @@
   :hook (scheme-mode . geiser-mode)
   :init
   (setq geiser-active-implementations '(guile chicken mit chibi chez)
-        geiser-mode-start-repl-p t
         geiser-smart-tab-p t)
   (unless (featurep! :lang racket)
     (push 'racket geiser-active-implementations))


### PR DESCRIPTION
Initially I believed it would be a good idea to start the repl upon
entry into a scheme file, but this has so far preempted tools that rely
on direnv to create ad-hoc environments leading to not all dependencies
being availabe for scheme files. I had not realized how annoying this
could be because at the time all of my scheme libraries were installed
in my user environment.

Another reason for this change is it brings the scheme module back into line with
the repl based modules for other lisps like clojure.