### PR TITLE
tools/magit: map zt/zb motions in magit-mode

### DIFF
--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -174,7 +174,9 @@ ensure it is built when we actually use Forge."
   (evil-define-key* 'normal magit-status-mode-map [escape] nil) ; q is enough
   (evil-define-key* '(normal visual) magit-mode-map
     "%"  #'magit-gitflow-popup
+    "zt" #'evil-scroll-line-to-top
     "zz" #'evil-scroll-line-to-center
+    "zb" #'evil-scroll-line-to-bottom
     "g=" #'magit-diff-default-context)
   (define-key! 'normal
     (magit-status-mode-map


### PR DESCRIPTION
Hi!

This PR adds `zt` and `zb` motions to magit-mode since these two keybinds aren't mapped to anything by default, and `zz` motion already exists. I've been using the following snippet in my config for a while:

``` emacs-lisp
(map! :map magit-mode-map
  :nv "zt" #'evil-scroll-line-to-top
  :nv "zb" #'evil-scroll-line-to-bottom)
```