### PR TITLE
Fix #3374

### DIFF
--- a/modules/term/vterm/autoload.el
+++ b/modules/term/vterm/autoload.el
@@ -1,10 +1,11 @@
 ;;; term/vterm/autoload.el -*- lexical-binding: t; -*-
 
 ;;;###autoload
-(defun +vterm/toggle (arg)
+(defun +vterm/toggle (arg &optional force-toggle)
   "Toggles a terminal popup window at project root.
 
-If prefix ARG is non-nil, recreate vterm buffer in the current project's root."
+If prefix ARG is non-nil, recreate vterm buffer in the current project's root.
+If FORCE-TOGGLE is non-nil and the vterm buffer is visible, hide it (default: select vterm window)"
   (interactive "P")
   (unless (fboundp 'module-load)
     (user-error "Your build of Emacs lacks dynamic modules support and cannot load vterm"))
@@ -23,12 +24,14 @@ If prefix ARG is non-nil, recreate vterm buffer in the current project's root."
         (when (window-live-p window)
           (delete-window window))))
     (if-let (win (get-buffer-window buffer-name))
-        (if (eq (selected-window) win)
+        (if force-toggle
             (delete-window win)
-          (select-window win)
-          (when (bound-and-true-p evil-local-mode)
-            (evil-change-to-initial-state))
-          (goto-char (point-max)))
+          (if (eq (selected-window) win)
+              (delete-window win)
+            (select-window win)
+            (when (bound-and-true-p evil-local-mode)
+              (evil-change-to-initial-state))
+            (goto-char (point-max))))
       (setenv "PROOT" (or (doom-project-root) default-directory))
       (let ((buffer (get-buffer-create buffer-name)))
         (with-current-buffer buffer


### PR DESCRIPTION
This patch provides an option to always toggle vterm buffer, even if displayed. Note that the default behavior is not changed. This enables a more ergonomic UX where the user can rely on a single binding to open/hide a pop-up

Currently, if vterm pop-up invoked via SPC o t is displayed, but another buffer is selected, a subsequent invocation of SPC o t selects the vterm buffer. This is a sensible default behavior, however for certain usage patterns it is inconvenient. Consider, for example, the case of tailing a log file, or issuing an ad hoc command in the terminal, going back to the code buffer, and realizing the terminal is not needed anymore and wanting to dismiss it.

The current behavior, moreover, is somewhat unexpected because a command with "toggle" in its name is expected to indeed toggle some feature consistently on subsequent invocations.

Furthermore, it is quite easy to select the vterm buffer, if so desired, via user's preferred window selection commands. An option to always hide the vterm pop-up if already displayed using the same keybinding used to show it would provide substantially improved UX over having to think about whether or not the buffer is selected, whether or not one should be using the o t binding or ~ binding, etc.