### PR TITLE
Upgrade tide, enable xref-tide-xref-backend

### DIFF
--- a/modules/lang/javascript/config.el
+++ b/modules/lang/javascript/config.el
@@ -190,8 +190,7 @@ to tide."
   (set-company-backend! 'tide-mode 'company-tide)
   ;; navigation
   (set-lookup-handlers! 'tide-mode :async t
-    :definition #'tide-jump-to-definition
-    :references #'tide-references
+    :xref-backend #'xref-tide-xref-backend
     :documentation #'tide-documentation-at-point)
   (set-popup-rule! "^\\*tide-documentation" :quit t)
   ;; resolve to `doom-project-root' if `tide-project-root' fails

--- a/modules/lang/javascript/packages.el
+++ b/modules/lang/javascript/packages.el
@@ -17,6 +17,6 @@
 (package! skewer-mode :pin "e5bed351939c92a1f788f78398583c2f83f1bb3c")
 
 ;; Programming environment
-(package! tide :pin "f0b6dac4829c3daecf02bf445a5b41b4c68f2911")
+(package! tide :pin "fa617f54629dc53a3182251dd8076c9e7ac9effa")
 (when (featurep! :tools lookup)
   (package! xref-js2 :pin "6f1ed5dae0c2485416196a51f2fa92f32e4b8262"))


### PR DESCRIPTION
This allows one to use `xref-find-definitions-other-window` which has no (working) counterpart in tide itself