### PR TITLE
Add separate package for lsp-metals

### DIFF
--- a/modules/lang/scala/packages.el
+++ b/modules/lang/scala/packages.el
@@ -5,4 +5,4 @@
 (package! scala-mode :pin "46bb948345")
 
 (when (featurep! +lsp)
-    (package! lsp-metals :pin "5468b638cd81b7d9ce9edc652c281b28bd775c23"))
+  (package! lsp-metals :pin "5468b638cd81b7d9ce9edc652c281b28bd775c23"))

--- a/modules/lang/scala/packages.el
+++ b/modules/lang/scala/packages.el
@@ -3,3 +3,6 @@
 
 (package! sbt-mode :pin "633a315ad4")
 (package! scala-mode :pin "46bb948345")
+
+(when (featurep! +lsp)
+    (package! lsp-metals :pin "5468b638cd81b7d9ce9edc652c281b28bd775c23"))


### PR DESCRIPTION
lsp-metals was extracted out of lsp-emacs into a separate package. This change adds that separate package to the scala module when the lsp feature is selected.

Fixes hlissner/doom-emacs#3362