### PR TITLE
checkers/spell: add support for using enchant

### DIFF
--- a/docs/modules.org
+++ b/docs/modules.org
@@ -33,7 +33,7 @@ loaded last*, before =:config= modules.
 
 * :checkers
 + syntax =+childframe= - Live error/warning highlights
-+ spell =+everywhere +aspell +hunspell= - Spell checking
++ spell =+everywhere +aspell +hunspell +enchant= - Spell checking
 + grammar - TODO
 
 * :completion

--- a/modules/checkers/spell/README.org
+++ b/modules/checkers/spell/README.org
@@ -11,6 +11,7 @@
 - [[#prerequisites][Prerequisites]]
   - [[#aspell][Aspell]]
   - [[#hunspell][Hunspell]]
+  - [[#enchant][Enchant]]
 - [[#features][Features]]
 - [[#configuration][Configuration]]
   - [[#changing-how-quickly-spell-fu-spellchecks-after-changes][Changing how quickly spell-fu spellchecks after changes]]
@@ -23,7 +24,7 @@
 - [[#troubleshooting][Troubleshooting]]
 
 * Description
-This modules provides spellchecking powered by =aspell= or =hunspell=.
+This modules provides spellchecking powered by =aspell=, =hunspell= or =enchant=.
 
 Spellcheck is automatically loaded in many ~text-mode~ derivatives, which
 includes ~org-mode~, ~markdown-mode~, the Git Commit buffer (from magit),
@@ -37,6 +38,7 @@ This module has no dedicated maintainers.
   but supports multiple languages and dictionaries.
 + =+aspell= Use =aspell= as a backend for correcting words.
 + =+hunspell= Use =hunspell= as a backend for correcting words.
++ =+enchant= Use =enchant-2= as a backend for correcting words.
 + =+everywhere= Spell check in programming modes as well (in comments).
 
 ** Plugins
@@ -50,14 +52,15 @@ This module has no dedicated maintainers.
   + [[https://gitlab.com/ideasman42/emacs-spell-fu][spell-fu]]
 
 * Prerequisites
-This module requires one of =aspell= or =hunspell= installed on your system and
-in your ~PATH~. They also need dictionaries for your language(s).
+This module requires one of =aspell=, =hunspell= or =enchant-2=
+installed on your system and in your ~PATH~.
+They also need dictionaries for your language(s).
 
 #+begin_quote
 If you *are not* using =+flyspell=, you will need aspell (and a dictionary)
-installed whether or not you have =+hunspell= enabled. This is because
-=spell-fu= does not support generating the word list with anything other than
-=aspell= yet.
+installed whether or not you have =+hunspell= or =+enchant= enabled.
+This is because =spell-fu= does not support generating the word list
+with anything other than =aspell= yet.
 #+end_quote
 
 ** Aspell
@@ -77,8 +80,23 @@ installed whether or not you have =+hunspell= enabled. This is because
 
 ** TODO Hunspell
 
+** Enchant
++ Ubuntu: ~apt-get install enchant-2~
++ Arch Linux: ~pacman -S enchant~
++ NixOS:
+  #+BEGIN_SRC nix
+  {
+    environment.systemPackages = with pkgs; [
+      enchant
+    ];
+  }
+  #+END_SRC
+
+  Enchant is just a wrapper for other spelling libraries
+  and you will need to have at least one of the supported backends installed as well.
+
 * Features
-+ Spell checking and correction using =aspell= or =hunspell=.
++ Spell checking and correction using =aspell=, =hunspell= or =enchant=.
 + Ignores source code inside org or markdown files.
 + Lazily spellchecking recent changes only when idle.
 + Choosing suggestions using completion interfaces (=ivy= or =helm=).

--- a/modules/checkers/spell/config.el
+++ b/modules/checkers/spell/config.el
@@ -16,15 +16,17 @@
             '("#\\+BEGIN_SRC" . "#\\+END_SRC")
             '("#\\+BEGIN_EXAMPLE" . "#\\+END_EXAMPLE"))
 
-  ;; Enable either aspell or hunspell.
-  ;;   If no module flags are given, enable either aspell or hunspell if their
-  ;;     binary is found.
-  ;;   If one of the flags `+aspell' or `+hunspell' is given, only enable that
-  ;;     spell checker.
+  ;; Enable either aspell, hunspell or enchant.
+  ;;   If no module flags are given, enable either aspell, hunspell or enchant
+  ;;     if their binary is found.
+  ;;   If one of the flags `+aspell', `+hunspell' or `+enchant' is given,
+  ;;     only enable that spell checker.
   (pcase (cond ((featurep! +aspell)   'aspell)
                ((featurep! +hunspell) 'hunspell)
-               ((executable-find "aspell")   'aspell)
-               ((executable-find "hunspell") 'hunspell))
+               ((featurep! +enchant)  'enchant)
+               ((executable-find "aspell")    'aspell)
+               ((executable-find "hunspell")  'hunspell)
+               ((executable-find "enchant-2") 'enchant))
     (`aspell
      (setq ispell-program-name "aspell"
            ispell-extra-args '("--sug-mode=ultra"
@@ -58,7 +60,10 @@
     (`hunspell
      (setq ispell-program-name "hunspell"))
 
-    (_ (doom-log "Spell checker not found. Either install `aspell' or `hunspell'"))))
+    (`enchant
+     (setq ispell-program-name "enchant-2"))
+
+    (_ (doom-log "Spell checker not found. Either install `aspell', `hunspell' or `enchant'"))))
 
 
 ;;


### PR DESCRIPTION
Support using [Enchant](https://abiword.github.io/enchant/).

Main motivation is using other backends than aspell/hunspell, but those can be used through enchant as well.