### PR TITLE
Fix hook name in org-roam

### DIFF
--- a/modules/lang/org/contrib/roam.el
+++ b/modules/lang/org/contrib/roam.el
@@ -9,7 +9,7 @@
 ;;; Packages
 
 (use-package! org-roam
-  :hook (org-load . org-roam-mode)
+  :hook (org-load-hook . org-roam-mode)
   :hook (org-roam-backlinks-mode . turn-on-visual-line-mode)
   :commands (org-roam-buffer-toggle-display
              org-roam-find-file


### PR DESCRIPTION
Resolves #3378 

I haven't fully understood why the dashboard worked when we open emacs directly, but this resolved the issue in server mode.