### PR TITLE
Fix installation instructions for Archlinux in direnv/README.org

### DIFF
--- a/modules/tools/direnv/README.org
+++ b/modules/tools/direnv/README.org
@@ -53,8 +53,10 @@ brew install direnv
 #+END_SRC
 
 ** Arch Linux
+~direnv~ is available on the AUR
+
 #+BEGIN_SRC bash
-sudo pacman -S direnv
+yay -S direnv
 #+END_SRC
 
 ** NixOS


### PR DESCRIPTION
In Archlinux,  `direnv` is available though the AUR, not the official repositories.