### PR TITLE
Add `ivy-avy`

### DIFF
--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -365,6 +365,8 @@ evil-ex-specific constructs, so we disable it solely in evil-ex."
   :defer t  ; is loaded by ivy
   :init (setq ivy-flx-limit 10000))
 
+(use-package! ivy-avy
+  :after ivy)
 
 (use-package! ivy-prescient
   :when (featurep! +prescient)

--- a/modules/completion/ivy/packages.el
+++ b/modules/completion/ivy/packages.el
@@ -4,6 +4,7 @@
 (package! swiper :pin "a007ba637d6c6e232fb894e10a40cfc1142a24ae")
 (package! ivy)
 (package! ivy-hydra)
+(package! ivy-avy)
 (package! counsel)
 
 (package! amx :pin "7fb7b874291e0cdeb1f0acb18564a686ec86788d")


### PR DESCRIPTION
`ivy-avy` makes it possible to select a candidate with `avy` by using `C-'` in an ivy minibuffer.

This functionality used to come with `swiper`, but it was split: https://github.com/melpa/melpa/pull/6951

This could be added as a module flag as well.

Also, I'm not sure if this keybinding should be added to the ivy module documentation.