### PR TITLE
Add a flag for disabling doom-themes' org fixes.

### DIFF
--- a/modules/ui/doom/README.org
+++ b/modules/ui/doom/README.org
@@ -25,8 +25,17 @@ This module gives Doom its signature look: powered by the =doom-one= theme
 + "Thin bar" fringe bitmaps for ~git-gutter-fringe~
 + File-visiting buffers are slightly brighter (thanks to solaire-mode)
 
+This module also enables some display enhancements for =org-mode= included with
+the =doom-themes= package, such as:
++ Changing the color of =TODO= items that are marked done.
++ Fontifying hashtags (=#=) and at-tags (=@=)
++ Hiding leading stars
+
+See doom-themes-org-config for more information.
+
 ** Module Flags
-This module provides no flags.
++ =+disable-org-config= Disables the additional syntax highlighting for org-mode
+  included in all doom themes.
 
 ** Plugins
 + [[https://github.com/hlissner/emacs-doom-themes][doom-themes]]

--- a/modules/ui/doom/config.el
+++ b/modules/ui/doom/config.el
@@ -11,7 +11,8 @@
   (unless doom-theme
     (setq doom-theme 'doom-one))
   ;; improve integration w/ org-mode
-  (add-hook 'doom-load-theme-hook #'doom-themes-org-config)
+  (unless (featurep! +disable-org-config)
+    (add-hook 'doom-load-theme-hook #'doom-themes-org-config))
   ;; more Atom-esque file icons for neotree/treemacs
   (when (featurep! :ui neotree)
     (add-hook 'doom-load-theme-hook #'doom-themes-neotree-config)


### PR DESCRIPTION
I want a more vanilla doom experience so I really need this module flag to prevent the default org settings from being overwritten.

As you can see, this is my first patch of doom :tada: Please let me know if there is anything else this PR needs.