### PR TITLE
Improve highlighting of Julia operators

### DIFF
--- a/modules/lang/julia/config.el
+++ b/modules/lang/julia/config.el
@@ -12,20 +12,30 @@
      mode
      `((,(let ((OR "\\|"))
            (concat "\\("  ; stolen `matlab.el' operators first
-                   "[<>!]=?" OR
+                   "[<>]=?" OR
                    "\\.[/*^']" OR
+                   "===" OR
                    "==" OR
                    "=>" OR
                    "\\<xor\\>" OR
                    "[-+*\\/^&|$]=?" OR  ; this has to come before next (updating operators)
-                   "[-!^&|*+\\/~:]" OR
+                   "[-^&|*+\\/~]" OR
+                   ;; `:` defines a symbol in Julia and must not be highlighted
+                   ;; as an operator. The only operators that start with `:` are
+                   ;; `:<` and `::`.
+                   "[:<]:" OR
+                   ;; Julia variables and names can have `!`. Thus, `!` must be
+                   ;; highlighted as a single operator only in some
+                   ;; circumstances. However, full support can only be
+                   ;; implemented by a full parser. Thus, here, we will handle
+                   ;; only the simple cases.
+                   "[[:space:]]!=?=?" OR "^!=?=?" OR
+                   ;; The other math operators that starts with `!`.
                    ;; more extra julia operators follow
                    "[%$]" OR
                    ;; bitwise operators
                    ">>>" OR ">>" OR "<<" OR
                    ">>>=" OR ">>" OR "<<" OR
-                   ;; comparison
-                   "[<>!]=?" OR
                    "\\)"))
         1 font-lock-type-face)))))
 

--- a/modules/lang/julia/config.el
+++ b/modules/lang/julia/config.el
@@ -12,6 +12,10 @@
      mode
      `((,(let ((OR "\\|"))
            (concat "\\("  ; stolen `matlab.el' operators first
+                   ;; `:` defines a symbol in Julia and must not be highlighted
+                   ;; as an operator. The only operators that start with `:` are
+                   ;; `:<` and `::`. This must be defined before `<`.
+                   "[:<]:" OR
                    "[<>]=?" OR
                    "\\.[/*^']" OR
                    "===" OR
@@ -20,10 +24,6 @@
                    "\\<xor\\>" OR
                    "[-+*\\/^&|$]=?" OR  ; this has to come before next (updating operators)
                    "[-^&|*+\\/~]" OR
-                   ;; `:` defines a symbol in Julia and must not be highlighted
-                   ;; as an operator. The only operators that start with `:` are
-                   ;; `:<` and `::`.
-                   "[:<]:" OR
                    ;; Julia variables and names can have `!`. Thus, `!` must be
                    ;; highlighted as a single operator only in some
                    ;; circumstances. However, full support can only be


### PR DESCRIPTION
Hi!

This commit fix some problems related to highlighting math operators in Julia that created some problems like https://github.com/JuliaEditorSupport/julia-emacs/issues/141

The problem is that, different from MATLAB, Julia can have function and variable names with `!`. Thus, I tried to address some cases, like `!` before an empty space or beginning of the line. However, there things like `a==!var` or `(!var)` is also valid but cannot be treated inside this function. For a full support, we would need a full parser.

I also add some tweaks for `:` (which defined a symbol) and also added the operator `===`.

Before:

<img width="338" alt="Captura de Tela 2020-08-18 às 20 59 07" src="https://user-images.githubusercontent.com/1068295/90577127-6986b000-e196-11ea-9ac9-ae2807f8ace9.png">

After:

<img width="334" alt="Captura de Tela 2020-08-18 às 21 00 10" src="https://user-images.githubusercontent.com/1068295/90577134-6d1a3700-e196-11ea-865b-cae6a34b7327.png">
