### PR TITLE
Update Mac Install for emacs-plus

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -243,7 +243,7 @@ to least recommended for Doom (based on compatibility).
 - [[https://github.com/d12frosted/homebrew-emacs-plus][emacs-plus]]:
   #+BEGIN_SRC bash
   brew tap d12frosted/emacs-plus
-  brew install emacs-plus --with-modern-icon-cg433n
+  brew install emacs-plus --with-modern-cg433n-icon
   ln -s /usr/local/opt/emacs-plus/Emacs.app /Applications/Emacs.app
   #+END_SRC
 


### PR DESCRIPTION
The parameter is wrong. It must be --with-modern-cg433n-icon and not --with-modern-icon-cg433n

You can check it on the github repo site https://github.com/d12frosted/homebrew-emacs-plus