### PR TITLE
Docs update add to path

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -464,12 +464,15 @@ provides, and ~doom help COMMAND~ to display documentation for a particular
 **** Add Doom to PATH
 I recommend you add =~/.emacs.d/bin= to your ~PATH~ so you can call =doom=
 directly and from anywhere. 
-To accomplish this: (For Debian-based distros. Mileage may vary in other distro 
-families.)
+To accomplish this, add the following to your ~/.profile: 
+/(For Debian-based distros. Mileage may vary in other distro families.)/
 #+BEGIN_SRC bash
-echo 'export PATH="$HOME/.emacs.d/bin:$PATH" #Add Doom to Path' >> ~/.profile
-source ~/.profile
+# add doom emacs to path
+if [ -d "$HOME/.emacs.d/bin" ] ; then
+    PATH="$HOME/.emacs.d/bin:$PATH"
+fi
 #+END_SRC
+Then run =source ~/.profile= to apply the settings without restarting your system.
 
 /Note: Using .profile is recommended per 
 [[https://help.ubuntu.com/community/EnvironmentVariables#A.2BAH4-.2F.profile][Ubuntu Documentation]]./

--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -34,6 +34,7 @@ us know!
       - [[#with-wsl--ubuntu-1804-lts][With WSL + Ubuntu 18.04 LTS]]
   - [[#doom-emacs][Doom Emacs]]
     - [[#the-bindoom-utility][The ~bin/doom~ utility]]
+      - [[#add-doom-to-path][Add Doom to PATH]]
     - [[#install-doom-manually][Install Doom Manually]]
     - [[#install-doom-alongside-other-configs-with-chemacs][Install Doom alongside other configs (with Chemacs)]]
   - [[#externalsystem-dependencies][External/system dependencies]]
@@ -470,8 +471,8 @@ echo 'export PATH="$HOME/.emacs.d/bin:$PATH" #Add Doom to Path' >> ~/.profile
 source ~/.profile
 #+END_SRC
 
-/Note: Using .profile is recommended per [[https://help.ubuntu.com/
-community/EnvironmentVariables#A.2BAH4-.2F.profile][Ubuntu Documentation]]./
+/Note: Using .profile is recommended per 
+[[https://help.ubuntu.com/community/EnvironmentVariables#A.2BAH4-.2F.profile][Ubuntu Documentation]]./
 #+begin_quote
 Shell config files such as ~/.bashrc, ~/.bash_profile, and ~/.bash_login are 
 often suggested for setting environment variables. While this may work on Bash 

--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -460,11 +460,26 @@ Use ~doom help~ to see an overview of the available commands that =doom=
 provides, and ~doom help COMMAND~ to display documentation for a particular
 ~COMMAND~.
 
-#+begin_quote
+**** Add Doom to PATH
 I recommend you add =~/.emacs.d/bin= to your ~PATH~ so you can call =doom=
-directly and from anywhere. Accomplish this by adding this to your .bashrc or
-.zshrc file: ~export PATH="$HOME/.emacs.d/bin:$PATH"~
+directly and from anywhere. 
+To accomplish this: (For Debian-based distros. Mileage may vary in other distro 
+families.)
+#+BEGIN_SRC bash
+echo 'export PATH="$HOME/.emacs.d/bin:$PATH" #Add Doom to Path' >> ~/.profile
+source ~/.profile
+#+END_SRC
+
+/Note: Using .profile is recommended per [[https://help.ubuntu.com/
+community/EnvironmentVariables#A.2BAH4-.2F.profile][Ubuntu Documentation]]./
+#+begin_quote
+Shell config files such as ~/.bashrc, ~/.bash_profile, and ~/.bash_login are 
+often suggested for setting environment variables. While this may work on Bash 
+shells for programs started from the shell, variables set in those files are 
+not available by default to programs started from the graphical environment in 
+a desktop session. 
 #+end_quote
+/Methods may vary in other distro families./
 
 *** Install Doom Manually
 If you'd rather install Doom yourself, instead of rely on the magic of =doom


### PR DESCRIPTION
Updated the instructions for adding Doom to PATH during Linux installation, based on recommendations from Ubuntu Documentation to use .profile instead of .bashrc or .zshrc.