### PR TITLE
Only fallback to hledger if ledger isn't installed

### DIFF
--- a/modules/lang/ledger/config.el
+++ b/modules/lang/ledger/config.el
@@ -7,10 +7,9 @@
         ledger-mode-should-check-version nil)
 
   :config
-  (setq ledger-binary-path
-        (if (executable-find "hledger")
-            "hledger"
-          "ledger"))
+  ;; fallback to hledger in case ledger binary is not found
+  (when (and (not (executable-find ledger-binary-path)) (executable-find "hledger"))
+    (setq ledger-binary-path "hledger"))
 
   (set-company-backend! 'ledger-mode 'company-capf)
 


### PR DESCRIPTION
Most of the report commands fail with `hledger`, so if the user has both programs installed it should use ledger as default (or simply not set another value).