### PR TITLE
Add terminal-notifier support for org-pomodoro

### DIFF
--- a/modules/lang/org/contrib/pomodoro.el
+++ b/modules/lang/org/contrib/pomodoro.el
@@ -10,6 +10,8 @@
   (alert-add-rule :category "org-pomodoro"
                   :style (cond (alert-growl-command
                                 'growl)
+                               (alert-notifier-command
+                                'notifier)
                                (alert-libnotify-command
                                 'libnotify)
                                (alert-default-style))))


### PR DESCRIPTION
This adds notification support for pomodoros in org-mode when using MacOs via [terminal-notifier](https://github.com/julienXX/terminal-notifier). 

Growl is propietary commercial software and libnotify doesn't seem to work properly on Catalina.  The list of supported alert styles in alert.el is [here](https://github.com/jwiegley/alert/blob/master/alert.el#L134)

In order to test it:
1. Install terminal-notifier ( `brew install terminal-notifier` helps)
2. Enable the `+pomodoro` flag
3. Open / create an org file with a headline
4. Put the cursor under the headline
5. Start and end a pomodoro immediately with `M-x org-pomodoro`
6. Give terminal-notifier accessibility permissions if it asks for them.