### PR TITLE
Support number highlighting for long Elixir numbers

### DIFF
--- a/modules/lang/elixir/config.el
+++ b/modules/lang/elixir/config.el
@@ -3,6 +3,14 @@
 (after! projectile
   (add-to-list 'projectile-project-root-files "mix.exs"))
 
+(after! highlight-numbers
+  (puthash 'elixir-mode
+    (rx (and symbol-start
+            (? "-")
+            (+ digit)
+            (0+ (and "_" (= 3 digit)))
+            symbol-end))
+    highlight-numbers-modelist))
 
 ;;
 ;;; Packages

--- a/modules/lang/elixir/config.el
+++ b/modules/lang/elixir/config.el
@@ -5,12 +5,8 @@
 
 (after! highlight-numbers
   (puthash 'elixir-mode
-    (rx (and symbol-start
-            (? "-")
-            (+ digit)
-            (0+ (and "_" (= 3 digit)))
-            symbol-end))
-    highlight-numbers-modelist))
+           "\\_<-?[[:digit:]]+\\(?:_[[:digit:]]\\{3\\}\\)*\\_>"
+           highlight-numbers-modelist))
 
 ;;
 ;;; Packages


### PR DESCRIPTION
## Background
The built-in Elixir formatter uses an underscore to delimit long numbers. However, the generic regex for `highlight-numbers-mode` does not recognize them. This adds a mode-specific regex for `elixir-mode`.

#### Before
<img width="432" alt="Before" src="https://user-images.githubusercontent.com/16150/88200672-b3b25b00-cc03-11ea-926d-e3d6638ae791.png">

#### After
<img width="439" alt="After" src="https://user-images.githubusercontent.com/16150/88200700-bf9e1d00-cc03-11ea-8e30-9f48fc9d50db.png">

## Note

I have also added direct support for font face on numbers to elixir-editors/emacs-elixir#459 if you have any feedback on that as well as I don't want things to conflict with `highlight-numbers-mode`