### PR TITLE
lang/common-lisp: fix SPC m ; regression

### DIFF
--- a/modules/lang/common-lisp/config.el
+++ b/modules/lang/common-lisp/config.el
@@ -89,7 +89,10 @@
         (:localleader
          :map lisp-mode-map
          :desc "Sly"          "'" #'sly
-         :desc "Sly (ask)"    ";" (λ!! #'sly '-)
+         :desc "Sly (ask)"    ";" (lambda ()
+                                    (interactive)
+                                    (let ((current-prefix-arg '-))
+                                      (call-interactively #'sly)))
          :desc "Expand macro" "m" #'macrostep-expand
          (:prefix ("c" . "compile")
           :desc "Compile file"          "c" #'sly-compile-file


### PR DESCRIPTION
Commit a9bf0b89851af0a6a1f763d8e4053502aa04f74d replaced call-interactively with funcall-interactively in λ!!, which breaks SPC m ; for two reasons. First, function sly presumes it was called interactively when its INTERACTIVE argument is non-nil, but funcall-interactively bypasses the interactive form, changing only the result of called-interactively-p (which sly eschews). Second, sly does not accept the prefix argument as an argument; instead, it directly checks current-prefix-arg.