### PR TITLE
Change emacs-plus icon

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -243,7 +243,7 @@ to least recommended for Doom (based on compatibility).
 - [[https://github.com/d12frosted/homebrew-emacs-plus][emacs-plus]]:
   #+BEGIN_SRC bash
   brew tap d12frosted/emacs-plus
-  brew install emacs-plus
+  brew install emacs-plus --with-modern-icon-cg433n
   ln -s /usr/local/opt/emacs-plus/Emacs.app /Applications/Emacs.app
   #+END_SRC
 


### PR DESCRIPTION
Change the emacs-plus icon from spacemac's logo to a more neutral modern emacs icon.