### PR TITLE
Use swiper-helm instead of swiper-isearch

### DIFF
--- a/modules/config/default/autoload/search.el
+++ b/modules/config/default/autoload/search.el
@@ -26,9 +26,11 @@ If prefix ARG is set, prompt for a directory to search from."
 If a selection is active, pre-fill the prompt with it."
   (interactive)
   (call-interactively
-   (if (region-active-p)
-       #'swiper-isearch-thing-at-point
-     #'swiper-isearch)))
+   (if (featurep! :completion helm)
+       #'swiper-helm
+     (if (region-active-p)
+         #'swiper-isearch-thing-at-point
+       #'swiper-isearch))))
 
 ;;;###autoload
 (defun +default/search-project (&optional arg)


### PR DESCRIPTION
`+default/search-buffer` always used the ivy version even if helm was
enabled instead.

As far as I can tell `swiper-helm` isn't quite equivalent to the isearch
variants of `swiper`, but it is close enough (at least for me)

----

I'm not certain if this is the idiomatic way of doing this logic, let me know if there are any improvements I can make on it.