### PR TITLE
Return org-journal-is-journal to magic-mode-alist.

### DIFF
--- a/modules/lang/org/contrib/journal.el
+++ b/modules/lang/org/contrib/journal.el
@@ -18,6 +18,7 @@
                       buffer-file-name (expand-file-name org-journal-dir org-directory))
                      (require 'org-journal nil t)))
         (delq! '+org-journal-p magic-mode-alist 'assq)
+        (add-to-list 'magic-mode-alist '(org-journal-is-journal . org-journal-mode))
         (org-journal-is-journal))))
 
   ;; `org-journal-dir' defaults to "~/Documents/journal/", which is an odd


### PR DESCRIPTION
After first lazy load, put the `org-journal-is-journal` back to recognize
correctly journal files. 