### PR TITLE
Add automatic fold after save to TeX-fold

### DIFF
--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -88,6 +88,8 @@ If no viewers are found, `latex-preview-pane' is used.")
   ;; Fold after cdlatex macro insertions
   (advice-add #'cdlatex-math-symbol :after #'+latex-fold-last-macro-a)
   (advice-add #'cdlatex-math-modify :after #'+latex-fold-last-macro-a)
+  ;; Fold after saving
+  (add-hook! 'after-save-hook TeX-fold-buffer)
   ;; Fold after snippets
   (when (featurep! :editor snippets)
     (add-hook! 'TeX-fold-mode-hook

--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -89,7 +89,7 @@ If no viewers are found, `latex-preview-pane' is used.")
   (advice-add #'cdlatex-math-symbol :after #'+latex-fold-last-macro-a)
   (advice-add #'cdlatex-math-modify :after #'+latex-fold-last-macro-a)
   ;; Fold after saving
-  (add-hook! 'after-save-hook TeX-fold-buffer)
+  (add-hook 'after-save-hook #'TeX-fold-buffer)
   ;; Fold after snippets
   (when (featurep! :editor snippets)
     (add-hook! 'TeX-fold-mode-hook


### PR DESCRIPTION
Since the Tex-fold-buffer bind (`C-c C-o C-b`) is really clunky and preferably we (I?) want the buffer as folded as possible, I see this as an optimal solution.