### PR TITLE
Added clojure to list of supported lsp languages.

### DIFF
--- a/modules/config/default/autoload/text.el
+++ b/modules/config/default/autoload/text.el
@@ -135,7 +135,7 @@ possible, or just one char if that's not possible."
                        (beg  (plist-get pair :beg))
                        (end  (plist-get pair :end)))
                   (cond ((and end beg (= end (+ beg (length op) (length cl))))
-                         (sp-backward-delete-char 1))
+                         (delete-char -1))
                         ((doom-surrounded-p pair 'inline 'balanced)
                          (delete-char -1 killflag)
                          (delete-char 1)

--- a/modules/tools/lsp/README.org
+++ b/modules/tools/lsp/README.org
@@ -35,6 +35,7 @@ As of this writing, this is the state of LSP support in Doom Emacs:
 | Module           | Major modes                                             | Default language server                                       |
 |------------------+---------------------------------------------------------+---------------------------------------------------------------|
 | [[../../lang/cc/README.org][:lang cc]]         | c-mode, c++-mode, objc-mode                             | ccls                                                          |
+| [[../../lang/clojure/README.org][:lang clojure]]    | clojure-mode                                            | clojure-lsp                                                   |
 | [[../../lang/csharp/README.org][:lang csharp]]     | csharp-mode                                             | omnisharp                                                     |
 | [[../../lang/elixir/README.org][:lang elixir]]     | elixir-mode                                             | elixir-ls                                                     |
 | [[../../lang/fsharp/README.org][:lang fsharp]]     | fsharp-mode                                             | Mono, .NET core                                               |


### PR DESCRIPTION
Clojure was not in the list, but the functionality exists.

Signed-off-by: Johan Thoren <jthoren@itrsgroup.com>