### PR TITLE
Fix python-pytest-popup

### DIFF
--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -183,7 +183,7 @@ called.")
 
 
 (use-package! python-pytest
-  :defer t
+  :commands python-pytest-dispatch
   :init
   (map! :after python
         :localleader

--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -194,7 +194,7 @@ called.")
         "t" #'python-pytest-function-dwim
         "T" #'python-pytest-function
         "r" #'python-pytest-repeat
-        "p" #'python-pytest-popup))
+        "p" #'python-pytest-dispatch))
 
 
 ;;


### PR DESCRIPTION
It is now obsolete, it has been renamed to `python-pytest-dispatch` in
https://github.com/wbolster/emacs-python-pytest/commit/ee61741d4e35dc639b5e269efaa488d743da9c35

Not sure if we need to update the keybindings, though.