### PR TITLE
Fix deduplication in add-load-path!

### DIFF
--- a/core/core-lib.el
+++ b/core/core-lib.el
@@ -328,7 +328,7 @@ The current file is the file from which `add-to-load-path!' is used."
   `(let ((default-directory ,(dir!))
          file-name-handler-alist)
      (dolist (dir (list ,@dirs))
-       (cl-pushnew (expand-file-name dir) load-path))))
+       (cl-pushnew (expand-file-name dir) load-path :test #'string=))))
 
 (defmacro after! (package &rest body)
   "Evaluate BODY after PACKAGE have loaded.


### PR DESCRIPTION
Currently, `add-load-path!` doesn’t check for duplicates in `load-path`, because `cl-pushnew` tests for equality with `eql`. This changes the predicate to `string=`, fixing the bug.