### PR TITLE
Update elixir-mode to support new sigil font locks

### DIFF
--- a/modules/lang/elixir/packages.el
+++ b/modules/lang/elixir/packages.el
@@ -2,7 +2,7 @@
 ;;; lang/elixir/packages.el
 
 ;; +elixir.el
-(package! elixir-mode :pin "231291ecad")
+(package! elixir-mode :pin "670098a")
 (package! alchemist :pin "6f99367511")
 (when (featurep! :checkers syntax)
   (package! flycheck-credo :pin "e88f11ead5"))


### PR DESCRIPTION
## Background

Adds font lock support for EEx and LiveView templates in `elixir-mode`