### PR TITLE
Use separate geiser REPLs per project

### DIFF
--- a/modules/lang/scheme/config.el
+++ b/modules/lang/scheme/config.el
@@ -10,7 +10,7 @@
   :init
   (setq geiser-active-implementations '(guile chicken mit chibi chez)
         geiser-autodoc-identifier-format "%s → %s"
-        geiser-smart-tab-p t)
+        geiser-repl-current-project-function 'doom-project-root)
   (unless (featurep! :lang racket)
     (push 'racket geiser-active-implementations))
   (after! scheme                        ; built-in


### PR DESCRIPTION
By default geiser will re-use an existing REPL with the same interpreter.  This doesn't work well when with multiple projects using dir-locals or direnv to provide project-specific settings that affect the REPL (ie. binary and library paths).

Support for per-project REPLs was added upstream; this patch enables it by default for doom.

Also disabling `geiser-smart-tab-p` because TAB needs to stay in its lane.

@elais ping