### PR TITLE
Rust module: Modify command for executing `cargo audit`

### DIFF
--- a/modules/lang/rust/autoload.el
+++ b/modules/lang/rust/autoload.el
@@ -23,4 +23,4 @@
 (defun +rust/cargo-audit ()
   "Run 'cargo audit' for the current project."
   (interactive)
-  (rustic-run-cargo-command "cargo audit -f"))
+  (rustic-run-cargo-command "cargo audit"))


### PR DESCRIPTION
I'm not sure if the execution of `cargo audit` with the `-f` flag has/had a specific reason. I opened an issue for this on #3852 to discuss this.