### PR TITLE
[Fix] string comparison in TERM check in org-capture

### DIFF
--- a/bin/org-capture
+++ b/bin/org-capture
@@ -31,7 +31,7 @@ shift $((OPTIND-1))
 [ -t 0 ] && str="$*" || str=$(cat)
 
 # Fix incompatible terminals that cause odd 'not a valid terminal' errors
-[ $TERM -eq "alacritty" ] && export TERM=xterm-256color
+[ $TERM = "alacritty" ] && export TERM=xterm-256color
 
 if [ $daemon ]; then
   emacsclient -a "" \


### PR DESCRIPTION
The `bin/org-capture` script was using `-eq`, which is a numeric comparison, and was producing an "integer expression expected" error. Changed to `=`, the string comparison operator.