### PR TITLE
[UI] Set prompt to readonly in comint buffers

### DIFF
--- a/core/core-ui.el
+++ b/core/core-ui.el
@@ -391,6 +391,10 @@ windows, switch to `doom-fallback-buffer'. Otherwise, delegate to original
 (setq ansi-color-for-comint-mode t)
 
 
+(after! comint
+  (setq comint-prompt-read-only t))
+
+
 (after! compile
   (setq compilation-always-kill t       ; kill compilation process before starting another
         compilation-ask-about-save nil  ; save all buffers on `compile'


### PR DESCRIPTION
Comint buffers like *Python*, *shell*, etc. will benifit from this
change as the prompt wont be deletable.