### PR TITLE
Fix CLI error messages for unrecognized commands

### DIFF
--- a/bin/doom
+++ b/bin/doom
@@ -106,7 +106,9 @@ with a different private module."
                                            start-time))))))
         (user-error
          (print! (error "%s\n") (error-message-string e))
-         (print! (yellow "See 'doom help %s' for documentation on this command.") (car args))
+         (if (doom-cli-get command)
+             (print! (yellow "See 'doom help %s' for documentation on this command.") command)
+           (print! (yellow "See 'doom help' for documentation.")))
          (error "")) ; Ensure non-zero exit code
         ((debug error)
          (print! (error "There was an unexpected error:"))


### PR DESCRIPTION
`bin/doom` is producing some odd error messages.

> $ doom nonexistent
> x Couldn’t find any "nonexistent" command
> 
> See 'doom help nil' for documentation on this command.
> 
> $ doom sync --nonexistent
> x Unrecognized switch "--nonexistent"
> 
> See 'doom help --nonexistent' for documentation on this command.

I would have expected this instead:

> $ doom nonexistent
> x Couldn’t find any "nonexistent" command
> 
> See 'doom help' for documentation.
> 
> $ doom sync --nonexistent
> x Unrecognized switch "--nonexistent"
> 
> See 'doom help sync' for documentation on this command.

The argument passed to `print!` doesn't appear to have been kept up to date with the refactoring. It looks like `(car args)` used to point to the first argument after "doom" (what a C program would call `argv[1]`), but the refactoring made `command` a separate variable, and now `(car args)` denotes `argv[2]`.