### PR TITLE
update emacs-lisp outline regexp to fold defs

### DIFF
--- a/modules/lang/emacs-lisp/config.el
+++ b/modules/lang/emacs-lisp/config.el
@@ -3,7 +3,7 @@
 (defvar +emacs-lisp-enable-extra-fontification t
   "If non-nil, highlight special forms, and defined functions and variables.")
 
-(defvar +emacs-lisp-outline-regexp "[ \t]*;;;;* [^ \t\n]"
+(defvar +emacs-lisp-outline-regexp "\\([ \t]*;;;;* [^ \t\n]\\|\\((def\\)\\)"
   "Regexp to use for `outline-regexp' in `emacs-lisp-mode'.
 This marks a foldable marker for `outline-minor-mode' in elisp buffers.")
 


### PR DESCRIPTION
Allows outline-mode to also fold defs, which can be useful when developing large emacs-lisp files. I've had this in my config for a while and find it useful, was wondering if upstream would like to have it as well:

![image](https://user-images.githubusercontent.com/1667473/88451355-9d690100-ce88-11ea-9b03-4516b2633ef0.png)
