### PR TITLE
Fix typo in `:ui hydra` module readme

### DIFF
--- a/modules/ui/hydra/README.org
+++ b/modules/ui/hydra/README.org
@@ -24,7 +24,7 @@ This module provides no flags.
 + [[https://github.com/abo-abo/hydra][hydra]]
 
 * Prerequisites
-This module has no prereqisites.
+This module has no prerequisites.
 
 * Configuration
 Configuring this module is only setting bindings to the provided hydra, or


### PR DESCRIPTION
Not a big deal but I found this typo.