### PR TITLE
Enable projectile-locate-dominating-file on tramp

### DIFF
--- a/core/core-projects.el
+++ b/core/core-projects.el
@@ -190,16 +190,7 @@ when using many of projectile's command, e.g. `projectile-compile-command',
 This suppresses the error so these commands will still run, but prompt you for
 the command instead."
     :around #'projectile-default-generic-command
-    (ignore-errors (apply orig-fn args)))
-
-  ;; Projectile root-searching functions can cause an infinite loop on TRAMP
-  ;; connections, so disable them.
-  ;; TODO Is this still necessary?
-  (defadvice! doom--projectile-locate-dominating-file-a (file _name)
-    "Don't traverse the file system if on a remote connection."
-    :before-while #'projectile-locate-dominating-file
-    (and (stringp file)
-         (not (file-remote-p file nil t)))))
+    (ignore-errors (apply orig-fn args))))
 
 
 ;;


### PR DESCRIPTION
Essentially this makes projectile work properly (again?) when using tramp.

This causes the following (all of it on tramp):
- If `projectile-locate-dominating-file` is disabled then `projectile-find-file` doesn't work, which also makes `+ivy/projectile-find-file` only able to search in the current directory.
- It allows `projectile-vc` to work again (only on machines with the same OS).
- Projects are now added properly: they now appear with `counsel-projectile-switch-project` (accessible in Open project) in the dashboard.
- LSP autocompletion now includes files from the whole project (LSP still doesn't work properly though, see #3390).

I tested it with Emacs 26.3 and 27.0.91 , both with ssh and sshx.  The infinite loop was no longer present.