### PR TITLE
Fix `+spell/add-word` when using flyspell

### DIFF
--- a/modules/checkers/spell/autoload/+flyspell.el
+++ b/modules/checkers/spell/autoload/+flyspell.el
@@ -35,7 +35,7 @@ SCOPE can be `buffer' or `session' to exclude words only from the current buffer
 or session. Otherwise, the addition is permanent."
   (interactive
    (list (progn (require 'flyspell)
-                (flyspell-get-word))
+                (car (flyspell-get-word)))
          (cond ((equal current-prefix-arg '(16))
                 'session)
                ((equal current-prefix-arg '(4))


### PR DESCRIPTION
This addressed #3890 and #3935

``+spell/add-word`` expects `flyspell-get-word` to return as a string
the current word. Instead, it returns a list of the form
`(<word> <start-pos> <end-pos>)`.