### PR TITLE
Load yas when yas-activate-extra-mode is called

### DIFF
--- a/modules/editor/snippets/config.el
+++ b/modules/editor/snippets/config.el
@@ -15,7 +15,9 @@
              yas-lookup-snippet
              yas-insert-snippet
              yas-new-snippet
-             yas-visit-snippet-file)
+             yas-visit-snippet-file
+             yas-activate-extra-mode
+             yas-deactivate-extra-mode)
   :init
   ;; Remove default ~/.emacs.d/snippets
   (defvar yas-snippet-dirs nil)


### PR DESCRIPTION
Auto load when `yas-activate-extra-mode` or `yas-deactivate-extra-mode` is called. These functions are called in `.emacs.d/modules/editor/snippets/autoload/snippets.el` by function `+snippets-enable-project-modes-h`, which may be called before yasnippet is loaded.
