### PR TITLE
Update :tools lsp-ivy

### DIFF
--- a/modules/tools/lsp/packages.el
+++ b/modules/tools/lsp/packages.el
@@ -5,7 +5,7 @@
     (progn
       (package! eglot :pin "ac9239bed5e3bfbf057382d1a75cdfa23f2caddd")
       (package! project :pin "da0333a697b18f0a863c1b1523d2fc7991b31174"))
-  (package! lsp-mode :pin "7b0b9c3785222ed89744a0d1376e764c30e950ac")
+  (package! lsp-mode :pin "1f6d8777a3445d23678216fe1f46475de5f4fb0e")
   (package! lsp-ui :pin "ce997c4dabb494ec4aaa93373ae27cd4d5cd0a4d")
   (when (featurep! :completion ivy)
     (package! lsp-ivy :pin "f6e321187e773d7e5dfb215802fff5f308226cf9"))


### PR DESCRIPTION
Upgrate lsp-ivy version to latest commit

I need the last version for setting true to `lsp-ivy-show-symbol-filename`, could became a default value in :lsp if you wish :) 