### PR TITLE
tools/magit: map Forge jumps in evil-mode

### DIFF
--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -101,6 +101,11 @@
   :preface
   (setq forge-database-file (concat doom-etc-dir "forge/forge-database.sqlite"))
   :config
+  ;; Map Forge jumps in `evil-mode'
+  (when (featurep! :editor evil +everywhere)
+    (map! :map magit-mode-map
+      :n "gi" #'forge-jump-to-issues
+      :n "gm" #'forge-jump-to-pullreqs))
   ;; All forge list modes are derived from `forge-topic-list-mode'
   (map! :map forge-topic-list-mode-map :n "q" #'kill-current-buffer)
   (set-popup-rule! "^\\*?[0-9]+:\\(?:new-\\|[0-9]+$\\)" :size 0.45 :modeline t :ttl 0 :quit nil)

--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -101,11 +101,6 @@
   :preface
   (setq forge-database-file (concat doom-etc-dir "forge/forge-database.sqlite"))
   :config
-  ;; Map Forge jumps in `evil-mode'
-  (when (featurep! :editor evil +everywhere)
-    (map! :map magit-mode-map
-      :n "gi" #'forge-jump-to-issues
-      :n "gm" #'forge-jump-to-pullreqs))
   ;; All forge list modes are derived from `forge-topic-list-mode'
   (map! :map forge-topic-list-mode-map :n "q" #'kill-current-buffer)
   (set-popup-rule! "^\\*?[0-9]+:\\(?:new-\\|[0-9]+$\\)" :size 0.45 :modeline t :ttl 0 :quit nil)
@@ -179,7 +174,9 @@ ensure it is built when we actually use Forge."
     "zt" #'evil-scroll-line-to-top
     "zz" #'evil-scroll-line-to-center
     "zb" #'evil-scroll-line-to-bottom
-    "g=" #'magit-diff-default-context)
+    "g=" #'magit-diff-default-context
+    "gi" #'forge-jump-to-issues
+    "gm" #'forge-jump-to-pullreqs)
   (define-key! 'normal
     (magit-status-mode-map
      magit-stash-mode-map


### PR DESCRIPTION
Hi!

This PR will add `gi` and `gm` mnemonics in magit-mode to quickly jump to issues and pull requests respectively. I chose `m` for pull requests because `p` was already taken and it makes sense for GitLab users, not sure if GitHub users will agree.

P.S. I'm not sure if this is the proper way to go about it as I'm new to Elisp; please let me know if/how it could be improved.