### PR TITLE
Org-roam: Add keybinding for org-roam-insert-immediate

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -165,13 +165,13 @@
          :desc "Search Forever" "s" #'org-journal-search-forever))
        (:when (featurep! :lang org +roam)
         (:prefix ("r" . "roam")
-         :desc "Switch to buffer"          "b" #'org-roam-switch-to-buffer
-         :desc "Org Roam Capture"          "c" #'org-roam-capture
-         :desc "Find file"                 "f" #'org-roam-find-file
-         :desc "Show graph"                "g" #'org-roam-graph
-         :desc "Insert"                    "i" #'org-roam-insert
-         :desc "Insert (skip org-capture)" "I" #'org-roam-insert-immediate
-         :desc "Org Roam"                  "r" #'org-roam
+         :desc "Switch to buffer"              "b" #'org-roam-switch-to-buffer
+         :desc "Org Roam Capture"              "c" #'org-roam-capture
+         :desc "Find file"                     "f" #'org-roam-find-file
+         :desc "Show graph"                    "g" #'org-roam-graph
+         :desc "Insert"                        "i" #'org-roam-insert
+         :desc "Insert (skipping org-capture)" "I" #'org-roam-insert-immediate
+         :desc "Org Roam"                      "r" #'org-roam
          (:prefix ("d" . "by date")
           :desc "Arbitrary date" "d" #'org-roam-dailies-date
           :desc "Today"          "t" #'org-roam-dailies-today

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -165,12 +165,13 @@
          :desc "Search Forever" "s" #'org-journal-search-forever))
        (:when (featurep! :lang org +roam)
         (:prefix ("r" . "roam")
-         :desc "Switch to buffer" "b" #'org-roam-switch-to-buffer
-         :desc "Org Roam Capture" "c" #'org-roam-capture
-         :desc "Find file"        "f" #'org-roam-find-file
-         :desc "Show graph"       "g" #'org-roam-graph
-         :desc "Insert"           "i" #'org-roam-insert
-         :desc "Org Roam"         "r" #'org-roam
+         :desc "Switch to buffer"          "b" #'org-roam-switch-to-buffer
+         :desc "Org Roam Capture"          "c" #'org-roam-capture
+         :desc "Find file"                 "f" #'org-roam-find-file
+         :desc "Show graph"                "g" #'org-roam-graph
+         :desc "Insert"                    "i" #'org-roam-insert
+         :desc "Insert (skip org-capture)" "I" #'org-roam-insert-immediate
+         :desc "Org Roam"                  "r" #'org-roam
          (:prefix ("d" . "by date")
           :desc "Arbitrary date" "d" #'org-roam-dailies-date
           :desc "Today"          "t" #'org-roam-dailies-today

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -499,12 +499,13 @@
 
        (:when (featurep! :lang org +roam)
         (:prefix ("r" . "roam")
-         :desc "Switch to buffer" "b" #'org-roam-switch-to-buffer
-         :desc "Org Roam Capture" "c" #'org-roam-capture
-         :desc "Find file"        "f" #'org-roam-find-file
-         :desc "Show graph"       "g" #'org-roam-graph
-         :desc "Insert"           "i" #'org-roam-insert
-         :desc "Org Roam"         "r" #'org-roam
+         :desc "Switch to buffer"          "b" #'org-roam-switch-to-buffer
+         :desc "Org Roam Capture"          "c" #'org-roam-capture
+         :desc "Find file"                 "f" #'org-roam-find-file
+         :desc "Show graph"                "g" #'org-roam-graph
+         :desc "Insert"                    "i" #'org-roam-insert
+         :desc "Insert (skip org-capture)" "I" #'org-roam-insert-immediate
+         :desc "Org Roam"                  "r" #'org-roam
          (:prefix ("d" . "by date")
           :desc "Arbitrary date" "d" #'org-roam-dailies-date
           :desc "Today"          "t" #'org-roam-dailies-today

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -499,13 +499,13 @@
 
        (:when (featurep! :lang org +roam)
         (:prefix ("r" . "roam")
-         :desc "Switch to buffer"          "b" #'org-roam-switch-to-buffer
-         :desc "Org Roam Capture"          "c" #'org-roam-capture
-         :desc "Find file"                 "f" #'org-roam-find-file
-         :desc "Show graph"                "g" #'org-roam-graph
-         :desc "Insert"                    "i" #'org-roam-insert
-         :desc "Insert (skip org-capture)" "I" #'org-roam-insert-immediate
-         :desc "Org Roam"                  "r" #'org-roam
+         :desc "Switch to buffer"              "b" #'org-roam-switch-to-buffer
+         :desc "Org Roam Capture"              "c" #'org-roam-capture
+         :desc "Find file"                     "f" #'org-roam-find-file
+         :desc "Show graph"                    "g" #'org-roam-graph
+         :desc "Insert"                        "i" #'org-roam-insert
+         :desc "Insert (skipping org-capture)" "I" #'org-roam-insert-immediate
+         :desc "Org Roam"                      "r" #'org-roam
          (:prefix ("d" . "by date")
           :desc "Arbitrary date" "d" #'org-roam-dailies-date
           :desc "Today"          "t" #'org-roam-dailies-today

--- a/modules/lang/org/contrib/roam.el
+++ b/modules/lang/org/contrib/roam.el
@@ -15,6 +15,7 @@
              org-roam-find-file
              org-roam-graph
              org-roam-insert
+             org-roam-insert-immediate
              org-roam-switch-to-buffer
              org-roam-dailies-date
              org-roam-dailies-today
@@ -33,6 +34,7 @@
         "f" #'org-roam-find-file
         "g" #'org-roam-graph
         "i" #'org-roam-insert
+        "I" #'org-roam-insert-immediate
         "m" #'org-roam
         (:prefix ("d" . "by date")
           :desc "Arbitrary date" "d" #'org-roam-dailies-date


### PR DESCRIPTION
This function allows the creation of file references in org-roam, without opening org-capture