### PR TITLE
Support fcitx5

### DIFF
--- a/modules/input/chinese/config.el
+++ b/modules/input/chinese/config.el
@@ -20,6 +20,9 @@
   :after evil
   :config
   (when (executable-find "fcitx-remote")
+    (fcitx-evil-turn-on))
+  (when (executable-find "fcitx5-remote")
+    (setq fcitx-remote-command "fcitx5-remote")
     (fcitx-evil-turn-on)))
 
 


### PR DESCRIPTION
fcitx5 uses `fcitx5-remote` to control its status.
see:
https://github.com/cute-jumper/fcitx.el/issues/47
https://github.com/cute-jumper/fcitx.el/commit/c89c90cca6dc148647d8bc7b4766c84ddd988e34