### PR TITLE
Updated Mac installation instructions

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -248,8 +248,6 @@ to least recommended for Doom (based on compatibility).
   ln -s /usr/local/opt/emacs-plus/Emacs.app /Applications/Emacs.app
   #+END_SRC
 
-  Replace =emacs-plus= with =emacs-plus@27= to install Emacs 27.x instead.
-
 - [[https://bitbucket.org/mituharu/emacs-mac/overview][emacs-mac]] is another acceptable option. It offers slightly better integration
   with macOS, native emojis and better childframe support. However, at the time
   of writing, it [[https://github.com/railwaycat/homebrew-emacsmacport/issues/52][lacks multi-tty support]] (which impacts daemon usage):


### PR DESCRIPTION
d12frosted's homebrew-emacs-plus was updated to Emacs 27, so the addendum is no longer necessary