### PR TITLE
Fix localdir instead of doomdir referenced in cli

### DIFF
--- a/bin/doom
+++ b/bin/doom
@@ -56,7 +56,7 @@ with a different private module."
       (print! (info "EMACSDIR=%s") emacsdir))
     (when doomdir
       (setenv "DOOMDIR" (file-name-as-directory doomdir))
-      (print! (info "DOOMDIR=%s") localdir))
+      (print! (info "DOOMDIR=%s") doomdir))
     (when localdir
       (setenv "DOOMLOCALDIR" (file-name-as-directory localdir))
       (print! (info "DOOMLOCALDIR=%s") localdir))


### PR DESCRIPTION
Fixes bug https://github.com/hlissner/doom-emacs/issues/3367. It's just a typo. 