### PR TITLE
Add :lang nix +nixpkgs-fmt flag to pick formatter

### DIFF
--- a/modules/lang/nix/README.org
+++ b/modules/lang/nix/README.org
@@ -41,7 +41,7 @@ This module has no dedicated maintainers.
 + ~nixpkgs-fmt~ can be used as alternative with =+nixpkgs-fmt=
   + Install it using your configured nixpkgs: ~nix-env -i nixpkgs-fmt~
   + Or directly from the repository: ~nix-env -f https://github.com/nix-community/nixpkgs-fmt/archive/master.tar.gz -i~
-+ ~:editor format~ ~format-all~ also supports ~nixfmt~ so you can use that also to format Nix code, default binding is ~SPC c f~ in evil.
++ ~:editor format~ integration for both formatters exists, so you can use that also to format Nix code, default binding is ~SPC c f~ in evil.
 
 * Features
 ** Keybindings

--- a/modules/lang/nix/README.org
+++ b/modules/lang/nix/README.org
@@ -20,23 +20,27 @@ Adds many tools for [[https://nixos.org/][Nix(OS)]] users in nice package for Do
 + Syntax highlighting
 + Completion through ~company~ / ~helm~
 + Nix option lookup
-+ Formatting (~nixfmt~)
++ Formatting (~nixfmt~ or ~nixpkgs-fmt~)
 
 ** Maintainers
 This module has no dedicated maintainers.
 
 ** Module Flags
-This module provides no flags.
++ =+nixpkgs-fmt= Use ~nixpkgs-fmt~ instead of ~nixfmt~.
 
 ** Plugins
 + [[https://github.com/NixOS/nix-mode][nix-mode]]
 + [[https://github.com/jwiegley/nix-update-el][nix-update]]
++ [[https://github.com/purcell/emacs-nixpkgs-fmt][nixpkgs-fmt]]
 
 * Prerequisites
-+ ~nixfmt~ is required to use formatting
++ ~nixfmt~ is required to use formatting by default
   + If you have Nix(OS) installed it can be installed through Nix configuration ~environment.systemPackages = with pkgs; [ nixfmt ];~ (recommended)
   + Or through nix-env ~nix-env -iA nixpkgs.nixfmt~
   + Or through nix-shell ~nix-shell -f https://github.com/serokell/nixfmt/archive/master.tar.gz -i~
++ ~nixpkgs-fmt~ can be used as alternative with =+nixpkgs-fmt=
+  + Install it using your configured nixpkgs: ~nix-env -i nixpkgs-fmt~
+  + Or directly from the repository: ~nix-env -f https://github.com/nix-community/nixpkgs-fmt/archive/master.tar.gz -i~
 + ~:editor format~ ~format-all~ also supports ~nixfmt~ so you can use that also to format Nix code, default binding is ~SPC c f~ in evil.
 
 * Features
@@ -46,7 +50,7 @@ This module provides no flags.
 | ~<localleader> b~ | ~nix-build~          |
 | ~<localleader> f~ | ~nix-update-fetch~   |
 | ~<localleader> o~ | ~+nix/lookup-option~ |
-| ~<localleader> p~ | ~nix-format-buffer~  |
+| ~<localleader> p~ | ~+nix/format-buffer~ |
 | ~<localleader> r~ | ~nix-repl-show~      |
 | ~<localleader> s~ | ~nix-repl-shell~     |
 | ~<localleader> u~ | ~nix-unpack~         |

--- a/modules/lang/nix/README.org
+++ b/modules/lang/nix/README.org
@@ -40,7 +40,6 @@ This module has no dedicated maintainers.
   + Or through nix-shell ~nix-shell -f https://github.com/serokell/nixfmt/archive/master.tar.gz -i~
 + ~nixpkgs-fmt~ can be used as alternative with =+nixpkgs-fmt=
   + Install it using your configured nixpkgs: ~nix-env -i nixpkgs-fmt~
-  + Or directly from the repository: ~nix-env -f https://github.com/nix-community/nixpkgs-fmt/archive/master.tar.gz -i~
 + ~:editor format~ integration for both formatters exists, so you can use that also to format Nix code, default binding is ~SPC c f~ in evil.
 
 * Features

--- a/modules/lang/nix/config.el
+++ b/modules/lang/nix/config.el
@@ -50,4 +50,8 @@
 
 (when (featurep! +nixpkgs-fmt)
   (use-package! nixpkgs-fmt
-    :commands nixpkgs-fmt nixpkgs-fmt-buffer))
+    :commands nixpkgs-fmt nixpkgs-fmt-buffer)
+
+    ;; Redefine formatter for nix-mode (nixfmt is default)
+    (set-formatter! 'nixpkgs-fmt #'nixpkgs-fmt
+      :modes '(nix-mode)))

--- a/modules/lang/nix/config.el
+++ b/modules/lang/nix/config.el
@@ -32,7 +32,7 @@
   (map! :localleader
         :map nix-mode-map
         "f" #'nix-update-fetch
-        "p" #'nix-format-buffer
+        "p" #'+nix/format-buffer
         "r" #'nix-repl-show
         "s" #'nix-shell
         "b" #'nix-build
@@ -47,3 +47,7 @@
 
 (use-package! nix-repl
   :commands nix-repl-show)
+
+(when (featurep! +nixpkgs-fmt)
+  (use-package! nixpkgs-fmt
+    :commands nixpkgs-fmt nixpkgs-fmt-buffer))

--- a/modules/lang/nix/doctor.el
+++ b/modules/lang/nix/doctor.el
@@ -4,6 +4,8 @@
 (unless (executable-find "nix")
   (warn! "Couldn't find the nix package manager. nix-mode won't work."))
 
-(unless (executable-find "nixfmt")
-  (warn! "Couldn't find nixfmt. nix-format-buffer won't work."))
-
+(if (featurep! +nixpkgs-fmt)
+  (unless (executable-find "nipkgs-fmt")
+    (warn! "Couldn't find nixpkgs-fmt. nixpkgs-fmt won't work."))
+  (unless (executable-find "nixfmt")
+    (warn! "Couldn't find nixfmt. nix-format-buffer won't work.")))

--- a/modules/lang/nix/packages.el
+++ b/modules/lang/nix/packages.el
@@ -9,3 +9,6 @@
 
 (when (featurep! :completion helm)
   (package! helm-nixos-options :pin "977b9a505ffc8b33b70ec7742f90e469b3168297"))
+
+(when (featurep! +nixpkgs-fmt)
+  (package! nixpkgs-fmt :pin "cc8ee143d4ef45a8c540901852326ccdf6ff8482"))


### PR DESCRIPTION
Not sure about how ~~this should be~~ I integrated with `:editor format` and maybe switching the functions can be done somehow simpler than with that additional `+nix/format-buffer` function? 