### PR TITLE
racket-mode: avoid using flycheck-disable-checker

### DIFF
--- a/modules/lang/racket/config.el
+++ b/modules/lang/racket/config.el
@@ -34,7 +34,8 @@
     (when (featurep! :checkers syntax)
       (add-hook! 'racket-xp-mode-hook
         (defun +racket-disable-flycheck-h ()
-          (flycheck-disable-checker 'racket)))))
+          (unless (memq 'racket flycheck-disabled-checkers)
+            (push 'racket flycheck-disabled-checkers))))))
 
   (unless (or (featurep! :editor parinfer)
               (featurep! :editor lispy))

--- a/modules/lang/racket/config.el
+++ b/modules/lang/racket/config.el
@@ -34,8 +34,7 @@
     (when (featurep! :checkers syntax)
       (add-hook! 'racket-xp-mode-hook
         (defun +racket-disable-flycheck-h ()
-          (unless (memq 'racket flycheck-disabled-checkers)
-            (push 'racket flycheck-disabled-checkers))))))
+          (cl-pushnew 'racket flycheck-disabled-checkers)))))
 
   (unless (or (featurep! :editor parinfer)
               (featurep! :editor lispy))


### PR DESCRIPTION
The problem is that at this point, flycheck-mode might not be active
yet. Calling flycheck-disable-checker will always call (flycheck-buffer)
which would result in an error: (user-error "Flycheck mode disabled")