### PR TITLE
org-roam: check for sqlite3 executable in doctor

### DIFF
--- a/modules/lang/org/doctor.el
+++ b/modules/lang/org/doctor.el
@@ -6,5 +6,7 @@
     (warn! "Couldn't find gnuplot. org-plot/gnuplot will not work")))
 
 (when (featurep! +roam)
+  (unless (executable-find "sqlite3")
+    (warn! "Couldn't find the sqlite3 executable. org-roam will not work."))
   (unless (executable-find "dot")
     (warn! "Couldn't find the dot executable (from graphviz). org-roam will not be able to generate graph visuallizations.")))


### PR DESCRIPTION
org-roam fails with [very unhelpful](https://discord.com/channels/406534637242810369/406554085794381833/737720230507315200) errors when `sqlite3` executable is not found.

Perhaps checking it in `doom doctor` will make it a bit easier to find the problem.