### PR TITLE
fix for #3266: wrong-type-arg stringp from format

### DIFF
--- a/modules/config/literate/autoload.el
+++ b/modules/config/literate/autoload.el
@@ -27,7 +27,7 @@ byte-compiled from.")
              (and (require 'ob-tangle)
                   (letf! (defun message (msg &rest args)
                            (when msg
-                           (print! (info "%s") (apply #'format msg args))))
+                             (print! (info "%s") (apply #'format msg args))))
                     (org-babel-tangle-file org dest))
                   ;; Write the cache file to serve as our mtime cache
                   (with-temp-file +literate-config-cache-file))

--- a/modules/config/literate/autoload.el
+++ b/modules/config/literate/autoload.el
@@ -26,7 +26,8 @@ byte-compiled from.")
              ;; would load all of :lang org (very expensive!).
              (and (require 'ob-tangle)
                   (letf! (defun message (msg &rest args)
-                           (print! (info "%s") (apply #'format msg args)))
+                           (when msg
+                           (print! (info "%s") (apply #'format msg args))))
                     (org-babel-tangle-file org dest))
                   ;; Write the cache file to serve as our mtime cache
                   (with-temp-file +literate-config-cache-file))


### PR DESCRIPTION
Literate configurations trigger issue #3266 when tangling on interactive save and epdfinfo is missing. For some reason, pdf-tools-install's prompt for installation ends up calling `message(nil)` which our `letf!`version does not handle well. My patch ignores these cases, which results in the prompt working and both epdfinfo installation and tangling succeeding when saving a literate config.