### PR TITLE
modules/checkers/spell: remove tex option

### DIFF
--- a/modules/checkers/spell/config.el
+++ b/modules/checkers/spell/config.el
@@ -28,8 +28,7 @@
     (`aspell
      (setq ispell-program-name "aspell"
            ispell-extra-args '("--sug-mode=ultra"
-                               "--run-together"
-                               "--dont-tex-check-comments"))
+                               "--run-together"))
 
      (unless ispell-dictionary
        (setq ispell-dictionary "en"))


### PR DESCRIPTION
It causes aspell 0.60.8 to fail with message `the key "check-tex-comments" is unknown`.