### PR TITLE
:input layout bepo enhancements

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -68,9 +68,10 @@
       (:after geiser-doc :map geiser-doc-mode-map
        :n "o"    #'link-hint-open-link)
 
-      (:after (evil-org evil-easymotion)
-       :map evil-org-mode-map
-       :m "gsh" #'+org/goto-visible)
+      (:unless (featurep! :input layout +bepo)
+        (:after (evil-org evil-easymotion)
+         :map evil-org-mode-map
+         :m "gsh" #'+org/goto-visible))
 
       (:when (featurep! :editor multiple-cursors)
        :prefix "gz"

--- a/modules/input/layout/+bepo.el
+++ b/modules/input/layout/+bepo.el
@@ -56,7 +56,11 @@
     (setq evil-markdown-movement-bindings '((up . "s")
                                             (down . "t")
                                             (left . "c")
-                                            (right . "r")))
+                                            (right . "r"))
+          evil-org-movement-bindings '((up . "s")
+                                       (down . "t")
+                                       (left . "c")
+                                       (right . "r")))
     (doom-bepo-rotate-ts-bare-keymap '(read-expression-map))
     (doom-bepo-rotate-bare-keymap '(evil-window-map) doom-bepo-cr-rotation-style)
     (doom-bepo-rotate-evil-keymap doom-bepo-cr-rotation-style)
@@ -120,6 +124,9 @@
               (kbd "C-h !")))
             'org-time-stamp-inactive)
           (apply #'completing-read args))))
+    (after! (evil org evil-org-agenda)
+      (doom-bepo-rotate-bare-keymap '(org-agenda-keymap) doom-bepo-cr-rotation-style)
+      (doom-bepo--evil-collection-hook nil '(evil-org-agenda-mode-map)))
     (after! (evil magit evil-magit)
       (doom-bepo-rotate-ts-bare-keymap
        '(magit-mode-map

--- a/modules/input/layout/+bepo.el
+++ b/modules/input/layout/+bepo.el
@@ -14,14 +14,9 @@
 (set-face-attribute 'nobreak-space nil :underline t)
 
 (add-transient-hook! 'doom-init-modules-hook
-  ;; "ts" would be a little too common for an evil escape sequence
-  (setq evil-escape-key-sequence "gq")
   (setq avy-keys '(?a ?u ?i ?e ?, ?c ?t ?s ?r ?n)
-        lispy-avy-keys '(?a ?u ?i ?e ?, ?c ?t ?s ?r ?n ?m ?b ?é ?p ?o ?è ?v ?d ?l ?j ?z)
-        evil-markdown-movement-bindings '((up . "s")
-                                          (down . "t")
-                                          (left . "c")
-                                          (right . "r")))
+        lispy-avy-keys '(?a ?u ?i ?e ?, ?c ?t ?s ?r ?n ?m ?b ?é ?p ?o ?è ?v ?d ?l ?j ?z))
+
   ;; :ui window-select settings, ignoring +numbers flag for now
   (after! ace-window
     (setq aw-keys '(?a ?u ?i ?e ?, ?c ?t ?s ?r ?n)))
@@ -29,21 +24,6 @@
     (setq switch-window-shortcut-style 'qwerty
           switch-window-qwerty-shortcuts '("a" "u" "i" "e" "," "c" "t" "s" "r")))
 
-  (doom-bepo-rotate-ts-bare-keymap '(read-expression-map))
-  (doom-bepo-rotate-bare-keymap '(evil-window-map) doom-bepo-cr-rotation-style)
-
-  (map! :i "C-t" #'+default-newline
-        (:when (featurep! :editor multiple-cursors)
-         :prefix "gz"
-         :nv "t" #'evil-mc-make-cursor-move-next-line
-         :nv "s" #'evil-mc-make-cursor-move-prev-line
-         ;; the old toggle mapping (t) is made available both on "T" for mnemonics and
-         ;; "j" as a "classic" rotation
-         :nv "T" #'+multiple-cursors/evil-mc-toggle-cursors
-         :nv "j" #'+multiple-cursors/evil-mc-toggle-cursors)
-        (:when (featurep! :ui popup)
-         :n "C-$"   #'+popup/toggle
-         :n "C-#"   #'+popup/raise))
   (map!
    :leader
    :desc "Window" "é" 'evil-window-map
@@ -67,80 +47,103 @@
      :desc "Jump to next hunk"         ")"   #'git-gutter:next-hunk
      :desc "Jump to previous hunk"     "("   #'git-gutter:previous-hunk))
    (:prefix-map ("p" . "project")
-    :desc "Browse other project"         "»" #'doom/browse-in-other-project))
-  (after! treemacs
-    (doom-bepo-rotate-ts-bare-keymap '(evil-treemacs-state-map)))
-  (after! (:or helm ivy)
-    (doom-bepo-rotate-bare-keymap
-     '(minibuffer-local-map
-       minibuffer-local-ns-map
-       minibuffer-local-completion-map
-       minibuffer-local-must-match-map
-       minibuffer-local-isearch-map
-       read-expression-map)
-     doom-bepo-cr-rotation-style))
-  (after! ivy
-    (doom-bepo-rotate-bare-keymap '(ivy-minibuffer-map ivy-switch-buffer-map) doom-bepo-cr-rotation-style))
-  (after! helm
-    (doom-bepo-rotate-bare-keymap '(helm-map) doom-bepo-cr-rotation-style))
-  (after! helm-rg
-    (doom-bepo-rotate-bare-keymap '(helm-rg-map) doom-bepo-cr-rotation-style))
-  (after! helm-files
-    (doom-bepo-rotate-bare-keymap '(helm-read-file-map) doom-bepo-cr-rotation-style))
-  (after! general
-    (doom-bepo-rotate-evil-keymap doom-bepo-cr-rotation-style))
-  (after! company
-    (doom-bepo-rotate-bare-keymap '(company-active-map company-search-map) doom-bepo-cr-rotation-style))
-  (after! evil-snipe
-    (doom-bepo--evil-collection-hook
-     nil
-     '(evil-snipe-local-mode-map evil-snipe-override-local-mode-map)))
-  (after! lispyville
-    ;; <> en direct
-    (general-translate-key '(normal motion) 'lispyville-mode-map
-      "«" "<"
-      "»" ">"))
-  (after! org
-    (defadvice! doom-bepo--org-completing-read (&rest args)
-      "Completing-read with SPACE being a normal character, and C-c mapping left alone."
-      :override #'org-completing-read
-      (let ((enable-recursive-minibuffers t)
-            (minibuffer-local-completion-map
-             (copy-keymap minibuffer-local-completion-map)))
-        (define-key minibuffer-local-completion-map " " 'self-insert-command)
-        (define-key minibuffer-local-completion-map "?" 'self-insert-command)
-        (define-key minibuffer-local-completion-map
-          (cond
-           ((eq doom-bepo-cr-rotation-style 'ergodis)
-            (kbd "C-l !"))
-           (t
-            (kbd "C-h !")))
-          'org-time-stamp-inactive)
-        (apply #'completing-read args))))
-  (after! (evil magit evil-magit)
-    (doom-bepo-rotate-ts-bare-keymap
-     '(magit-mode-map
-       magit-diff-section-base-map
-       magit-staged-section-map
-       magit-unstaged-section-map
-       magit-untracked-section-map))
-    ;; Without this, "s" is mapped to 'magit-delete-thing (the old "k" for "kill") and
-    ;; takes precedence over the evil command to go up one line
-    (map! :map magit-mode-map "s" nil)
-    (doom-bepo--evil-collection-hook
-     nil
-     '(magit-mode-map
-       magit-cherry-mode-map
-       magit-mode-map
-       magit-blob-mode-map
-       magit-diff-mode-map
-       magit-log-mode-map
-       magit-log-select-mode-map
-       magit-reflog-mode-map
-       magit-status-mode-map
-       magit-file-mode-map
-       magit-log-read-revs-map
-       magit-process-mode-map
-       magit-refs-mode-map)))
-  (after! evil-easymotion
-    (doom-bepo-rotate-bare-keymap '(evilem-map) doom-bepo-cr-rotation-style)))
+    :desc "Browse other project"         "»" #'doom/browse-in-other-project)))
+
+(when (featurep! :editor evil)
+  (add-transient-hook! 'doom-init-modules-hook
+    ;; "ts" would be a little too common for an evil escape sequence
+    (setq evil-escape-key-sequence "gq")
+    (setq evil-markdown-movement-bindings '((up . "s")
+                                            (down . "t")
+                                            (left . "c")
+                                            (right . "r")))
+    (doom-bepo-rotate-ts-bare-keymap '(read-expression-map))
+    (doom-bepo-rotate-bare-keymap '(evil-window-map) doom-bepo-cr-rotation-style)
+    (doom-bepo-rotate-evil-keymap doom-bepo-cr-rotation-style)
+
+    (map! :i "C-t" #'+default-newline
+          (:when (featurep! :editor multiple-cursors)
+           :prefix "gz"
+           :nv "t" #'evil-mc-make-cursor-move-next-line
+           :nv "s" #'evil-mc-make-cursor-move-prev-line
+           ;; the old toggle mapping (t) is made available both on "T" for mnemonics and
+           ;; "j" as a "classic" rotation
+           :nv "T" #'+multiple-cursors/evil-mc-toggle-cursors
+           :nv "j" #'+multiple-cursors/evil-mc-toggle-cursors)
+          (:when (featurep! :ui popup)
+           :n "C-$"   #'+popup/toggle
+           :n "C-#"   #'+popup/raise))
+    (after! treemacs
+      (doom-bepo-rotate-ts-bare-keymap '(evil-treemacs-state-map)))
+    (after! (:or helm ivy)
+      (doom-bepo-rotate-bare-keymap
+       '(minibuffer-local-map
+         minibuffer-local-ns-map
+         minibuffer-local-completion-map
+         minibuffer-local-must-match-map
+         minibuffer-local-isearch-map
+         read-expression-map)
+       doom-bepo-cr-rotation-style))
+    (after! ivy
+      (doom-bepo-rotate-bare-keymap '(ivy-minibuffer-map ivy-switch-buffer-map) doom-bepo-cr-rotation-style))
+    (after! helm
+      (doom-bepo-rotate-bare-keymap '(helm-map) doom-bepo-cr-rotation-style))
+    (after! helm-rg
+      (doom-bepo-rotate-bare-keymap '(helm-rg-map) doom-bepo-cr-rotation-style))
+    (after! helm-files
+      (doom-bepo-rotate-bare-keymap '(helm-read-file-map) doom-bepo-cr-rotation-style))
+    (after! company
+      (doom-bepo-rotate-bare-keymap '(company-active-map company-search-map) doom-bepo-cr-rotation-style))
+    (after! evil-snipe
+      (doom-bepo--evil-collection-hook
+       nil
+       '(evil-snipe-local-mode-map evil-snipe-override-local-mode-map)))
+    (after! lispyville
+      ;; <> en direct
+      (general-translate-key '(normal motion) 'lispyville-mode-map
+        "«" "<"
+        "»" ">"))
+    (after! org
+      (defadvice! doom-bepo--org-completing-read (&rest args)
+        "Completing-read with SPACE being a normal character, and C-c mapping left alone."
+        :override #'org-completing-read
+        (let ((enable-recursive-minibuffers t)
+              (minibuffer-local-completion-map
+               (copy-keymap minibuffer-local-completion-map)))
+          (define-key minibuffer-local-completion-map " " 'self-insert-command)
+          (define-key minibuffer-local-completion-map "?" 'self-insert-command)
+          (define-key minibuffer-local-completion-map
+            (cond
+             ((eq doom-bepo-cr-rotation-style 'ergodis)
+              (kbd "C-l !"))
+             (t
+              (kbd "C-h !")))
+            'org-time-stamp-inactive)
+          (apply #'completing-read args))))
+    (after! (evil magit evil-magit)
+      (doom-bepo-rotate-ts-bare-keymap
+       '(magit-mode-map
+         magit-diff-section-base-map
+         magit-staged-section-map
+         magit-unstaged-section-map
+         magit-untracked-section-map))
+      ;; Without this, "s" is mapped to 'magit-delete-thing (the old "k" for "kill") and
+      ;; takes precedence over the evil command to go up one line
+      (map! :map magit-mode-map "s" nil)
+      (doom-bepo--evil-collection-hook
+       nil
+       '(magit-mode-map
+         magit-cherry-mode-map
+         magit-mode-map
+         magit-blob-mode-map
+         magit-diff-mode-map
+         magit-log-mode-map
+         magit-log-select-mode-map
+         magit-reflog-mode-map
+         magit-status-mode-map
+         magit-file-mode-map
+         magit-log-read-revs-map
+         magit-process-mode-map
+         magit-refs-mode-map)))
+    (after! evil-easymotion
+      (doom-bepo-rotate-bare-keymap '(evilem-map) doom-bepo-cr-rotation-style))))

--- a/modules/input/layout/README.org
+++ b/modules/input/layout/README.org
@@ -19,7 +19,7 @@
   - [[#how-to-deactivate-the-new-bindings-and-go-back-to-the-old-ones-][How to deactivate the new bindings and go back to the old ones ?]]
 
 * Description
-This module provides barebones support for using Doom with evil-mode with non-qwerty layouts.
+This module provides barebones support for using Doom with non-qwerty layouts.
 
 ** Maintainers
 + @gagbo (Author)
@@ -31,8 +31,10 @@ This module provides barebones support for using Doom with evil-mode with non-qw
 None
 
 * Prerequisites
-This module should only be active if evil is enabled. It uses a general.el utility function, and
-the hooks provided by evil-collection to make the necessary changes.
+If you are using =:editor evil=, you should use =(evil +everywhere)=, as the
+module uses =evil-collection= utilities to do the remapping.
+
+If you are not using =:editor evil=, then you have nothing to do.
 
 * Features
 # An in-depth list of features, how to use them, and their dependencies.
@@ -67,6 +69,9 @@ while =t=, =s=, =j=, and =k= are flipped:
 A nice addition in the future might be to have all the normal mode bindings that
 start with =g= start with =,= instead to avoid the curl on these common
 bindings. This is *not* implemented for the time being.
+
+Also, implementing all those changes as a minor we could flip on and off would
+help with adoption
 
 * Configuration
 ** Bépo

--- a/modules/input/layout/autoload/bepo.el
+++ b/modules/input/layout/autoload/bepo.el
@@ -4,7 +4,7 @@
 (defun doom-bepo-rotate-ts-bare-keymap (keymaps)
   "Rotate [jk] with [ts] in KEYMAP."
   (dolist (keymap keymaps)
-    (general-translate-key nil keymap
+    (evil-collection-translate-key nil keymap
       "t" "j"
       "T" "J"
       "s" "k"
@@ -13,44 +13,44 @@
       "J" "T"
       "k" "s"
       "K" "S"
-      "C-t" "C-j"
-      "C-s" "C-k"
-      "C-j" "C-t"
-      "C-k" "C-s"
-      "M-t" "M-j"
-      "M-s" "M-k"
-      "M-j" "M-t"
-      "M-k" "M-s"
-      "C-S-t" "C-S-j"
-      "C-S-s" "C-S-k"
-      "C-S-j" "C-S-t"
-      "C-S-k" "C-S-s"
-      "M-S-t" "M-S-j"
-      "M-S-s" "M-S-k"
-      "M-S-j" "M-S-t"
-      "M-S-k" "M-S-s")))
+      (kbd  "C-t") (kbd  "C-j")
+      (kbd  "C-s") (kbd  "C-k")
+      (kbd  "C-j") (kbd  "C-t")
+      (kbd  "C-k") (kbd  "C-s")
+      (kbd  "M-t") (kbd  "M-j")
+      (kbd  "M-s") (kbd  "M-k")
+      (kbd  "M-j") (kbd  "M-t")
+      (kbd  "M-k") (kbd  "M-s")
+      (kbd  "C-S-t") (kbd  "C-S-j")
+      (kbd  "C-S-s") (kbd  "C-S-k")
+      (kbd  "C-S-j") (kbd  "C-S-t")
+      (kbd  "C-S-k") (kbd  "C-S-s")
+      (kbd  "M-S-t") (kbd  "M-S-j")
+      (kbd  "M-S-s") (kbd  "M-S-k")
+      (kbd  "M-S-j") (kbd  "M-S-t")
+      (kbd  "M-S-k") (kbd  "M-S-s"))))
 
 ;;;###autoload
 (defun doom-bepo-rotate-é-quotes-bare-keymap (keymaps)
   "Rotate [w<>] with [é«»] in KEYMAP."
   (dolist (keymap keymaps)
-    (general-translate-key nil keymap
+    (evil-collection-translate-key nil keymap
       "é" "w"
       "É" "W"
       "«" "<"
       "»" ">"
-      "C-é" "C-w"
-      "C-«" "C-<"
-      "C-»" "C->"
-      "M-é" "M-w"
-      "M-«" "M-<"
-      "M-»" "M->"
-      "C-S-é" "C-S-w"
-      "C-S-«" "C-S-<"
-      "C-S-»" "C-S->"
-      "M-S-é" "M-S-w"
-      "M-S-«" "M-S-<"
-      "M-S-»" "M-S->")))
+      (kbd  "C-é") (kbd  "C-w")
+      (kbd  "C-«") (kbd  "C-<")
+      (kbd  "C-»") (kbd  "C->")
+      (kbd  "M-é") (kbd  "M-w")
+      (kbd  "M-«") (kbd  "M-<")
+      (kbd  "M-»") (kbd  "M->")
+      (kbd  "C-S-é") (kbd  "C-S-w")
+      (kbd  "C-S-«") (kbd  "C-S-<")
+      (kbd  "C-S-»") (kbd  "C-S->")
+      (kbd  "M-S-é") (kbd  "M-S-w")
+      (kbd  "M-S-«") (kbd  "M-S-<")
+      (kbd  "M-S-»") (kbd  "M-S->"))))
 
 ;;;###autoload
 (defun doom-bepo-rotate-cr-bare-keymap (keymaps &optional style)
@@ -62,47 +62,47 @@ Undefined behaviour in other cases, for forward compatibility."
   (let ((style (or style 'ergodis)))
     (dolist (keymap keymaps)
       (progn
-        (general-translate-key nil keymap
+        (evil-collection-translate-key nil keymap
           "c" "h"
           "C" "H"
           "r" "l"
           "R" "L"
-          "C-c" "C-h"
-          "C-r" "C-l"
-          "M-c" "M-h"
-          "M-r" "M-l"
-          "C-S-c" "C-S-h"
-          "C-S-r" "C-S-l"
-          "M-S-c" "M-S-h"
-          "M-S-r" "M-S-l")
+          (kbd  "C-c") (kbd  "C-h")
+          (kbd  "C-r") (kbd  "C-l")
+          (kbd  "M-c") (kbd  "M-h")
+          (kbd  "M-r") (kbd  "M-l")
+          (kbd  "C-S-c") (kbd  "C-S-h")
+          (kbd  "C-S-r") (kbd  "C-S-l")
+          (kbd  "M-S-c") (kbd  "M-S-h")
+          (kbd  "M-S-r") (kbd  "M-S-l"))
         (cond ((eq style 'ergodis)
-               (general-translate-key nil keymap
+               (evil-collection-translate-key nil keymap
                  "h" "r"
                  "H" "R"
                  "l" "c"
                  "L" "C"
-                 "C-h" "C-r"
-                 "C-l" "C-c"
-                 "M-h" "M-r"
-                 "M-l" "M-c"
-                 "C-S-h" "C-S-r"
-                 "C-S-l" "C-S-c"
-                 "M-S-h" "M-S-r"
-                 "M-S-l" "M-S-c"))
+                 (kbd  "C-h") (kbd  "C-r")
+                 (kbd  "C-l") (kbd  "C-c")
+                 (kbd  "M-h") (kbd  "M-r")
+                 (kbd  "M-l") (kbd  "M-c")
+                 (kbd  "C-S-h") (kbd  "C-S-r")
+                 (kbd  "C-S-l") (kbd  "C-S-c")
+                 (kbd  "M-S-h") (kbd  "M-S-r")
+                 (kbd  "M-S-l") (kbd  "M-S-c")))
               (t
-               (general-translate-key nil keymap
+               (evil-collection-translate-key nil keymap
                  "h" "c"
                  "H" "C"
                  "l" "r"
                  "L" "R"
-                 "C-h" "C-c"
-                 "C-l" "C-r"
-                 "M-h" "M-c"
-                 "M-l" "M-r"
-                 "C-S-h" "C-S-c"
-                 "C-S-l" "C-S-r"
-                 "M-S-h" "M-S-c"
-                 "M-S-l" "M-S-r")))))))
+                 (kbd  "C-h") (kbd  "C-c")
+                 (kbd  "C-l") (kbd  "C-r")
+                 (kbd  "M-h") (kbd  "M-c")
+                 (kbd  "M-l") (kbd  "M-r")
+                 (kbd  "C-S-h") (kbd  "C-S-c")
+                 (kbd  "C-S-l") (kbd  "C-S-r")
+                 (kbd  "M-S-h") (kbd  "M-S-c")
+                 (kbd  "M-S-l") (kbd  "M-S-r"))))))))
 
 ;;;###autoload
 (defun doom-bepo-rotate-bare-keymap (keymaps &optional cr-style)
@@ -117,7 +117,7 @@ See `doom-bepo-cr-rotation-style' for the meaning of CR-STYLE"
   "Remap evil-{normal,operator,motion,...}-state-map
   to be more natural with Bépo keyboard layout.
 See `doom-bepo-cr-rotation-style' for the meaning of CR-STYLE."
-  (general-translate-key nil '(normal motion visual)
+  (evil-collection-translate-key nil '(evil-normal-state-map evil-motion-state-map evil-visual-state-map)
     "c" "h"
     "C" "H"
     "t" "j"
@@ -131,62 +131,62 @@ See `doom-bepo-cr-rotation-style' for the meaning of CR-STYLE."
     "k" "s"
     "K" "S")
   (cond ((eq cr-style 'ergodis)
-         (general-translate-key nil '(normal motion visual)
+         (evil-collection-translate-key nil '(evil-normal-state-map evil-motion-state-map evil-visual-state-map)
            "h" "r"
            "H" "R"
            "l" "c"
            "L" "C"))
         (t
-         (general-translate-key nil '(normal motion visual)
+         (evil-collection-translate-key nil '(evil-normal-state-map evil-motion-state-map evil-visual-state-map)
            "h" "c"
            "H" "C"
            "l" "r"
            "L" "R")))
 
-  (general-translate-key nil '(insert)
-    "C-c" "C-h"
-    "C-C" "C-H"
-    "C-t" "C-j"
-    "C-T" "C-J"
-    "C-s" "C-k"
-    "C-S" "C-K"
-    "C-r" "C-l"
-    "C-R" "C-L"
-    "C-j" "C-t"
-    "C-J" "C-T"
-    "C-k" "C-s"
-    "C-K" "C-S")
+  (evil-collection-translate-key nil '(evil-insert-state-map)
+    (kbd  "C-c") (kbd  "C-h")
+    (kbd  "C-C") (kbd  "C-H")
+    (kbd  "C-t") (kbd  "C-j")
+    (kbd  "C-T") (kbd  "C-J")
+    (kbd  "C-s") (kbd  "C-k")
+    (kbd  "C-S") (kbd  "C-K")
+    (kbd  "C-r") (kbd  "C-l")
+    (kbd  "C-R") (kbd  "C-L")
+    (kbd  "C-j") (kbd  "C-t")
+    (kbd  "C-J") (kbd  "C-T")
+    (kbd  "C-k") (kbd  "C-s")
+    (kbd  "C-K") (kbd  "C-S"))
   (cond ((eq cr-style 'ergodis)
-         (general-translate-key nil '(insert)
-           "C-h" "C-r"
-           "C-H" "C-R"
-           "C-l" "C-c"
-           "C-L" "C-C"))
+         (evil-collection-translate-key nil '(evil-insert-state-map)
+           (kbd  "C-h") (kbd  "C-r")
+           (kbd  "C-H") (kbd  "C-R")
+           (kbd  "C-l") (kbd  "C-c")
+           (kbd  "C-L") (kbd  "C-C")))
         (t
-         (general-translate-key nil '(insert)
-           "C-h" "C-c"
-           "C-H" "C-C"
-           "C-l" "C-r"
-           "C-L" "C-R")))
+         (evil-collection-translate-key nil '(evil-insert-state-map)
+           (kbd  "C-h") (kbd  "C-c")
+           (kbd  "C-H") (kbd  "C-C")
+           (kbd  "C-l") (kbd  "C-r")
+           (kbd  "C-L") (kbd  "C-R"))))
 
 
   ;; <> as direct access
-  (general-translate-key nil '(normal motion)
+  (evil-collection-translate-key nil '(evil-normal-state-map evil-motion-state-map)
     "«" "<"
     "»" ">")
 
   ;; " è replaces ^0 to go at BOL
-  (general-translate-key nil '(normal motion)
+  (evil-collection-translate-key nil '(evil-normal-state-map evil-motion-state-map)
     "è" "^"
     "È" "0")
 
   ;; [W] -> [É]
   ;; [C-W] -> [W]
-  (general-translate-key nil '(normal motion operator)
+  (evil-collection-translate-key nil '(evil-normal-state-map evil-motion-state-map evil-operator-state-map)
     "é" "w"
     "É" "W"
-    "w" "C-w"
-    "W" "C-w C-w"))
+    "w" (kbd  "C-w")
+    "W" (kbd  "C-w C-w")))
 
 ;;;###autoload
 (defun doom-bepo-rotate-collection-keymaps-h-builder (cr-style)
@@ -195,7 +195,7 @@ See `doom-bepo-cr-rotation-style' for the meaning of CR-STYLE."
   (let* ((cr-style (or cr-style 'ergodis))
          (doom-bepo-hook (lambda (_mode mode-keymaps &rest _rest)
                            (dolist (keymap mode-keymaps)
-                             (general-translate-key '(normal motion visual) keymap
+                             (evil-collection-translate-key '(normal motion visual) keymap
                                "c" "h"
                                "C" "H"
                                "t" "j"
@@ -209,60 +209,60 @@ See `doom-bepo-cr-rotation-style' for the meaning of CR-STYLE."
                                "k" "s"
                                "K" "S")
                              (cond ((eq cr-style 'ergodis)
-                                    (general-translate-key '(normal motion visual) keymap
+                                    (evil-collection-translate-key '(normal motion visual) keymap
                                       "h" "r"
                                       "H" "R"
                                       "l" "c"
                                       "L" "C"))
                                    (t
-                                    (general-translate-key '(normal motion visual) keymap
+                                    (evil-collection-translate-key '(normal motion visual) keymap
                                       "h" "c"
                                       "H" "C"
                                       "l" "r"
                                       "L" "R")))
 
 
-                             (general-translate-key '(insert) keymap
-                               "C-c" "C-h"
-                               "C-C" "C-H"
-                               "C-t" "C-j"
-                               "C-T" "C-J"
-                               "C-s" "C-k"
-                               "C-S" "C-K"
-                               "C-r" "C-l"
-                               "C-R" "C-L"
-                               "C-j" "C-t"
-                               "C-J" "C-T"
-                               "C-k" "C-s"
-                               "C-K" "C-S")
+                             (evil-collection-translate-key '(insert) keymap
+                               (kbd  "C-c") (kbd  "C-h")
+                               (kbd  "C-C") (kbd  "C-H")
+                               (kbd  "C-t") (kbd  "C-j")
+                               (kbd  "C-T") (kbd  "C-J")
+                               (kbd  "C-s") (kbd  "C-k")
+                               (kbd  "C-S") (kbd  "C-K")
+                               (kbd  "C-r") (kbd  "C-l")
+                               (kbd  "C-R") (kbd  "C-L")
+                               (kbd  "C-j") (kbd  "C-t")
+                               (kbd  "C-J") (kbd  "C-T")
+                               (kbd  "C-k") (kbd  "C-s")
+                               (kbd  "C-K") (kbd  "C-S"))
                              (cond ((eq cr-style 'ergodis)
-                                    (general-translate-key '(insert) keymap
-                                      "C-h" "C-r"
-                                      "C-H" "C-R"
-                                      "C-l" "C-c"
-                                      "C-L" "C-C"))
+                                    (evil-collection-translate-key '(insert) keymap
+                                      (kbd  "C-h") (kbd  "C-r")
+                                      (kbd  "C-H") (kbd  "C-R")
+                                      (kbd  "C-l") (kbd  "C-c")
+                                      (kbd  "C-L") (kbd  "C-C")))
                                    (t
-                                    (general-translate-key '(insert) keymap
-                                      "C-h" "C-c"
-                                      "C-H" "C-C"
-                                      "C-l" "C-r"
-                                      "C-L" "C-R")))
+                                    (evil-collection-translate-key '(insert) keymap
+                                      (kbd  "C-h") (kbd  "C-c")
+                                      (kbd  "C-H") (kbd  "C-C")
+                                      (kbd  "C-l") (kbd  "C-r")
+                                      (kbd  "C-L") (kbd  "C-R"))))
 
                              ;; <> en direct
-                             (general-translate-key '(normal motion visual) keymap
+                             (evil-collection-translate-key '(normal motion visual) keymap
                                "«" "<"
                                "»" ">")
 
                              ;; è pour aller au début de ligne
-                             (general-translate-key '(normal motion visual) keymap
+                             (evil-collection-translate-key '(normal motion visual) keymap
                                "è" "^"
                                "È" "0")
 
                              ;; [W] -> [É]
                              ;; [C-W] -> [W]
-                             (general-translate-key '(normal motion operator visual) keymap
+                             (evil-collection-translate-key '(normal motion operator visual) keymap
                                "é" "w"
                                "É" "W"
-                               "w" "C-w"
-                               "W" "C-w C-w")))))
+                               "w" (kbd  "C-w")
+                               "W" (kbd  "C-w C-w"))))))
     doom-bepo-hook))

--- a/modules/input/layout/autoload/bepo.el
+++ b/modules/input/layout/autoload/bepo.el
@@ -13,22 +13,22 @@
       "J" "T"
       "k" "s"
       "K" "S"
-      (kbd  "C-t") (kbd  "C-j")
-      (kbd  "C-s") (kbd  "C-k")
-      (kbd  "C-j") (kbd  "C-t")
-      (kbd  "C-k") (kbd  "C-s")
-      (kbd  "M-t") (kbd  "M-j")
-      (kbd  "M-s") (kbd  "M-k")
-      (kbd  "M-j") (kbd  "M-t")
-      (kbd  "M-k") (kbd  "M-s")
-      (kbd  "C-S-t") (kbd  "C-S-j")
-      (kbd  "C-S-s") (kbd  "C-S-k")
-      (kbd  "C-S-j") (kbd  "C-S-t")
-      (kbd  "C-S-k") (kbd  "C-S-s")
-      (kbd  "M-S-t") (kbd  "M-S-j")
-      (kbd  "M-S-s") (kbd  "M-S-k")
-      (kbd  "M-S-j") (kbd  "M-S-t")
-      (kbd  "M-S-k") (kbd  "M-S-s"))))
+      (kbd "C-t") (kbd "C-j")
+      (kbd "C-s") (kbd "C-k")
+      (kbd "C-j") (kbd "C-t")
+      (kbd "C-k") (kbd "C-s")
+      (kbd "M-t") (kbd "M-j")
+      (kbd "M-s") (kbd "M-k")
+      (kbd "M-j") (kbd "M-t")
+      (kbd "M-k") (kbd "M-s")
+      (kbd "C-S-t") (kbd "C-S-j")
+      (kbd "C-S-s") (kbd "C-S-k")
+      (kbd "C-S-j") (kbd "C-S-t")
+      (kbd "C-S-k") (kbd "C-S-s")
+      (kbd "M-S-t") (kbd "M-S-j")
+      (kbd "M-S-s") (kbd "M-S-k")
+      (kbd "M-S-j") (kbd "M-S-t")
+      (kbd "M-S-k") (kbd "M-S-s"))))
 
 ;;;###autoload
 (defun doom-bepo-rotate-é-quotes-bare-keymap (keymaps)
@@ -39,18 +39,18 @@
       "É" "W"
       "«" "<"
       "»" ">"
-      (kbd  "C-é") (kbd  "C-w")
-      (kbd  "C-«") (kbd  "C-<")
-      (kbd  "C-»") (kbd  "C->")
-      (kbd  "M-é") (kbd  "M-w")
-      (kbd  "M-«") (kbd  "M-<")
-      (kbd  "M-»") (kbd  "M->")
-      (kbd  "C-S-é") (kbd  "C-S-w")
-      (kbd  "C-S-«") (kbd  "C-S-<")
-      (kbd  "C-S-»") (kbd  "C-S->")
-      (kbd  "M-S-é") (kbd  "M-S-w")
-      (kbd  "M-S-«") (kbd  "M-S-<")
-      (kbd  "M-S-»") (kbd  "M-S->"))))
+      (kbd "C-é") (kbd "C-w")
+      (kbd "C-«") (kbd "C-<")
+      (kbd "C-»") (kbd "C->")
+      (kbd "M-é") (kbd "M-w")
+      (kbd "M-«") (kbd "M-<")
+      (kbd "M-»") (kbd "M->")
+      (kbd "C-S-é") (kbd "C-S-w")
+      (kbd "C-S-«") (kbd "C-S-<")
+      (kbd "C-S-»") (kbd "C-S->")
+      (kbd "M-S-é") (kbd "M-S-w")
+      (kbd "M-S-«") (kbd "M-S-<")
+      (kbd "M-S-»") (kbd "M-S->"))))
 
 ;;;###autoload
 (defun doom-bepo-rotate-cr-bare-keymap (keymaps &optional style)
@@ -67,42 +67,42 @@ Undefined behaviour in other cases, for forward compatibility."
           "C" "H"
           "r" "l"
           "R" "L"
-          (kbd  "C-c") (kbd  "C-h")
-          (kbd  "C-r") (kbd  "C-l")
-          (kbd  "M-c") (kbd  "M-h")
-          (kbd  "M-r") (kbd  "M-l")
-          (kbd  "C-S-c") (kbd  "C-S-h")
-          (kbd  "C-S-r") (kbd  "C-S-l")
-          (kbd  "M-S-c") (kbd  "M-S-h")
-          (kbd  "M-S-r") (kbd  "M-S-l"))
+          (kbd "C-c") (kbd "C-h")
+          (kbd "C-r") (kbd "C-l")
+          (kbd "M-c") (kbd "M-h")
+          (kbd "M-r") (kbd "M-l")
+          (kbd "C-S-c") (kbd "C-S-h")
+          (kbd "C-S-r") (kbd "C-S-l")
+          (kbd "M-S-c") (kbd "M-S-h")
+          (kbd "M-S-r") (kbd "M-S-l"))
         (cond ((eq style 'ergodis)
                (evil-collection-translate-key nil keymap
                  "h" "r"
                  "H" "R"
                  "l" "c"
                  "L" "C"
-                 (kbd  "C-h") (kbd  "C-r")
-                 (kbd  "C-l") (kbd  "C-c")
-                 (kbd  "M-h") (kbd  "M-r")
-                 (kbd  "M-l") (kbd  "M-c")
-                 (kbd  "C-S-h") (kbd  "C-S-r")
-                 (kbd  "C-S-l") (kbd  "C-S-c")
-                 (kbd  "M-S-h") (kbd  "M-S-r")
-                 (kbd  "M-S-l") (kbd  "M-S-c")))
+                 (kbd "C-h") (kbd "C-r")
+                 (kbd "C-l") (kbd "C-c")
+                 (kbd "M-h") (kbd "M-r")
+                 (kbd "M-l") (kbd "M-c")
+                 (kbd "C-S-h") (kbd "C-S-r")
+                 (kbd "C-S-l") (kbd "C-S-c")
+                 (kbd "M-S-h") (kbd "M-S-r")
+                 (kbd "M-S-l") (kbd "M-S-c")))
               (t
                (evil-collection-translate-key nil keymap
                  "h" "c"
                  "H" "C"
                  "l" "r"
                  "L" "R"
-                 (kbd  "C-h") (kbd  "C-c")
-                 (kbd  "C-l") (kbd  "C-r")
-                 (kbd  "M-h") (kbd  "M-c")
-                 (kbd  "M-l") (kbd  "M-r")
-                 (kbd  "C-S-h") (kbd  "C-S-c")
-                 (kbd  "C-S-l") (kbd  "C-S-r")
-                 (kbd  "M-S-h") (kbd  "M-S-c")
-                 (kbd  "M-S-l") (kbd  "M-S-r"))))))))
+                 (kbd "C-h") (kbd "C-c")
+                 (kbd "C-l") (kbd "C-r")
+                 (kbd "M-h") (kbd "M-c")
+                 (kbd "M-l") (kbd "M-r")
+                 (kbd "C-S-h") (kbd "C-S-c")
+                 (kbd "C-S-l") (kbd "C-S-r")
+                 (kbd "M-S-h") (kbd "M-S-c")
+                 (kbd "M-S-l") (kbd "M-S-r"))))))))
 
 ;;;###autoload
 (defun doom-bepo-rotate-bare-keymap (keymaps &optional cr-style)
@@ -144,30 +144,30 @@ See `doom-bepo-cr-rotation-style' for the meaning of CR-STYLE."
            "L" "R")))
 
   (evil-collection-translate-key nil '(evil-insert-state-map)
-    (kbd  "C-c") (kbd  "C-h")
-    (kbd  "C-C") (kbd  "C-H")
-    (kbd  "C-t") (kbd  "C-j")
-    (kbd  "C-T") (kbd  "C-J")
-    (kbd  "C-s") (kbd  "C-k")
-    (kbd  "C-S") (kbd  "C-K")
-    (kbd  "C-r") (kbd  "C-l")
-    (kbd  "C-R") (kbd  "C-L")
-    (kbd  "C-j") (kbd  "C-t")
-    (kbd  "C-J") (kbd  "C-T")
-    (kbd  "C-k") (kbd  "C-s")
-    (kbd  "C-K") (kbd  "C-S"))
+    (kbd "C-c") (kbd "C-h")
+    (kbd "C-C") (kbd "C-H")
+    (kbd "C-t") (kbd "C-j")
+    (kbd "C-T") (kbd "C-J")
+    (kbd "C-s") (kbd "C-k")
+    (kbd "C-S") (kbd "C-K")
+    (kbd "C-r") (kbd "C-l")
+    (kbd "C-R") (kbd "C-L")
+    (kbd "C-j") (kbd "C-t")
+    (kbd "C-J") (kbd "C-T")
+    (kbd "C-k") (kbd "C-s")
+    (kbd "C-K") (kbd "C-S"))
   (cond ((eq cr-style 'ergodis)
          (evil-collection-translate-key nil '(evil-insert-state-map)
-           (kbd  "C-h") (kbd  "C-r")
-           (kbd  "C-H") (kbd  "C-R")
-           (kbd  "C-l") (kbd  "C-c")
-           (kbd  "C-L") (kbd  "C-C")))
+           (kbd "C-h") (kbd "C-r")
+           (kbd "C-H") (kbd "C-R")
+           (kbd "C-l") (kbd "C-c")
+           (kbd "C-L") (kbd "C-C")))
         (t
          (evil-collection-translate-key nil '(evil-insert-state-map)
-           (kbd  "C-h") (kbd  "C-c")
-           (kbd  "C-H") (kbd  "C-C")
-           (kbd  "C-l") (kbd  "C-r")
-           (kbd  "C-L") (kbd  "C-R"))))
+           (kbd "C-h") (kbd "C-c")
+           (kbd "C-H") (kbd "C-C")
+           (kbd "C-l") (kbd "C-r")
+           (kbd "C-L") (kbd "C-R"))))
 
 
   ;; <> as direct access
@@ -185,8 +185,8 @@ See `doom-bepo-cr-rotation-style' for the meaning of CR-STYLE."
   (evil-collection-translate-key nil '(evil-normal-state-map evil-motion-state-map evil-operator-state-map)
     "é" "w"
     "É" "W"
-    "w" (kbd  "C-w")
-    "W" (kbd  "C-w C-w")))
+    "w" (kbd "C-w")
+    "W" (kbd "C-w C-w")))
 
 ;;;###autoload
 (defun doom-bepo-rotate-collection-keymaps-h-builder (cr-style)
@@ -223,30 +223,30 @@ See `doom-bepo-cr-rotation-style' for the meaning of CR-STYLE."
 
 
                              (evil-collection-translate-key '(insert) keymap
-                               (kbd  "C-c") (kbd  "C-h")
-                               (kbd  "C-C") (kbd  "C-H")
-                               (kbd  "C-t") (kbd  "C-j")
-                               (kbd  "C-T") (kbd  "C-J")
-                               (kbd  "C-s") (kbd  "C-k")
-                               (kbd  "C-S") (kbd  "C-K")
-                               (kbd  "C-r") (kbd  "C-l")
-                               (kbd  "C-R") (kbd  "C-L")
-                               (kbd  "C-j") (kbd  "C-t")
-                               (kbd  "C-J") (kbd  "C-T")
-                               (kbd  "C-k") (kbd  "C-s")
-                               (kbd  "C-K") (kbd  "C-S"))
+                               (kbd "C-c") (kbd "C-h")
+                               (kbd "C-C") (kbd "C-H")
+                               (kbd "C-t") (kbd "C-j")
+                               (kbd "C-T") (kbd "C-J")
+                               (kbd "C-s") (kbd "C-k")
+                               (kbd "C-S") (kbd "C-K")
+                               (kbd "C-r") (kbd "C-l")
+                               (kbd "C-R") (kbd "C-L")
+                               (kbd "C-j") (kbd "C-t")
+                               (kbd "C-J") (kbd "C-T")
+                               (kbd "C-k") (kbd "C-s")
+                               (kbd "C-K") (kbd "C-S"))
                              (cond ((eq cr-style 'ergodis)
                                     (evil-collection-translate-key '(insert) keymap
-                                      (kbd  "C-h") (kbd  "C-r")
-                                      (kbd  "C-H") (kbd  "C-R")
-                                      (kbd  "C-l") (kbd  "C-c")
-                                      (kbd  "C-L") (kbd  "C-C")))
+                                      (kbd "C-h") (kbd "C-r")
+                                      (kbd "C-H") (kbd "C-R")
+                                      (kbd "C-l") (kbd "C-c")
+                                      (kbd "C-L") (kbd "C-C")))
                                    (t
                                     (evil-collection-translate-key '(insert) keymap
-                                      (kbd  "C-h") (kbd  "C-c")
-                                      (kbd  "C-H") (kbd  "C-C")
-                                      (kbd  "C-l") (kbd  "C-r")
-                                      (kbd  "C-L") (kbd  "C-R"))))
+                                      (kbd "C-h") (kbd "C-c")
+                                      (kbd "C-H") (kbd "C-C")
+                                      (kbd "C-l") (kbd "C-r")
+                                      (kbd "C-L") (kbd "C-R"))))
 
                              ;; <> en direct
                              (evil-collection-translate-key '(normal motion visual) keymap
@@ -263,6 +263,6 @@ See `doom-bepo-cr-rotation-style' for the meaning of CR-STYLE."
                              (evil-collection-translate-key '(normal motion operator visual) keymap
                                "é" "w"
                                "É" "W"
-                               "w" (kbd  "C-w")
-                               "W" (kbd  "C-w C-w"))))))
+                               "w" (kbd "C-w")
+                               "W" (kbd "C-w C-w"))))))
     doom-bepo-hook))


### PR DESCRIPTION
Fixes #3858

## Evil-collection instead of general for key translation

This is the biggest, most meaningful change. Using `evil-collection-translate-key` instead of `general-translate-key` prevents all the void-variable errors that happened because the general utility doesn't defer the key remapping on keymaps that aren't defined yet. See emacs-evil/evil-collection#368


## Split evil-specific changes
There are changes that are not necessarily oriented only to evil users, so splitting these off makes sense to know what you get if you enable this module without evil enabled.