### PR TITLE
Change :app calendar README and add cfw:org-create-file-source to list of commands

### DIFF
--- a/modules/app/calendar/README.org
+++ b/modules/app/calendar/README.org
@@ -34,7 +34,8 @@ calendar data from:
   (cfw:open-calendar-buffer
    :contents-sources
    (list
-    (cfw:org-create-source "Green")  ; orgmode source
+    (cfw:org-create-source "Green")  ; org-agenda source
+    (cfw:org-create-file-source "cal" "/path/to/cal.org" "Cyan")  ; other org source
     (cfw:howm-create-source "Blue")  ; howm source
     (cfw:cal-create-source "Orange") ; diary source
     (cfw:ical-create-source "Moon" "~/moon.ics" "Gray")  ; ICS source1

--- a/modules/app/calendar/README.org
+++ b/modules/app/calendar/README.org
@@ -43,23 +43,6 @@ calendar data from:
    )))
 #+END_SRC
 
-To control what org files ~clfw:org-create-source~ will use, ~let~-bind
-~org-agenda-files~ around a call to ~+calendar/open-calendar~ like so:
-
-#+BEGIN_SRC emacs-lisp
-;;;###autoload
-(defun cfw:open-org-calendar-with-cal1 ()
-  (interactive)
-  (let ((org-agenda-files '("/path/to/org/" "/path/to/cal1.org")))
-    (call-interactively #'+calendar/open-calendar)))
-
-;;;###autoload
-(defun cfw:open-org-calendar-with-cal2 ()
-  (interactive)
-  (let ((org-agenda-files '("/path/to/org/" "/path/to/cal2.org")))
-    (call-interactively #'+calendar/open-calendar)))
-#+END_SRC
-
 The [[https://github.com/kiwanami/emacs-calfw][kiwanami/emacs-calfw]] project readme contains more examples.
 
 ** Synchronizing Org and Google Calendar

--- a/modules/app/calendar/config.el
+++ b/modules/app/calendar/config.el
@@ -33,6 +33,7 @@
 (use-package! calfw-org
   :commands (cfw:open-org-calendar
              cfw:org-create-source
+             cfw:org-create-file-source
              cfw:open-org-calendar-withkevin
              my-open-calendar))
 


### PR DESCRIPTION
The example in the README to include org files from other sources in the calendar view doesn't really work, because the binding to `org-agenda-files` is lost e.g. when calendar view is refreshed.
Fortunately, there is the function `cfw:org-create-file-source` that allows us to list other org files in the content sources.