### PR TITLE
Notmuch -- make +afew feature and  fix +notmuch/update buffer kill

### DIFF
--- a/modules/email/notmuch/README.org
+++ b/modules/email/notmuch/README.org
@@ -19,13 +19,14 @@
   - [[#offlineimap][offlineimap]]
   - [[#mbsync][mbsync]]
   - [[#notmuch][notmuch]]
+  - [[#notmuch-sync-backend][+notmuch-sync-backend]]
 - [[#troubleshooting][Troubleshooting]]
 
 * Description
 This module makes Emacs an email client, using ~notmuch~.
 
 ** Module Flags
-+ This module install no module flags.
++ =+afew=
 
 
 ** Plugins
@@ -105,6 +106,18 @@ Before you can use =notmuch=, you need to index your email initially.
 
 #+BEGIN_SRC sh
 notmuch new
+#+END_SRC
+
+** +notmuch-sync-backend
+
+Setting this variable to =`gmi=, =`mbsync=, =`mbsync-xdg=, or ='offlineimap= will run commands that sync your notmuch database using the supported tools.
+If you have a unique way of indexing notmuch emails or if you want to alter the commands that are run setting =+notmuch-sync-backend= to ='custom= will run the command stored in the =+notmuch-sync-command= variable.
+
+#+BEGIN_SRC emacs-lisp
+(use-package! notmuch
+  :init
+  (setq +notmuch-sync-backend 'custom
+        +notmuch-sync-command "my-notmuch-sync-cmd"))
 #+END_SRC
 
 * Troubleshooting

--- a/modules/email/notmuch/autoload.el
+++ b/modules/email/notmuch/autoload.el
@@ -29,31 +29,47 @@
   (doom-kill-matching-buffers "^\\*notmuch")
   (+workspace/delete "*MAIL*"))
 
+
+(defmacro notmuch--if-compile (command on-success &optional on-failure)
+  (declare (indent 2))
+  `(with-current-buffer (compile ,command t)
+     (let ((w (get-buffer-window (current-buffer))))
+       (select-window w)
+       (add-hook
+        'compilation-finish-functions
+        (lambda (buf status)
+          (if (equal status "finished\n")
+              (progn
+                (delete-window w)
+                (kill-buffer buf)
+                ,on-success)
+            ,on-failure))
+        nil 'local))))
+
+(defun +notmuch-get-sync-command ()
+  (let ((afew-cmd "afew -a -t")
+         (sync-cmd (pcase +notmuch-sync-backend
+                (`gmi
+                 (concat "cd " +notmuch-mail-folder " && gmi sync && notmuch new"))
+                (`mbsync
+                 "mbsync -a && notmuch new")
+                (`mbsync-xdg
+                 "mbsync -c \"$XDG_CONFIG_HOME\"/isync/mbsyncrc -a && notmuch new")
+                (`offlineimap
+                 "offlineimap && notmuch new")
+                (`custom +notmuch-sync-command))))
+    (if (featurep! +afew)
+        (format "%s && %s" sync-cmd afew-cmd)
+      sync-cmd)))
+
 ;;;###autoload
 (defun +notmuch/update ()
   (interactive)
-  ;; create output buffer and jump to beginning
-  (let ((buf (get-buffer-create "*notmuch update*")))
-    (with-current-buffer buf
-      (erase-buffer))
-    (pop-to-buffer buf nil t)
-    (set-process-sentinel
-     (start-process-shell-command
-      "notmuch update" buf
-      (pcase +notmuch-sync-backend
-        (`gmi
-         (concat "cd " +notmuch-mail-folder " && gmi push && gmi pull && notmuch new && afew -a -t"))
-        (`mbsync
-         "mbsync -a && notmuch new && afew -a -t")
-        (`mbsync-xdg
-         "mbsync -c \"$XDG_CONFIG_HOME\"/isync/mbsyncrc -a && notmuch new && afew -a -t")
-        (`offlineimap
-         "offlineimap && notmuch new && afew -a -t")
-        (`custom +notmuch-sync-command)))
-     ;; refresh notmuch buffers if sync was successful
-     (lambda (_process event)
-       (if (string= event "finished\n")
-           (notmuch-refresh-all-buffers))))))
+  (notmuch--if-compile (+notmuch-get-sync-command)
+      (progn
+        (notmuch-refresh-all-buffers)
+        (message "Notmuch sync successful."))
+    (user-error "Failed to sync notmuch data.")))
 
 ;;;###autoload
 (defun +notmuch/search-delete ()

--- a/modules/email/notmuch/config.el
+++ b/modules/email/notmuch/config.el
@@ -68,9 +68,9 @@
              #'hide-mode-line-mode)
  
   (map! :localleader
-        :map (notmuch-search-mode-map notmuch-tree-mode-map notmuch-show-mode-map)
+        :map (notmuch-hello-mode-map notmuch-search-mode-map notmuch-tree-mode-map notmuch-show-mode-map)
         :desc "Compose email"   "c" #'+notmuch/compose
-        :desc "Fetch new email" "u" #'+notmuch/update
+        :desc "Sync email"      "u" #'+notmuch/update
         :desc "Quit notmuch"    "q" #'+notmuch/quit
         :map notmuch-search-mode-map
         :desc "Mark as deleted" "d" #'+notmuch/search-delete


### PR DESCRIPTION
Addressing #3188 

Using `compile` approach similar to `doom sync`. It runs in a buffer and
deletes the buffer when complete.

`afew` is and should be optional. Putting it behind a feature flag so
that if you don't have afew installed, it won't be run. It's easily
available for those that want it, and easy to ignore for everyone else.

added documentation.