### PR TITLE
org-trello: ignore credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .local/
 var/
 modules/private
+.trello/
 .yas-compiled-snippets.el
 
 # folders created by Cask


### PR DESCRIPTION
org-trello forces credentials to be stored under user-emacs-directory using
defconst, so ignore the directory to avoid accidentally committing secrets.