### PR TITLE
Fix #3348

### DIFF
--- a/core/core-ui.el
+++ b/core/core-ui.el
@@ -450,10 +450,9 @@ windows, switch to `doom-fallback-buffer'. Otherwise, delegate to original
 
 (use-package! winner
   ;; undo/redo changes to Emacs' window layout
-  :hook (window-configuration-change . winner-mode)
   :preface (defvar winner-dont-bind-my-keys t) ; I'll bind keys myself
   :config
-  (remove-hook 'window-configuration-change #'winner-mode)
+  (add-hook 'doom-first-buffer-hook #'winner-mode)
   (appendq! winner-boring-buffers
             '("*Compile-Log*" "*inferior-lisp*" "*Fuzzy Completions*"
               "*Apropos*" "*Help*" "*cvs*" "*Buffer List*" "*Ibuffer*"

--- a/core/core-ui.el
+++ b/core/core-ui.el
@@ -451,8 +451,8 @@ windows, switch to `doom-fallback-buffer'. Otherwise, delegate to original
 (use-package! winner
   ;; undo/redo changes to Emacs' window layout
   :preface (defvar winner-dont-bind-my-keys t) ; I'll bind keys myself
+  :hook (doom-first-buffer . winner-mode)
   :config
-  (add-hook 'doom-first-buffer-hook #'winner-mode)
   (appendq! winner-boring-buffers
             '("*Compile-Log*" "*inferior-lisp*" "*Fuzzy Completions*"
               "*Apropos*" "*Help*" "*cvs*" "*Buffer List*" "*Ibuffer*"


### PR DESCRIPTION
I am not sure what the setting + removing hook code in use-package!
winner was trying to accomplish, but it was breaking winner-redo
functionality. This patch fixes the issue.