### PR TITLE
Bump :tools ansible; fix #3555

### DIFF
--- a/modules/tools/ansible/packages.el
+++ b/modules/tools/ansible/packages.el
@@ -3,7 +3,7 @@
 
 (package! ansible :recipe (:nonrecursive t) :pin "b5ef59406604bc5027f4d816d90e633feef0149c")
 (package! ansible-doc :pin "86083a7bb2ed0468ca64e52076b06441a2f8e9e0")
-(package! jinja2-mode :pin "4540f99a3e363403a633587e05a9707605c16473")
+(package! jinja2-mode :pin "ecd19a40b7832bb00f0a2244e3b0713d0bf3850d")
 (package! yaml-mode :pin "34648f2502f52f4744d62758fa381fa35db1da49")
 
 (when (featurep! :completion company)


### PR DESCRIPTION
paradoxxxzero/jinja2-mode@4540f99 -> paradoxxxzero/jinja2-mode@ecd19a4


----

# 

This should fix #3555 as upstream has merged the PR to disable the indentation on save by default.