### PR TITLE
nix: remove company-nixos-options

### DIFF
--- a/modules/lang/nix/config.el
+++ b/modules/lang/nix/config.el
@@ -5,7 +5,6 @@
   :mode "\\.nix\\'"
   :config
   (set-repl-handler! 'nix-mode #'+nix/open-repl)
-  (set-company-backend! 'nix-mode 'company-nixos-options)
   (set-lookup-handlers! 'nix-mode
     :documentation '(+nix/lookup-option :async t))
 

--- a/modules/lang/nix/packages.el
+++ b/modules/lang/nix/packages.el
@@ -4,8 +4,5 @@
 (package! nix-mode :pin "0cf1ea1e0ed330b59f47056d927797e625ba8f53")
 (package! nix-update :pin "fc6c39c2da3fcfa62f4796816c084a6389c8b6e7")
 
-(when (featurep! :completion company)
-  (package! company-nixos-options :pin "977b9a505ffc8b33b70ec7742f90e469b3168297"))
-
 (when (featurep! :completion helm)
   (package! helm-nixos-options :pin "977b9a505ffc8b33b70ec7742f90e469b3168297"))


### PR DESCRIPTION
This package blocks emacs for several seconds or even more if no network
is available. I have not seen any way to disable it.
It is unlikely that upstream will fix this anytime soon,
hence removing this package:

https://github.com/travisbhartwell/nix-emacs/issues/28

Upstream is not working on this package anymore:

https://github.com/travisbhartwell/nix-emacs/pull/46