### PR TITLE
Fix visit docs for Racket & support racket-xp

### DIFF
--- a/modules/lang/racket/README.org
+++ b/modules/lang/racket/README.org
@@ -21,7 +21,7 @@ This module provide integration for [[https://github.com/greghendershott/racket-
 This module has no dedicated maintainers.
 
 ** Module Flags
-This module provides no flags.
++ =+xp= Enables the explore mode, which "analyzes expanded code to explain and explore."
 
 ** Plugins
 + [[https://github.com/greghendershott/racket-mode][racket-mode]]

--- a/modules/lang/racket/autoload.el
+++ b/modules/lang/racket/autoload.el
@@ -12,7 +12,7 @@
                 buf)))))
 
 ;;;###autoload
-(defun +racket-documentation (thing)
+(defun +racket-lookup-documentation (thing)
   "A `+lookup/documentation' handler for Racket."
   (let ((buf (if racket-xp-mode
                  (racket-xp-describe thing)
@@ -22,7 +22,7 @@
       t)))
 
 ;;;###autoload
-(defun +racket-definition (_thing)
+(defun +racket-lookup-definition (_thing)
   "A `+lookup/definition' handler for Racket."
   (if racket-xp-mode
       (call-interactively #'racket-xp-visit-definition)

--- a/modules/lang/racket/autoload.el
+++ b/modules/lang/racket/autoload.el
@@ -10,3 +10,20 @@
               (let ((buf (get-buffer "*Racket REPL*")))
                 (bury-buffer buf)
                 buf)))))
+
+;;;###autoload
+(defun +racket-documentation (thing)
+  "A `+lookup/documentation' handler for Racket."
+  (let ((buf (if racket-xp-mode
+                 (racket-xp-describe thing)
+               (racket-repl-describe thing))))
+    (when buf
+      (pop-to-buffer buf)
+      t)))
+
+;;;###autoload
+(defun +racket-definition (_thing)
+  "A `+lookup/definition' handler for Racket."
+  (if racket-xp-mode
+      (call-interactively #'racket-xp-visit-definition)
+    (call-interactively #'racket-repl-visit-definition)))

--- a/modules/lang/racket/config.el
+++ b/modules/lang/racket/config.el
@@ -13,8 +13,8 @@
   :config
   (set-repl-handler! 'racket-mode #'+racket/open-repl)
   (set-lookup-handlers! 'racket-mode
-    :definition    #'+racket-definition
-    :documentation #'+racket-documentation)
+    :definition    #'+racket-lookup-definition
+    :documentation #'+racket-lookup-documentation)
   (set-docsets! 'racket-mode "Racket")
   (set-pretty-symbols! 'racket-mode
     :lambda  "lambda"
@@ -28,7 +28,7 @@
              #'highlight-quoted-mode)
 
   (when (featurep! +xp)
-    (add-hook! 'racket-mode-hook #'racket-xp-mode))
+    (add-hook 'racket-mode-hook #'racket-xp-mode))
 
   (unless (or (featurep! :editor parinfer)
               (featurep! :editor lispy))

--- a/modules/lang/racket/config.el
+++ b/modules/lang/racket/config.el
@@ -32,7 +32,7 @@
 
   (unless (or (featurep! :editor parinfer)
               (featurep! :editor lispy))
-    (add-hook! 'racket-mode-hook #'racket-smart-open-bracket-mode))
+    (add-hook 'racket-mode-hook #'racket-smart-open-bracket-mode))
 
   (map! :localleader
         :map racket-mode-map

--- a/modules/lang/racket/config.el
+++ b/modules/lang/racket/config.el
@@ -13,8 +13,8 @@
   :config
   (set-repl-handler! 'racket-mode #'+racket/open-repl)
   (set-lookup-handlers! 'racket-mode
-    :definition    #'racket-xp-visit-definition
-    :documentation #'racket-xp-describe)
+    :definition    #'+racket-definition
+    :documentation #'+racket-documentation)
   (set-docsets! 'racket-mode "Racket")
   (set-pretty-symbols! 'racket-mode
     :lambda  "lambda"
@@ -26,6 +26,9 @@
   (add-hook! 'racket-mode-hook
              #'rainbow-delimiters-mode
              #'highlight-quoted-mode)
+
+  (when (featurep! +xp)
+    (add-hook! 'racket-mode-hook #'racket-xp-mode))
 
   (unless (or (featurep! :editor parinfer)
               (featurep! :editor lispy))


### PR DESCRIPTION
- Fix Racket's `+lookup/documentation` in the same way as
  https://github.com/hlissner/doom-emacs/commit/f20f477a44138d3bc8b
- Support the `+xp` feature which enables racket-xp. When it's not
  enabled, default handlers to the traditional racket-repl
  (which requires users to run code first)