### PR TITLE
ArchLinux packages now have 27.1 as default

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -155,8 +155,7 @@ pacman -S git emacs ripgrep
 pacman -S fd
 #+END_SRC
 
-The above installs Emacs 26.3 (at the time of writing). To acquire Emacs 27
-[[https://aur.archlinux.org/packages/emacs27-git/][emacs27-git]] is available on the AUR.
+The above installs Emacs 27 (at the time of writing).
 
 **** NixOS
 On NixOS Emacs 26.3 can be installed via ~nix-env -Ai nixos.emacs~, or


### PR DESCRIPTION
https://www.archlinux.org/packages/extra/x86_64/emacs/

We could point to emacs-git AUR package for emacs 28:
https://aur.archlinux.org/packages/emacs-git/

But I think the reference to emacs 27 was there simply because emacs 27
is the recommended version so I didn't include a replacement AUR link in this PR.