### PR TITLE
Make `fd` respect `projectile-globally-ignored-directories`

### DIFF
--- a/core/core-projects.el
+++ b/core/core-projects.el
@@ -138,6 +138,9 @@ c) are not valid projectile projects."
     (setq projectile-generic-command
           (concat (format "%s . -0 -H -E .git --color=never --type file --type symlink --follow"
                           doom-projectile-fd-binary)
+                  (cl-loop for dir in projectile-globally-ignored-directories
+                           concat " -E "
+                           concat (shell-quote-argument dir))
                   (if IS-WINDOWS " --path-separator=//"))
           projectile-git-command projectile-generic-command
           projectile-git-submodule-command nil


### PR DESCRIPTION
It's already done for `rg`, and it's probably worth it to do the same for `fd` for consistency. Even though it's not the best to add ignored directories, users may expect that changing `projectile-globally-ignored-directories` will have effect of files search.