### PR TITLE
Add support for pyright language server

### DIFF
--- a/modules/lang/python/README.org
+++ b/modules/lang/python/README.org
@@ -92,9 +92,11 @@ private config.el:
   (set-lsp-priority! 'mspyls 1))
 #+END_SRC
 
+*To use pyright*, install it from your shell with with ~npm i -g pyright~.
+
 * Features
 This module supports LSP. It requires installation of [[https://pypi.org/project/python-language-server/][Python Language
-Server]] or [[https://github.com/Microsoft/python-language-server][Microsoft Language Server]], see [[Language Server Protocol Support][LSP Support]].
+Server]], [[https://github.com/Microsoft/python-language-server][Microsoft Language Server]], or [[https://github.com/microsoft/pyright][pyright]], see [[Language Server Protocol Support][LSP Support]].
 
 To enable support for auto-formatting with black enable ~:editor format-all~ in
 ~init.el~ file.

--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -292,7 +292,9 @@ called.")
 
 
 (use-package! lsp-python-ms
-  :when (and (featurep! +lsp) (not (featurep! :tools lsp +eglot)))
+  :when (featurep! +lsp) 
+  :when (not (featurep! +pyright))
+  :when (not (featurep! :tools lsp +eglot)) 
   :after lsp-clients
   :preface
   (after! python
@@ -306,6 +308,12 @@ called.")
   (defadvice! +python--silence-errors-a (orig-fn &rest args)
     :around #'lsp-python-ms--extra-init-params
     (ignore-errors (apply orig-fn args))))
+
+(use-package!  lsp-pyright  
+  :when (featurep! +lsp) 
+  :when (featurep! +pyright) 
+  :when (not (featurep! :tools lsp +eglot))
+  :after lsp-clients)
 
 
 (use-package! cython-mode

--- a/modules/lang/python/packages.el
+++ b/modules/lang/python/packages.el
@@ -13,6 +13,14 @@
            (not (featurep! :tools lsp +eglot)))
   (package! lsp-python-ms :pin "7068cf04a0d0a1877afe56990cc577edd824a1e4"))
 
+(when (and (featurep! +lsp)
+           (featurep! +pyright)
+           (not (featurep! :tools lsp +eglot)))
+  (package! lsp-pyright
+    ;; REVIEW Remove this when added to melpa
+    :recipe (:host github :repo "emacs-lsp/lsp-pyright")
+    :pin "242d19b2dbaaccc5fb9cd1b1a9420ee6807ce77c"))
+
 ;; Programming environment
 (package! anaconda-mode :pin "10299bd9ff38c4f0da1d892905d02ef828e7fdce")
 (when (featurep! :completion company)


### PR DESCRIPTION
This should add pyright support to lsp-mode with an opt-in +pyright flag. 