### PR TITLE
Automatically download reveal.js and use local copy, default to v4

### DIFF
--- a/modules/lang/org/README.org
+++ b/modules/lang/org/README.org
@@ -69,7 +69,7 @@ https://www.mfoot.com/blog/2015/11/22/literate-emacs-configuration-with-org-mode
 + =+pandoc= Enables pandoc integration into the Org exporter.
 + =+pomodoro= Enables a pomodoro timer for clocking time on tasks.
 + =+present= Enables integration with reveal.js, beamer and org-tree-slide, so
-  Emacs can be used for presentations.
+  Emacs can be used for presentations. It automatically downloads [[https://github.com/hakimel/reveal.js][reveal.js]].
 + =+pretty= Enables pretty unicode symbols for bullets and priorities, and
   better syntax highlighting for latex. Keep in mind: this can be expensive. If
   org becomes too slow, it'd be wise to disable this flag.

--- a/modules/lang/org/contrib/present.el
+++ b/modules/lang/org/contrib/present.el
@@ -14,8 +14,8 @@
 (use-package! org-re-reveal
   :after ox
   :init
-  (setq org-re-reveal-root "https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.9.2"
-        org-re-reveal-revealjs-version "3.8"))
+  (setq org-re-reveal-root (expand-file-name "../../" (locate-library "dist/reveal.js" t))
+        org-re-reveal-revealjs-version "4"))
 
 
 (use-package! org-tree-slide

--- a/modules/lang/org/contrib/present.el
+++ b/modules/lang/org/contrib/present.el
@@ -13,7 +13,7 @@
 
 (use-package! org-re-reveal
   :after ox
-  :init
+  :config
   (setq org-re-reveal-root (expand-file-name "../../" (locate-library "dist/reveal.js" t))
         org-re-reveal-revealjs-version "4"))
 

--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -69,7 +69,11 @@
     :recipe (:host github :repo "anler/centered-window-mode")
     :pin "f50859941ab5c7cbeaee410f2d38716252b552ac")
   (package! org-tree-slide :pin "7126a4365072a32898f169ead8fb59265dabc605")
-  (package! org-re-reveal :pin "7fe39d5d03ccc75d2811445d25cbbb473b53de76"))
+  (package! org-re-reveal :pin "7fe39d5d03ccc75d2811445d25cbbb473b53de76")
+  (package! revealjs
+    :recipe (:host github :repo "hakimel/reveal.js"
+             :files ("css" "dist" "js" "plugin"))
+    :pin "15815efe05ca69c35ce66cfdbf93316e1db66ecb"))
 (when (featurep! +roam)
   (package! org-roam :pin "c33867e6bc282ff0a69d4ef4a020db82604039bb")
   (when (featurep! :completion company)


### PR DESCRIPTION
The +present option now automatically checks out the reveal.js
repository and configures org-re-reveal to use it. It also now uses
reveal.js 4 instead of 3.9.2.