### PR TITLE
Configure dired-git-info variables

### DIFF
--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -173,6 +173,8 @@ we have to clean it up ourselves."
 (map! :after dired
       :map (dired-mode-map ranger-mode-map)
       :ng ")" #'dired-git-info-mode)
+(setq dgi-commit-message-format "%h %cs %s"
+      dgi-auto-hide-details-p nil)
 (after! wdired
   ;; Temporarily disable `dired-git-info-mode' when entering wdired, due to
   ;; reported incompatibilities.


### PR DESCRIPTION
`dgi-commit-message-format` set to

`%h`  - Abbreviated commit hash
`%cs` - committer date, short format (YYYY-MM-DD)
`%s`  - subject

First two are fixed-width, which makes it look neater.

`dgi-auto-hide-details-p` set to `nil`, assuming a wide window.

I'm not sure if these are supposed to be inside `use-package!` after reading the previous commits to the file.

Screenshot:

![](https://i.imgur.com/i7HRniD.jpg)
