### PR TITLE
Add version (27) to macOS Homebrew guideline

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -243,8 +243,8 @@ to least recommended for Doom (based on compatibility).
 - [[https://github.com/d12frosted/homebrew-emacs-plus][emacs-plus]]:
   #+BEGIN_SRC bash
   brew tap d12frosted/emacs-plus
-  brew install emacs-plus --with-modern-cg433n-icon
-  ln -s /usr/local/opt/emacs-plus/Emacs.app /Applications/Emacs.app
+  brew install emacs-plus@27 --with-modern-cg433n-icon
+  ln -s /usr/local/opt/emacs-plus@27/Emacs.app /Applications/Emacs.app
   #+END_SRC
 
 - [[https://bitbucket.org/mituharu/emacs-mac/overview][emacs-mac]] is another acceptable option. It offers slightly better integration


### PR DESCRIPTION
`brew install emacs-plus` can take a version number (@27 or @28, otherwise defaults to 26). Since 27+ is recommended, I thought I'd add this. Tested on my machine (MBP running Catalina 10.15.5) and looks fine.