### PR TITLE
Gravatars now opt-in. Magit README updated.

### DIFF
--- a/modules/tools/magit/README.org
+++ b/modules/tools/magit/README.org
@@ -12,6 +12,7 @@
 - [[#prerequisites][Prerequisites]]
 - [[#features][Features]]
 - [[#configuration][Configuration]]
+  - [[#enable-gravatars][Enable Gravatars]]
 - [[#troubleshooting][Troubleshooting]]
 
 * Description
@@ -53,8 +54,13 @@ Forge will require [[https://magit.vc/manual/forge/Token-Creation.html#Token-Cre
 * TODO Features
 # An in-depth list of features, how to use them, and their dependencies.
 
-* TODO Configuration
-# How to configure this module, including common problems and how to address them.
+* Configuration
+Add these to =$DOOMDIR/config.el=.
+** Enable Gravatars
+This will enable gravatars when viewing commits. The service used by default is [[https://www.libravatar.org/][Libravatar]].
+#+BEGIN_SRC emacs-lisp
+(setq magit-revision-show-gravatars '("^Author:     " . "^Commit:     "))
+#+END_SRC
 
 * TODO Troubleshooting
 # Common issues and their solution, or places to look for help.

--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -11,7 +11,6 @@
         transient-history-file (concat doom-etc-dir "transient/history"))
   :config
   (setq transient-default-level 5
-        magit-revision-show-gravatars '("^Author:     " . "^Commit:     ")
         magit-diff-refine-hunk t ; show granular diffs in selected hunk
         ;; Don't autosave repo buffers. This is too magical, and saving can
         ;; trigger a bunch of unwanted side-effects, like save hooks and


### PR DESCRIPTION
**What did you expect to happen?**
I expected to view my commit without delay.

**What actually happened?**
I wasn't connected to the internet and magit waited for the gravatar request to expire before it showed me the commit.

**Screenshot:**
https://i.imgur.com/twPRDAO.jpg

**Steps to reproduce:**
1. View a commit in magit

**Suggested change:**
In `modules/tools/magit/config.el`, change
```lisp
magit-revision-show-gravatars '("^Author:     " . "^Commit:     ")
```
to
```lisp
magit-revision-show-gravatars nil
```
(or remove it because the default is `nil`)

It should be opt-in because it's connecting to an external server.

https://github.com/hlissner/doom-emacs/issues/2333 might be related.

I've updated `magit/README.org` with the deleted line.