### PR TITLE
Fix emacs binding for toggling org-tree-slide-mode

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -278,7 +278,7 @@
        (:when (featurep! :ui minimap)
         :desc "Minimap mode"               "m" #'minimap-mode)
        (:when (featurep! :lang org +present)
-        :desc "org-tree-slide mode"        "p" #'+org-present/start)
+        :desc "org-tree-slide mode"        "p" #'org-tree-slide-mode)
        :desc "Read-only mode"               "r" #'read-only-mode
        (:when (featurep! :checkers spell)
         :desc "Flyspell"                   "s" #'flyspell-mode)


### PR DESCRIPTION
org-tree-slide-mode toggling binding was calling a non-existing (obsolete?) function.

It now call `org-tree-slide-mode` as evil bindings does.