### PR TITLE
Disable flycheck when racket-xp-mode is enabled

### DIFF
--- a/modules/lang/racket/autoload.el
+++ b/modules/lang/racket/autoload.el
@@ -27,3 +27,7 @@
   (if racket-xp-mode
       (call-interactively #'racket-xp-visit-definition)
     (call-interactively #'racket-repl-visit-definition)))
+
+;;;###autoload
+(defun +racket--disable-flycheck ()
+  (add-to-list 'flycheck-disabled-checkers 'racket))

--- a/modules/lang/racket/config.el
+++ b/modules/lang/racket/config.el
@@ -30,6 +30,11 @@
   (when (featurep! +xp)
     (add-hook 'racket-mode-hook #'racket-xp-mode))
 
+  (add-hook 'racket-xp-mode-hook #'+racket--disable-flycheck)
+  (map! :map racket-xp-mode-map
+        :n "[e" #'racket-xp-previous-error
+        :n "]e" #'racket-xp-next-error)
+
   (unless (or (featurep! :editor parinfer)
               (featurep! :editor lispy))
     (add-hook 'racket-mode-hook #'racket-smart-open-bracket-mode))


### PR DESCRIPTION
Enabling both flycheck and racket-xp-mode would create redundant
error tooltips. Since racket-xp-mode provides a higher quality
error message, prefer it over flycheck.