### PR TITLE
Added warning for clang-format in doom doctor.

### DIFF
--- a/modules/lang/java/doctor.el
+++ b/modules/lang/java/doctor.el
@@ -8,5 +8,6 @@
 (unless (executable-find "javac")
   (warn! "Couldn't find the javac executable, are you sure the JDK is installed?"))
 
-(unless (executable-find "clang-format")
-  (warn! "Couldn't find clang-format. Code formatting will not work."))
+(when (featurep! :editor format)
+  (unless (executable-find "clang-format")
+    (warn! "Couldn't find clang-format. Code formatting will not work.")))

--- a/modules/lang/java/doctor.el
+++ b/modules/lang/java/doctor.el
@@ -7,3 +7,6 @@
 
 (unless (executable-find "javac")
   (warn! "Couldn't find the javac executable, are you sure the JDK is installed?"))
+
+(unless (executable-find "clang-format")
+  (warn! "Couldn't find clang-format. Code formatting will not work."))


### PR DESCRIPTION
Code formatting in Java doesn't work without clang-format, but no
warning is shown in `doom doctor`.