### PR TITLE
ui(tabs): use a smaller dot to show unsaved file status

### DIFF
--- a/modules/ui/tabs/config.el
+++ b/modules/ui/tabs/config.el
@@ -8,7 +8,7 @@
         centaur-tabs-set-bar 'left
         centaur-tabs-set-modified-marker t
         centaur-tabs-close-button "✕"
-        centaur-tabs-modified-marker "⬤"
+        centaur-tabs-modified-marker "•"
         ;; Scrolling (with the mouse wheel) past the end of the tab list
         ;; replaces the tab list with that of another Doom workspace. This
         ;; prevents that.


### PR DESCRIPTION
The default modified marker looks unfit to the tab's height and font size, the smaller one is more appropriate.

## Before
<img width="699" alt="before" src="https://user-images.githubusercontent.com/14329786/89118241-85bbf900-d4d6-11ea-8610-c8f9662c8bc0.png">

## After
<img width="702" alt="after" src="https://user-images.githubusercontent.com/14329786/89118243-881e5300-d4d6-11ea-94bf-ea7b2c258ae6.png">
