### PR TITLE
Fix Elisp file template header in doom-private-dir.

### DIFF
--- a/modules/editor/file-templates/autoload.el
+++ b/modules/editor/file-templates/autoload.el
@@ -89,6 +89,8 @@ evil is loaded and enabled)."
              (match-string 1 path))
             ((file-in-directory-p path doom-emacs-dir)
              (file-relative-name path doom-emacs-dir))
+            ((file-in-directory-p path doom-private-dir)
+             (file-relative-name path doom-private-dir))
             ((abbreviate-file-name path))))))
 
 


### PR DESCRIPTION
Currently, when I create a `.el` file anywhere in `doom-private-dir`, the automatically generated file header contains an absolute path. This PR fixes this issue by extending `+file-templates-get-short-path` to return a path relative to `doom-private-dir`, where applicable, as it already does with `doom-emacs-dir`.