### PR TITLE
Don't set prefix-arg when delegating to ivy/helm from +default/search-project

### DIFF
--- a/modules/config/default/autoload/search.el
+++ b/modules/config/default/autoload/search.el
@@ -27,6 +27,7 @@ If prefix ARG is set, prompt for a known project to search from."
   (interactive "P")
   (let* ((projectile-project-root nil)
          (disabled-command-function nil)
+         (current-prefix-arg nil)
          (default-directory
            (if arg
                (if-let (projects (projectile-relevant-known-projects))


### PR DESCRIPTION
The prefix arg for +default/search-project is intended to enable the
user to pick search location, however when it propagates to the ivy
search function it turns on the "search ignored files" functionality,
which us typically not intended and, furthermore, can be (if desired)
turned on simply by typing the search command in, for exampe,
counsel-rg's case as `-uu -- mysearchterm`


----

#