### PR TITLE
update indent-visualisation on indent-style change

### DIFF
--- a/core/autoload/text.el
+++ b/core/autoload/text.el
@@ -286,6 +286,7 @@ Respects `require-final-newline'."
   "Switch between tabs and spaces indentation style in the current buffer."
   (interactive)
   (setq indent-tabs-mode (not indent-tabs-mode))
+  (doom-highlight-non-default-indentation-h)
   (message "Indent style changed to %s" (if indent-tabs-mode "tabs" "spaces")))
 
 (defvar editorconfig-lisp-use-default-indent)


### PR DESCRIPTION
Requires `doom-highlight-non-default-indentation-h` to be idempotent though. Can you help me with this one? Right now it will just highlight both tabs and spaces after a switch.