### PR TITLE
Updated cg433n argument

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -243,7 +243,7 @@ to least recommended for Doom (based on compatibility).
 - [[https://github.com/d12frosted/homebrew-emacs-plus][emacs-plus]]:
   #+BEGIN_SRC bash
   brew tap d12frosted/emacs-plus
-  brew install emacs-plus --with-modern-icon-cg433n
+  brew install emacs-plus --with-modern-cg433n-icon
   ln -s /usr/local/opt/emacs-plus/Emacs.app /Applications/Emacs.app
   #+END_SRC
 


### PR DESCRIPTION
`--with-modern-cg433n-icon` used (updated) by https://github.com/d12frosted/homebrew-emacs-plus#icons Original argument listed: `--with-modern-icon-cg433n` does not work (used by https://github.com/daviderestivo/homebrew-emacs-head)