### PR TITLE
Bump lsp packages

### DIFF
--- a/modules/lang/dart/packages.el
+++ b/modules/lang/dart/packages.el
@@ -4,7 +4,7 @@
 (package! dart-mode :pin "04fcd649f1")
 
 (when (featurep! +lsp)
-  (package! lsp-dart :pin "afdcce3507"))
+  (package! lsp-dart :pin "10b898ebeb60e00395bbc72495afaf2f22b4fc9f"))
 
 (when (featurep! +flutter)
   (package! flutter :pin "293b7225b9")

--- a/modules/lang/java/packages.el
+++ b/modules/lang/java/packages.el
@@ -13,4 +13,4 @@
     (package! company-emacs-eclim :pin "23f5b294f8")))
 
 (when (featurep! +lsp)
-  (package! lsp-java :pin "6efb741845"))
+  (package! lsp-java :pin "fe118246903b9cfa9217f442f2b1b6524916253b"))

--- a/modules/lang/python/packages.el
+++ b/modules/lang/python/packages.el
@@ -11,7 +11,7 @@
 ;; LSP
 (when (and (featurep! +lsp)
            (not (featurep! :tools lsp +eglot)))
-  (package! lsp-python-ms :pin "db6f2636da1037bda06d5a2d992c4857ce3ad9b0"))
+  (package! lsp-python-ms :pin "7068cf04a0d0a1877afe56990cc577edd824a1e4"))
 
 ;; Programming environment
 (package! anaconda-mode :pin "10299bd9ff38c4f0da1d892905d02ef828e7fdce")

--- a/modules/lang/scala/packages.el
+++ b/modules/lang/scala/packages.el
@@ -5,4 +5,4 @@
 (package! scala-mode :pin "46bb948345")
 
 (when (featurep! +lsp)
-  (package! lsp-metals :pin "5468b638cd81b7d9ce9edc652c281b28bd775c23"))
+  (package! lsp-metals :pin "3d4d4b7b14d6f1041f75ddb45f36ca4cf9a6d854"))

--- a/modules/tools/debugger/packages.el
+++ b/modules/tools/debugger/packages.el
@@ -6,5 +6,5 @@
     (package! realgud-trepan-ni :pin "6e9cac5e8097018aadf41c88de541168036cc227")))
 
 (when (featurep! +lsp)
-  (package! dap-mode :pin "7ad915794b75481f12b3f02ac8f5c9bcfddd6938")
+  (package! dap-mode :pin "554f7cac9097ea1151af0b5b723dcdcc12abc4a8")
   (package! posframe :pin "6285217711bc846e565940261829b523e298f82e"))

--- a/modules/tools/lsp/packages.el
+++ b/modules/tools/lsp/packages.el
@@ -5,7 +5,7 @@
     (progn
       (package! eglot :pin "ac9239bed5e3bfbf057382d1a75cdfa23f2caddd")
       (package! project :pin "da0333a697b18f0a863c1b1523d2fc7991b31174"))
-  (package! lsp-mode :pin "666de5f50942efa461130846be740729b25081fd")
+  (package! lsp-mode :pin "7b0b9c3785222ed89744a0d1376e764c30e950ac")
   (package! lsp-ui :pin "ce997c4dabb494ec4aaa93373ae27cd4d5cd0a4d")
   (when (featurep! :completion ivy)
     (package! lsp-ivy :pin "f6e321187e773d7e5dfb215802fff5f308226cf9"))


### PR DESCRIPTION
lsp-mode did a huge migration to use plists instead of hash-tables.
This PR bump all lsp related projects.

More info here: https://github.com/emacs-lsp/lsp-mode/issues/1751