### PR TITLE
Updates getting_started.org following the release of Emacs 27.1

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -248,8 +248,6 @@ to least recommended for Doom (based on compatibility).
   ln -s /usr/local/opt/emacs-plus/Emacs.app /Applications/Emacs.app
   #+END_SRC
 
-  Replace =emacs-plus= with =emacs-plus@27= to install Emacs 27.x instead.
-
 - [[https://bitbucket.org/mituharu/emacs-mac/overview][emacs-mac]] is another acceptable option. It offers slightly better integration
   with macOS, native emojis and better childframe support. However, at the time
   of writing, it [[https://github.com/railwaycat/homebrew-emacsmacport/issues/52][lacks multi-tty support]] (which impacts daemon usage):


### PR DESCRIPTION
Emacs 27.1 has been released and emacs-plus (https://github.com/d12frosted/homebrew-emacs-plus) now installs 27.x by default.