### PR TITLE
Switch to emacs mode in mu4e view mode

### DIFF
--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -63,6 +63,11 @@
   ;; set mail user agent
   (setq mail-user-agent 'mu4e-user-agent)
 
+  ;; evil masks most mu4e-view-mode key bindings. Switch to Emacs mode for
+  ;; this.
+  (when (featurep! :editor evil)
+    (add-hook! 'mu4e-view-mode-hook #'evil-emacs-state))
+
   ;; Use fancy icons
   (setq mu4e-use-fancy-chars t
         mu4e-headers-draft-mark '("D" . "")

--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -66,7 +66,7 @@
   ;; evil masks most mu4e-view-mode key bindings. Switch to Emacs mode for
   ;; this.
   (when (featurep! :editor evil)
-    (add-hook! 'mu4e-view-mode-hook #'evil-emacs-state))
+    (add-hook 'mu4e-view-mode-hook #'evil-emacs-state))
 
   ;; Use fancy icons
   (setq mu4e-use-fancy-chars t


### PR DESCRIPTION
    Evil masks most of the keybindings that are set by mu4e-view-mode. Since
    this is a read-only buffer anyway use Emacs for that mode.
