### PR TITLE
tools/lookup: Update Xwidget WebKit browser support

### DIFF
--- a/docs/modules.org
+++ b/docs/modules.org
@@ -168,7 +168,7 @@ Small modules that give Emacs access to external tools & services.
 + [[file:../modules/tools/ein/README.org][ein]] - TODO
 + [[file:../modules/tools/eval/README.org][eval]] =+overlay= - REPL & code evaluation support for a variety of languages
 + gist - TODO
-+ [[file:../modules/tools/lookup/README.org][lookup]] =+dictionary +docsets +offline +xwidget= - Universal jump-to & documentation lookup
++ [[file:../modules/tools/lookup/README.org][lookup]] =+dictionary +docsets +offline= - Universal jump-to & documentation lookup
   backend
 + [[file:../modules/tools/lsp/README.org][lsp]] =+peek +eglot= - Installation and configuration of language server protocol client (lsp-mode or eglot)
 + macos - TODO

--- a/modules/tools/lookup/README.org
+++ b/modules/tools/lookup/README.org
@@ -21,6 +21,7 @@
   - [[#associating-lookup-handlers-with-major-modes][Associating lookup handlers with major modes]]
   - [[#associating-dash-docsets-with-major-modes][Associating Dash docsets with major modes]]
   - [[#open-in-eww-instead-of-browser][Open in eww instead of browser]]
+  - [[#open-in-xwidget-webkit-instead-of-browser][Open in Xwidget WebKit instead of browser]]
 - [[#appendix][Appendix]]
   - [[#commands][Commands]]
 
@@ -40,7 +41,6 @@ or synonyms.
 + ~+dictionary~ Enable word definition and thesaurus lookup functionality.
   + ~+offline~ Install and prefer offline dictionary/thesaurus.
 + ~+docsets~ Enable integration with Dash.app docsets.
-  + ~+xwidget~ Enable integration with [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Embedded-WebKit-Widgets.html][Embedded Webkit Widgets]].
 
 ** Plugins
 + [[https://github.com/jacktasia/dumb-jump][dumb-jump]]
@@ -208,11 +208,21 @@ This determines what docsets to implicitly search for when you use
 docsets must be installed with ~+lookup/install-docset~.
 
 ** Open in eww instead of browser
-To open results from ~+lookup/online~ in EWW instead of your system browser,
-change ~+lookup-open-url-fn~ (default: ~#'browse-url~):
+To open results from ~+lookup/online~ or ~+lookup/in-docsets~ in EWW instead
+of your system browser, change ~+lookup-open-url-fn~ (default:
+~#'browse-url~):
 
 #+BEGIN_SRC emacs-lisp
 (setq +lookup-open-url-fn #'eww)
+#+END_SRC
+
+** Open in Xwidget WebKit instead of browser
+To open results from ~+lookup/online~ or ~+lookup/in-docsets~ in Xwidget
+WebKit instead of your system browser, set ~+lookup-open-url-fn~ to
+~+lookup-xwidget-webkit-open-url-fn~ (needs Emacs with Xwidgets support):
+
+#+BEGIN_SRC emacs-lisp
+(setq +lookup-open-url-fn #'+lookup-xwidget-webkit-open-url-fn)
 #+END_SRC
 
 * Appendix

--- a/modules/tools/lookup/autoload/xwidget.el
+++ b/modules/tools/lookup/autoload/xwidget.el
@@ -1,0 +1,20 @@
+;;; tools/lookup/autoload/xwidget.el -*- lexical-binding: t; -*-
+
+(defvar +lookup--xwidget-webkit-last-session-buffer nil)
+
+;;;###autoload
+(defun +lookup-xwidget-webkit-open-url-fn (url &optional new-session)
+  (if (not (display-graphic-p))
+      (browse-url url)
+    (unless (featurep 'xwidget-internal)
+      (user-error "Your build of Emacs lacks Xwidgets support and cannot open Xwidget WebKit browser"))
+    (let ((orig-last-session-buffer (if (boundp 'xwidget-webkit-last-session-buffer)
+                                        xwidget-webkit-last-session-buffer
+                                      nil)))
+      (setq xwidget-webkit-last-session-buffer +lookup--xwidget-webkit-last-session-buffer)
+      (save-window-excursion
+        (xwidget-webkit-browse-url url new-session))
+      (with-popup-rules! '(("^\\*xwidget" :vslot -11 :size 0.35 :select nil))
+        (pop-to-buffer xwidget-webkit-last-session-buffer))
+      (setq +lookup--xwidget-webkit-last-session-buffer xwidget-webkit-last-session-buffer
+            xwidget-webkit-last-session-buffer orig-last-session-buffer))))

--- a/modules/tools/lookup/config.el
+++ b/modules/tools/lookup/config.el
@@ -116,8 +116,6 @@ Used by `+lookup/dictionary-definition' and `+lookup/synonyms'.
 For `+lookup/dictionary-definition', this is ignored on Mac, where Emacs users
 Dictionary.app behind the scenes to get definitions.")
 
-(defvar +lookup--dash-docs-xwidget-webkit-last-session-buffer nil)
-
 
 ;;
 ;;; dumb-jump
@@ -199,20 +197,6 @@ See https://github.com/magit/ghub/issues/81"
     :around #'dash-docs-read-json-from-url
     (let ((gnutls-algorithm-priority "NORMAL:-VERS-TLS1.3"))
       (funcall orig-fn url)))
-
-  ;; Dash docset + Xwidget integration
-  (when (featurep! +xwidget)
-    (defun +lookup-dash-docs-xwidget-webkit-browse-url-fn (url &optional new-session)
-      (if (not (display-graphic-p))
-          (eww url new-session)
-        (setq xwidget-webkit-last-session-buffer +lookup--dash-docs-xwidget-webkit-last-session-buffer)
-        (save-window-excursion
-          (xwidget-webkit-browse-url url new-session))
-        (with-popup-rules! '(("^\\*xwidget" :vslot -11 :size 0.35 :select nil))
-          (pop-to-buffer xwidget-webkit-last-session-buffer))
-        (setq +lookup--dash-docs-xwidget-webkit-last-session-buffer xwidget-webkit-last-session-buffer
-              xwidget-webkit-last-session-buffer nil)))
-    (setq dash-docs-browser-func #'+lookup-dash-docs-xwidget-webkit-browse-url-fn))
 
   (cond ((featurep! :completion helm)
          (require 'helm-dash nil t))


### PR DESCRIPTION
Remove :tools/lookup +xwidget and provide `+lookup-xwidget-webkit-open-url-fn` instead so that we can manually configure Xwidget WebKit browser for `+lookup/online` or `+lookup/in-docsets`.

Fixes #3441.