### PR TITLE
Use `.` instead of `source` for `sh` shell

### DIFF
--- a/bin/doom
+++ b/bin/doom
@@ -7,7 +7,7 @@
 :; _DOOMPOST="$_DOOMBASE/.local/.doom.sh"
 :; $EMACS --no-site-file --script "$0" -- "$@"
 :; CODE=$?
-:; [ -x "$_DOOMPOST" ] && source "$_DOOMPOST"
+:; [ -x "$_DOOMPOST" ] && . "$_DOOMPOST"
 :; exit $CODE
 
 ;; CLI ops tend to eat a lot of memory. To speed it up, stave off the GC, but


### PR DESCRIPTION
Related to issue #3781 

> In Bourne shell(sh), use the . command to source a file

- https://stackoverflow.com/a/13702462/768793
- https://stackoverflow.com/a/4732283/768793