### PR TITLE
change pinned agda version

### DIFF
--- a/modules/lang/agda/packages.el
+++ b/modules/lang/agda/packages.el
@@ -6,11 +6,11 @@
     :recipe (:host github :repo "agda/agda"
              :files ("src/data/emacs-mode/agda-input.el")
              :nonrecursive t)
-    :pin "ff9173e14e")
+    :pin "8eb0d01811a663cf2b27b482b3b18690adfa094b")
 
   (package! agda2-mode
     :recipe (:host github :repo "agda/agda"
              :files ("src/data/emacs-mode/*.el"
                      (:exclude "agda-input.el"))
              :nonrecursive t)
-    :pin "ff9173e14e"))
+    :pin "8eb0d01811a663cf2b27b482b3b18690adfa094b"))


### PR DESCRIPTION
Previous pin copies from agda/agda: `src/data/emacs-mode/agda2-mode.el` which checks if version 2.6.2 is installed, giving errors on the stable release version.

Pin the agda version at the v2.6.1 release.