### PR TITLE
Clarify ace-window font size and add example

### DIFF
--- a/modules/ui/window-select/README.org
+++ b/modules/ui/window-select/README.org
@@ -48,7 +48,15 @@ The first character of the buffers changes to a highlighted, user-selectable
 character.
 
  + Pros: the content of the buffers are always visible.
- + Cons: The displayed characters are small and difficult to see.
+ + Cons: Requires custom configuration to show large letters.
+ 
+**** Custom font-face example
+This changes the ace-window display to show a white letter with a red background. The box attribute adds some padding.
+#+BEGIN_SRC elisp
+  (custom-set-faces
+   '(aw-leading-char-face
+     ((t (:foreground "white" :background "red" :weight bold :height 2.5 :box (:line-width 10 :color "red"))))))
+#+END_SRC 
 
 ** switch-window
 Replaces the entire buffer with large letters.

--- a/modules/ui/window-select/README.org
+++ b/modules/ui/window-select/README.org
@@ -48,14 +48,15 @@ The first character of the buffers changes to a highlighted, user-selectable
 character.
 
  + Pros: the content of the buffers are always visible.
- + Cons: Requires custom configuration to show large letters.
+ + Cons: The display characters are small and difficult to see (see below for a way to enlarge them).
  
 **** Custom font-face example
 This changes the ace-window display to show a white letter with a red background. The box attribute adds some padding.
 #+BEGIN_SRC elisp
-  (custom-set-faces
-   '(aw-leading-char-face
-     ((t (:foreground "white" :background "red" :weight bold :height 2.5 :box (:line-width 10 :color "red"))))))
+(custom-set-faces!
+  '(aw-leading-char-face
+    :foreground "white" :background "red"
+    :weight bold :height 2.5 :box (:line-width 10 :color "red")))
 #+END_SRC 
 
 ** switch-window


### PR DESCRIPTION
I clarified the pros and cons of the different window packages and added an example to show users how to customize the ace-window letter.