### PR TITLE
Fix word wrap binding in emacs keybindings

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -269,7 +269,8 @@
        :desc "Frame fullscreen"             "F" #'toggle-frame-fullscreen
        :desc "Indent style"                 "I" #'doom/toggle-indent-style
        :desc "Line numbers"                 "l" #'doom/toggle-line-numbers
-       :desc "Word-wrap mode"               "w" #'+word-wrap-mode
+       (:when (featurep! :editor word-wrap)
+        :desc "Word-wrap mode"              "w" #'+word-wrap-mode)
        (:when (featurep! :checkers syntax)
         :desc "Flycheck"                   "f" #'flycheck-mode)
        (:when (featurep! :ui indent-guides)


### PR DESCRIPTION
As I explained in https://github.com/hlissner/doom-emacs/issues/3332 word-wrapping mode toggling is bound in emacs keybindings even if the word-wrap module is disable which result in an error when using it.

Here's my attempt at fixing this bug.