### PR TITLE
Add support for lua-langserver in lsp-mode

### DIFF
--- a/modules/lang/lua/+lsp-mode.el
+++ b/modules/lang/lua/+lsp-mode.el
@@ -1,0 +1,18 @@
+;;; lang/lua/+lsp-mode.el -*- lexical-binding: t; -*-
+
+(defun lsp-lua-langserver--lsp-command ()
+  "Generate LSP startup command."
+  (list (doom-path lua-lsp-dir
+                   (cond (IS-MAC     "bin/macOS")
+                         (IS-LINUX   "bin/Linux")
+                         (IS-WINDOWS "bin/Windows"))
+                   "lua-language-server")
+        "-E" "-e" "LANG=en"
+        (doom-path lua-lsp-dir "main.lua")))
+
+(after! lsp-mode
+  (lsp-register-client
+   (make-lsp-client :new-connection (lsp-stdio-connection 'lsp-lua-langserver--lsp-command)
+                    :major-modes '(lua-mode)
+                    :priority -1
+                    :server-id 'lua-langserver)))

--- a/modules/lang/lua/config.el
+++ b/modules/lang/lua/config.el
@@ -38,6 +38,8 @@ lua-language-server.")
          (doom-path lua-lsp-dir "main.lua")))
 
   (when (featurep! +lsp)
+    (unless (featurep! :tools lsp +eglot)
+      (load! "+lsp-mode"))
     (add-hook 'lua-mode-local-vars-hook #'lsp!)))
 
 


### PR DESCRIPTION
Register a `lsp-mode` client for `lua-langserver`. 

This could go upstream eventually, but the quickest patch to get it working was to use the same doom utils as the `eglot` config