### PR TITLE
remove doctor warning message for optional vterm dependency

### DIFF
--- a/modules/term/vterm/doctor.el
+++ b/modules/term/vterm/doctor.el
@@ -1,8 +1,5 @@
 ;;; term/vterm/doctor.el -*- lexical-binding: t; -*-
 
-(unless (executable-find "vterm-ctrl")
-  (warn! "Couldn't find libvterm. Vterm module won't compile"))
-
 (unless (executable-find "make")
   (warn! "Couldn't find make command. Vterm module won't compile"))
 


### PR DESCRIPTION
According to [emacs-libvterm](https://github.com/akermu/emacs-libvterm#requirements), `libvterm` is an optional dependency and not required to compile. 

I am seeing this manifest in my system on Ubuntu 20.04 with `libvterm-dev` installed. It doesn't include the `vterm-ctrl` binary, but `vterm` works just fine in my install. However, `doom doctor` persists with the warning message.