### PR TITLE
email: mu4e: optionally use org-mu4e

### DIFF
--- a/modules/email/mu4e/README.org
+++ b/modules/email/mu4e/README.org
@@ -36,6 +36,7 @@ via IMAP) and ~mu~ (to index my mail into a format ~mu4e~ can understand).
 
 ** Module Flags
 + ~+gmail~ Enables gmail-specific configuration.
++ ~+org~ Use ~org-mu4e~ for composing mail.
 
 ** Plugins
 This module install no plugins.

--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -108,16 +108,17 @@
         :desc "attach"        "a" #'mail-add-attachment))
 
 
-(use-package! org-mu4e
-  :hook (mu4e-compose-mode . org-mu4e-compose-org-mode)
-  :config
-  (setq org-mu4e-convert-to-html t)
-  (when (version< mu4e-mu-version "1.4")
-    (setq org-mu4e-link-query-in-headers-mode nil))
+(when (featurep! +org)
+  (use-package! org-mu4e
+    :hook (mu4e-compose-mode . org-mu4e-compose-org-mode)
+    :config
+    (setq org-mu4e-convert-to-html t)
+    (when (version< mu4e-mu-version "1.4")
+      (setq org-mu4e-link-query-in-headers-mode nil))
 
-  ;; Only render to html once. If the first send fails for whatever reason,
-  ;; org-mu4e would do so each time you try again.
-  (setq-hook! 'message-send-hook org-mu4e-convert-to-html nil))
+    ;; Only render to html once. If the first send fails for whatever reason,
+    ;; org-mu4e would do so each time you try again.
+    (setq-hook! 'message-send-hook org-mu4e-convert-to-html nil)))
 
 
 ;;


### PR DESCRIPTION
I find org-mu4e to be too distracting and AFAICS there is no way to turn
it off by default. This commit adds a new flag '+org' to make this an
optional feature.