### PR TITLE
[coq] Bump Proof General to latest version

### DIFF
--- a/modules/lang/coq/packages.el
+++ b/modules/lang/coq/packages.el
@@ -1,5 +1,5 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; lang/coq/packages.el
 
-(package! proof-general :pin "9196749d55")
-(package! company-coq :pin "f9dba9ddff")
+(package! proof-general :pin "0f0bb2c00fb7b20fd187cb92d4d2c3f84c4c5987")
+(package! company-coq :pin "7ec80586fa23e2d8caa3f26ad223c803df8abb0f")


### PR DESCRIPTION
New support for vos compilation in Coq 8.11+.