### PR TITLE
Add calfw-cal dependency to allow local diary source

### DIFF
--- a/modules/app/calendar/config.el
+++ b/modules/app/calendar/config.el
@@ -36,6 +36,9 @@
              cfw:open-org-calendar-withkevin
              my-open-calendar))
 
+(use-package! calfw-cal
+  :commands (cfw:cal-create-source))
+
 (use-package! calfw-ical
   :commands (cfw:ical-create-source))
 

--- a/modules/app/calendar/packages.el
+++ b/modules/app/calendar/packages.el
@@ -3,5 +3,6 @@
 
 (package! calfw :pin "03abce97620a4a7f7ec5f911e669da9031ab9088")
 (package! calfw-org :pin "03abce97620a4a7f7ec5f911e669da9031ab9088")
+(package! calfw-cal :pin "03abce97620a4a7f7ec5f911e669da9031ab9088")
 (package! calfw-ical :pin "03abce97620a4a7f7ec5f911e669da9031ab9088")
 (package! org-gcal :pin "744505832b34e07b44a5d97d8720b2d7492d7fc9")


### PR DESCRIPTION
As mentioned in https://github.com/hlissner/doom-emacs/issues/3331 there's a dependency missing in calendar app module to be able to follow the README along and configure local diary source.

This PR fixes it.