### PR TITLE
Fix non evil environment (void-variable evil-this-operator)

### DIFF
--- a/modules/config/default/autoload/deferred.el
+++ b/modules/config/default/autoload/deferred.el
@@ -13,8 +13,7 @@
   (setq prefix-arg current-prefix-arg
         unread-command-events
         (mapcar (lambda (e) (cons t e))
-                (vconcat (when (and (fboundp 'evil-this-operator)
-                                    evil-this-operator)
+                (vconcat (when (bound-and-true-p evil-this-operator)
                            (where-is-internal evil-this-operator
                                               evil-normal-state-map
                                               t))

--- a/modules/config/default/autoload/deferred.el
+++ b/modules/config/default/autoload/deferred.el
@@ -13,7 +13,8 @@
   (setq prefix-arg current-prefix-arg
         unread-command-events
         (mapcar (lambda (e) (cons t e))
-                (vconcat (when evil-this-operator
+                (vconcat (when (and (fboundp 'evil-this-operator)
+                                    evil-this-operator)
                            (where-is-internal evil-this-operator
                                               evil-normal-state-map
                                               t))


### PR DESCRIPTION
Non evil environment error

<details><pre>
Debugger entered--Lisp error: (void-variable evil-this-operator)
  (if evil-this-operator (progn (where-is-internal evil-this-operator evil-normal-state-map t)))
  (progn (if evil-this-operator (progn (where-is-internal evil-this-operator evil-normal-state-map t))))
  eval((progn (if evil-this-operator (progn (where-is-internal evil-this-operator evil-normal-state-map t)))) t)
  elisp--eval-last-sexp(nil)
  eval-last-sexp(nil)
  eros-eval-last-sexp(nil)
  #<subr funcall-interactively>(eros-eval-last-sexp nil)
  apply(#<subr funcall-interactively> (eros-eval-last-sexp nil))
  funcall-interactively(eros-eval-last-sexp nil)
  #<subr call-interactively>(eros-eval-last-sexp nil nil)
  apply(#<subr call-interactively> (eros-eval-last-sexp nil nil))
  explain-pause--wrap-call-interactively(#<subr call-interactively> eros-eval-last-sexp nil nil)
  apply(explain-pause--wrap-call-interactively #<subr call-interactively> (eros-eval-last-sexp nil nil))
  call-interactively(eros-eval-last-sexp nil nil)
  command-execute(eros-eval-last-sexp)

<pre></details>