### PR TITLE
Make unicode-fonts-setup run when emacs is started in daemon mode

### DIFF
--- a/modules/ui/unicode/autoload.el
+++ b/modules/ui/unicode/autoload.el
@@ -7,7 +7,7 @@
 necessary."
     (setq-default bidi-display-reordering t
                   doom-unicode-font nil)
-    (if initial-window-system
+    (if (display-graphic-p)
         (+unicode-setup-fonts-h (selected-frame))
       (add-hook 'after-make-frame-functions #'+unicode-setup-fonts-h))))
 


### PR DESCRIPTION
Fixes https://github.com/hlissner/doom-emacs/issues/3328.

The problem was simple: testing the variable `initial-window-system` is deprecated. One should call `(display-graphic-p)`