### PR TITLE
Notmuch module remove `*notmuch-hello*` buffer customizations + add some documentation

### DIFF
--- a/modules/email/notmuch/README.org
+++ b/modules/email/notmuch/README.org
@@ -19,6 +19,8 @@
   - [[#offlineimap][offlineimap]]
   - [[#mbsync][mbsync]]
   - [[#notmuch][notmuch]]
+  - [[#customize-notmuch-hello-buffer][Customize =*notmuch-hello*= buffer]]
+  - [[#changing-the-notmuch-landing-page][Changing the =notmuch= landing page]]
 - [[#troubleshooting][Troubleshooting]]
 
 * Description
@@ -35,13 +37,19 @@ This module makes Emacs an email client, using ~notmuch~.
 * Prerequisites
 This module requires:
 
-+ Either ~gmailieer~ (default), ~mbsync~ or ~offlineimap~ (to sync mail with)
-+ ~notmuch~, to index and tag your downloaded messages.
++ Either ~[[https://github.com/gauteh/lieer][gmailieer]]~ (default), ~mbsync~ or ~offlineimap~ (to sync mail with)
++ ~[[https://notmuchmail.org/][notmuch]]~, to index and tag your downloaded messages.
 + ~afew~, optionally to initially tag your downloaded messages.
-
 ** TODO MacOS
 
 ** TODO Arch Linux
+
+See: [[https://wiki.archlinux.org/index.php/Notmuch][Arch Wiki - Notmuch]]
+
+#+BEGIN_SRC sh
+pacman -S notmuch
+#+END_SRC
+
 ** NixOS
 #+BEGIN_SRC nix
 environment.systemPackages = with pkgs; [
@@ -57,6 +65,7 @@ environment.systemPackages = with pkgs; [
 
 ** TODO openSUSE
 ** TODO Debian/Ubuntu
+
 * TODO Features
 
 * Configuration
@@ -105,6 +114,30 @@ Before you can use =notmuch=, you need to index your email initially.
 
 #+BEGIN_SRC sh
 notmuch new
+#+END_SRC
+
+** Customize =*notmuch-hello*= buffer
+
+It is possible to change the =*notmuch-hello*= buffer if you want to.
+
+#+BEGIN_SRC emacs-lisp
+(use-package! notmuch
+  :config
+  (setq notmuch-show-log nil
+        notmuch-hello-sections `(notmuch-hello-insert-saved-searches
+                                 notmuch-hello-insert-alltags)
+        ;; Maybe you don't like seeing email headers when you write email either.
+        notmuch-message-headers-visible nil))
+#+END_SRC
+
+** Changing the =notmuch= landing page
+
+You may want to forego the =*notmuch-hello*= buffer by having ~M-x =notmuch~ or ~SPC o m~ take you straight to a search page.
+
+When using ~SPC o m~ the =+notmuch-home-function= is called. By default it uses the =notmuch= function and so has the same familiar behavior of running a vanilla install of notmuch-emacs. But, by overwriting this function you can run a custom search as your landing page.
+
+#+BEGIN_SRC emacs-lisp
+(setq +notmuch-home-function (lambda () (notmuch-search "tag:inbox")))
 #+END_SRC
 
 * Troubleshooting

--- a/modules/email/notmuch/README.org
+++ b/modules/email/notmuch/README.org
@@ -44,11 +44,13 @@ This module requires:
 
 ** Arch Linux
 Run one of the following commands.
+
 #+BEGIN_SRC sh
-#sudo pacman -S isync notmuch #mbsync
-## OR
-#sudo pacman -S offlineimap notmuch
-##+END_SRC
+pacman -S isync notmuch #mbsync
+#+END_SRC
+#+BEGIN_SRC sh
+pacman -S offlineimap notmuch
+#+END_SRC
 
 See: [[https://wiki.archlinux.org/index.php/Notmuch][Arch Wiki - Notmuch]]
 
@@ -117,12 +119,10 @@ notmuch new
 #+END_SRC
 
 ** Customize =*notmuch-hello*= buffer
-
 It is possible to change the =*notmuch-hello*= buffer if you want to.
 
 #+BEGIN_SRC emacs-lisp
-(use-package! notmuch
-  :config
+(after! notmuch
   (setq notmuch-show-log nil
         notmuch-hello-sections `(notmuch-hello-insert-saved-searches
                                  notmuch-hello-insert-alltags)
@@ -132,9 +132,13 @@ It is possible to change the =*notmuch-hello*= buffer if you want to.
 
 ** Changing the =notmuch= landing page
 
-You may want to forego the =*notmuch-hello*= buffer by having ~M-x =notmuch~ or ~SPC o m~ take you straight to a search page.
+You may want to forego the =*notmuch-hello*= buffer by having ~M-x =notmuch~ or
+~SPC o m~ take you straight to a search page.
 
-When using ~SPC o m~ the =+notmuch-home-function= is called. By default it uses the =notmuch= function and so has the same familiar behavior of running a vanilla install of notmuch-emacs. But, by overwriting this function you can run a custom search as your landing page.
+When using ~SPC o m~ the =+notmuch-home-function= is called. By default it uses
+the =notmuch= function and so has the same familiar behavior of running a
+vanilla install of notmuch-emacs. But, by overwriting this function you can run
+a custom search as your landing page.
 
 #+BEGIN_SRC emacs-lisp
 (setq +notmuch-home-function (lambda () (notmuch-search "tag:inbox")))

--- a/modules/email/notmuch/README.org
+++ b/modules/email/notmuch/README.org
@@ -42,13 +42,15 @@ This module requires:
 + ~afew~, optionally to initially tag your downloaded messages.
 ** TODO MacOS
 
-** TODO Arch Linux
+** Arch Linux
+Run one of the following commands.
+#+BEGIN_SRC sh
+#sudo pacman -S isync notmuch #mbsync
+## OR
+#sudo pacman -S offlineimap notmuch
+##+END_SRC
 
 See: [[https://wiki.archlinux.org/index.php/Notmuch][Arch Wiki - Notmuch]]
-
-#+BEGIN_SRC sh
-pacman -S notmuch
-#+END_SRC
 
 ** NixOS
 #+BEGIN_SRC nix
@@ -94,7 +96,7 @@ This module uses =Gmailier= by default. To use =mbsync=, change ~+notmuch-sync-b
 (setq +notmuch-sync-backend 'mbsync)
 #+END_SRC
 
-The steps needed to set up =mu4e= with =mbsync= are very similar to the ones for
+The steps needed to set up =notmuch= with =mbsync= are very similar to the ones for
 [[*offlineimap][offlineimap]].
 
 Start with writing a ~\~/.mbsyncrc~. An example for GMAIL can be found on
@@ -103,8 +105,6 @@ page]] contains all needed information to set up your own.
 
 Next you can download your email with ~mbsync --all~. This may take a while, but
 should be quicker than =offlineimap= ;).
-
-You can now proceed with the [[*mu and mu4e][mu and mu4e]] section.
 
 ** notmuch
 You should have your email downloaded already. If you have not, you need to set

--- a/modules/email/notmuch/autoload.el
+++ b/modules/email/notmuch/autoload.el
@@ -12,7 +12,7 @@
         (if-let* ((buf (cl-find-if (lambda (it) (string-match-p "^\\*notmuch" (buffer-name (window-buffer it))))
                                    (doom-visible-windows))))
             (select-window (get-buffer-window buf))
-          (notmuch-search "tag:inbox"))
+          (funcall +notmuch-home-function))
         (+workspace/display))
     ('error
      (+notmuch/quit)

--- a/modules/email/notmuch/config.el
+++ b/modules/email/notmuch/config.el
@@ -2,6 +2,9 @@
 
 ;; FIXME This module is a WIP!
 
+(defvar +notmuch-home-function #'notmuch
+  "Function for customizing the landing page for doom-emacs =notmuch.")
+
 (defvar +notmuch-sync-backend 'gmi
   "Which backend to use. Can be either gmi, mbsync, offlineimap or nil (manual).")
 
@@ -27,8 +30,6 @@
   (set-popup-rule! "^\\*notmuch-hello" :side 'left :size 30 :ttl 0)
 
   (setq notmuch-fcc-dirs nil
-        notmuch-show-logo nil
-        notmuch-message-headers-visible nil
         message-kill-buffer-on-exit t
         message-send-mail-function 'message-send-mail-with-sendmail
         notmuch-search-oldest-first nil
@@ -42,17 +43,12 @@
           ("tags" . "(%s)"))
         notmuch-tag-formats
         '(("unread" (propertize tag 'face 'notmuch-tag-unread)))
-        notmuch-hello-sections
-        '(notmuch-hello-insert-saved-searches
-          notmuch-hello-insert-alltags)
         notmuch-saved-searches
         '((:name "inbox"   :query "tag:inbox not tag:trash" :key "i")
           (:name "flagged" :query "tag:flagged"             :key "f")
           (:name "sent"    :query "tag:sent"                :key "s")
           (:name "drafts"  :query "tag:draft"               :key "d"))
         notmuch-archive-tags '("-inbox" "-unread"))
-
-  ;; (setq-hook! 'notmuch-show-mode-hook line-spacing 0)
 
   ;; only unfold unread messages in thread by default
   (add-hook 'notmuch-show-hook #'+notmuch-show-expand-only-unread-h)


### PR DESCRIPTION
@hlissner I would like to progress development of this module if no one else has interest. It seems to have been in a WIP state for a while.

What I did here is remove some aesthetic customizations that the doom module currently does on the notmuch-hello buffer. I think these customizations are easy to achieve with user config and I provided documentation to do so. As a user of `notmuch` with vanilla emacs I've grown very used to landing on the normal notmuch-hello buffer and I think that should be the default when using `notmuch` in doom as well.

I think I've struck a decent balance here of having unsurprising defaults, but also easy customization for those that want it. Please consider this PR for merge.