### PR TITLE
remove doom/open-manual, fix doom/describe-module

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -1309,9 +1309,7 @@ You can also evaluate code with ~eval-expression~ (=M-;= or =SPC ;=).
 *** TODO For Doom Modules, packages, autodefs, etc.
 + ~doom/open-news~ (=SPC h n=) ::
      ...
-+ ~doom/open-manual~ (=SPC h D=) ::
-     ...
-+ ~doom/describe-module~ (=SPC h d=) ::
++ ~doom/describe-module~ (=SPC h d m=) ::
      Jumps to a module's documentation.
 + ~doom/describe-autodefs~ (=SPC h A=) ::
      Jumps to the documentation for an autodef function/macro. These are special


### PR DESCRIPTION
The `doom/open-manual function` seems to no longer exist. The `doom/describe-module` key binding is fixed since `SPC h d` is the doom help prefix. Under this prefix is `doom/describe-module`.

I am not aware if `doom/open-manual` was replaced by something else, but I'm happy to include that in the PR if someone can point me to it :)

Thanks for all the work on Doom Emacs!