### PR TITLE
ui/nav-flash add vterm to +nav-flash-blink-cursor-maybe

### DIFF
--- a/modules/ui/nav-flash/autoload.el
+++ b/modules/ui/nav-flash/autoload.el
@@ -14,11 +14,12 @@ jumping to another part of the file)."
 
 ;;;###autoload
 (defun +nav-flash-blink-cursor-maybe (&rest _)
-  "Like `+nav-flash-blink-cursor', but no-ops if in special-mode or term-mode,
-or triggered from one of `+nav-flash-exclude-commands'."
+  "Like `+nav-flash-blink-cursor', but no-ops if in special-mode, term-mode,
+vterm-mode, or triggered from one of `+nav-flash-exclude-commands'."
   (unless (or (memq this-command +nav-flash-exclude-commands)
               (bound-and-true-p so-long-minor-mode)
-              (derived-mode-p 'so-long-mode 'special-mode 'term-mode)
+              (derived-mode-p 'so-long-mode 'special-mode 'term-mode
+                              'vterm-mode)
               (and (equal (point-marker) (car +nav-flash--last-point))
                    (equal (selected-window) (cdr +nav-flash--last-point))))
     (+nav-flash-blink-cursor)


### PR DESCRIPTION
`vterm-mode` is morally equivalent to `term-mode` (but `vterm-mode` is not derived from `term-mode`), so I would expect functions that exclude `term-mode` to exclude `vterm-mode` as well.