### PR TITLE
Updated macOS emacs-plus installation docs to use updated build flag

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -243,7 +243,7 @@ to least recommended for Doom (based on compatibility).
 - [[https://github.com/d12frosted/homebrew-emacs-plus][emacs-plus]]:
   #+BEGIN_SRC bash
   brew tap d12frosted/emacs-plus
-  brew install emacs-plus --with-modern-icon-cg433n
+  brew install emacs-plus --with-modern-cg433n-icon
   ln -s /usr/local/opt/emacs-plus/Emacs.app /Applications/Emacs.app
   #+END_SRC
 


### PR DESCRIPTION
As of commit [c9a41a](https://github.com/d12frosted/homebrew-emacs-plus/commit/c9a41a3abc88edd792bf282a7e3ee0637af19b5f#diff-aacb4ce123f9200898dff4a35e6a8461) to the [d12frosted/homebrew-emacs-plus](https://github.com/d12frosted/homebrew-emacs-plus) homebrew formula, all of the icon flags have been unified

In the case of the Doom Emacs documentation, that means the [macOS -> With Homebrew](https://github.com/hlissner/doom-emacs/blob/develop/docs/getting_started.org#with-homebrew) section is currently incorrect given that the `--with-modern-icon-cg433n` flag has been changed to `--with-modern-cg433n-icon`