### PR TITLE
Filter directories when rebuilding straight repos

### DIFF
--- a/core/cli/packages.el
+++ b/core/cli/packages.el
@@ -490,8 +490,9 @@ If ELPA-P, include packages installed with package.el (M-x package-install)."
              (and (or repos-p regraft-repos-p)
                   (straight--directory-files (straight--repos-dir) nil nil 'sort))))
         (list (when builds-p
-                (seq-remove (doom-rpartial #'gethash straight--profile-cache)
-                            (straight--directory-files (straight--build-dir) nil nil 'sort)))
+                (seq-filter #'file-directory-p
+                            (seq-remove (doom-rpartial #'gethash straight--profile-cache)
+                                        (straight--directory-files (straight--build-dir) nil nil 'sort))))
               (when repos-p
                 (seq-remove (doom-rpartial #'straight--checkhash straight--repo-cache)
                             rdirs))


### PR DESCRIPTION
Fixes #3257 
This prevents auto-generated files like .DS_Store on macOS from causing an error when running `doom sync`