### PR TITLE
Fix magic-mode-alist for org-journal after loading

### DIFF
--- a/modules/lang/org/contrib/journal.el
+++ b/modules/lang/org/contrib/journal.el
@@ -18,6 +18,7 @@
                       buffer-file-name (expand-file-name org-journal-dir org-directory))
                      (require 'org-journal nil t)))
         (delq! '+org-journal-p magic-mode-alist 'assq)
+        (add-to-list 'magic-mode-alist '(org-journal-is-journal . org-journal-mode))
         (org-journal-is-journal))))
 
   ;; `org-journal-dir' defaults to "~/Documents/journal/", which is an odd


### PR DESCRIPTION
In order for org-journal files to be opened in org-mode, some function needs to be hooked with `magic-mode-alist`. Org-journal handles it with function `org-journal-is-journal`, while Doom overrides the behavior due to lazy-loading concern, and add `+org-journal-p` instead. When `+org-journal-p` decides the loading of org-journal is inevitable, it loads it, and remove itself from `magic-mode-alist`.

However, it didn't add `org-journal-is-journal` back, so there is nothing in `magic-mode-alist` that handles the mode for an org-journal file. This PR fixes the behavior.