### PR TITLE
Bump :tools lsp

### DIFF
--- a/modules/tools/lsp/packages.el
+++ b/modules/tools/lsp/packages.el
@@ -3,11 +3,11 @@
 
 (if (featurep! +eglot)
     (progn
-      (package! eglot :pin "5f873d288e1c5434c1640bef03555ed056cb0d35")
+      (package! eglot :pin "61b71ea769fa14887465517f70832861f7052816")
       (package! project :pin "da0333a697b18f0a863c1b1523d2fc7991b31174"))
-  (package! lsp-mode :pin "4145a70ce1d4bfb2463606ba34c5965080b080d9")
-  (package! lsp-ui :pin "c39ae3713f95a2d86e11fd1f77e89a671d08d18a")
+  (package! lsp-mode :pin "9a79593e8a4efd1b07e6503fc646df726eeb66b6")
+  (package! lsp-ui :pin "25552041f5af110c282fe8a2c714dec0f7a2320e")
   (when (featurep! :completion ivy)
-    (package! lsp-ivy :pin "4cdb739fc2bc47f7d4dcad824f9240c70c4cb37d"))
+    (package! lsp-ivy :pin "20cac6296e5038b7131ee6f34a96635f1d30fe3c"))
   (when (featurep! :completion helm)
-    (package! helm-lsp :pin "4263c967267b0579956b3b12ef32878a9ea80d97")))
+    (package! helm-lsp :pin "fc09aa0903ee6abe4955e9a6062dcea667ebff5a")))


### PR DESCRIPTION
A fix upstream gets rid of a (random) bug that forces users to restart emacs.
Specifically https://github.com/emacs-lsp/lsp-mode/issues/2141.