### PR TITLE
Make gpg files incompatible with undo-fu session

### DIFF
--- a/modules/emacs/undo/config.el
+++ b/modules/emacs/undo/config.el
@@ -33,7 +33,7 @@
   :hook (undo-fu-mode . global-undo-fu-session-mode)
   :preface
   (setq undo-fu-session-directory (concat doom-cache-dir "undo-fu-session/")
-        undo-fu-session-incompatible-files '("/COMMIT_EDITMSG\\'" "/git-rebase-todo\\'"))
+        undo-fu-session-incompatible-files '("\\.gpg$" "/COMMIT_EDITMSG\\'" "/git-rebase-todo\\'"))
 
   ;; HACK We avoid `:config' here because `use-package's `:after' complicates
   ;;      the load order of a package's `:config' block and makes it impossible


### PR DESCRIPTION
Since gpg files are explicitly meant to be encrypted it doesn't make a lot of sense to store undo data unencrypted. This commit adds gpg files to the `undo-fu-session-incompatible-files` list.