### PR TITLE
Add gitflow and move worktree in magit dispatch

### DIFF
--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -192,4 +192,8 @@ ensure it is built when we actually use Forge."
         (setcar desc (cdr key))))
     (evil-define-key* evil-magit-state git-rebase-mode-map
       "gj" #'git-rebase-move-line-down
-      "gk" #'git-rebase-move-line-up)))
+      "gk" #'git-rebase-move-line-up))
+  (transient-replace-suffix 'magit-dispatch 'magit-worktree
+    '("%" "Gitflow" magit-gitflow-popup))
+  (transient-append-suffix 'magit-dispatch '(0 -1 -1)
+    '("*" "Worktree" magit-worktree)))


### PR DESCRIPTION
- Adds `magit-gitflow-popup` as `%` keybinding in the `magit-dispatch`, mirroring the keybinding in `magit-mode-map`.
- The existing binding `magit-worktree` is moved to `*`

Fixes #3410 