### PR TITLE
Add Rusty Object Notation to the Rust module

### DIFF
--- a/modules/lang/rust/config.el
+++ b/modules/lang/rust/config.el
@@ -80,3 +80,5 @@
   (set-lookup-handlers! 'rustic-mode
     :definition '(racer-find-definition :async t)
     :documentation '+rust-racer-lookup-documentation))
+
+(use-package! ron-mode)

--- a/modules/lang/rust/packages.el
+++ b/modules/lang/rust/packages.el
@@ -4,3 +4,4 @@
 (package! rustic :pin "75b99201bb4e7a0bd990c006896ad7897f284ca2")
 (unless (featurep! +lsp)
   (package! racer :pin "a0bdf778f01e8c4b8a92591447257422ac0b455b"))
+(package! ron-mode :pin "e7bfa03623")


### PR DESCRIPTION
# Add RON support to the Rust module
#### About RON
Rusty Object Notation (RON) is a new JSON-like format used by several projects written in the Rust programming language (most predominantly, it is the main configuration format in the Amethyst game engine). This project adds support for it into Doom EMACS.

---
#### Why not add it into it's own module?

1. It is an exceptionally small project: The package does not exceed 70 lines at the time of writing.

2. It is only used within the Rust ecosystem