### PR TITLE
Improve fill-column module for Emacs 27+

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -266,10 +266,8 @@
       ;;; <leader> t --- toggle
       (:prefix-map ("t" . "toggle")
        :desc "Big mode"                     "b" #'doom-big-font-mode
-       (:when (and (featurep! :ui fill-column) EMACS27+)
-        :desc "Fill Column Indicator"       "c" #'display-fill-column-indicator-mode)
-       (:when (and (featurep! :ui fill-column) (not EMACS27+))
-        :desc "Fill Column Indicator"       "c" #'hl-fill-column-mode)
+       (:when (featurep! :ui fill-column)
+        :desc "Fill Column Indicator"       "c" #'+fill-column-enable-h)
        :desc "Flymake"                      "f" #'flymake-mode
        :desc "Frame fullscreen"             "F" #'toggle-frame-fullscreen
        :desc "Indent style"                 "I" #'doom/toggle-indent-style

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -266,6 +266,10 @@
       ;;; <leader> t --- toggle
       (:prefix-map ("t" . "toggle")
        :desc "Big mode"                     "b" #'doom-big-font-mode
+       (:when (and (featurep! :ui fill-column) EMACS27+)
+        :desc "Fill Column Indicator"       "c" #'display-fill-column-indicator-mode)
+       (:when (and (featurep! :ui fill-column) (not EMACS27+))
+        :desc "Fill Column Indicator"       "c" #'hl-fill-column-mode)
        :desc "Flymake"                      "f" #'flymake-mode
        :desc "Frame fullscreen"             "F" #'toggle-frame-fullscreen
        :desc "Indent style"                 "I" #'doom/toggle-indent-style

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -650,10 +650,8 @@
       ;;; <leader> t --- toggle
       (:prefix-map ("t" . "toggle")
        :desc "Big mode"                     "b" #'doom-big-font-mode
-       (:when (and (featurep! :ui fill-column) EMACS27+)
-        :desc "Fill Column Indicator"       "c" #'display-fill-column-indicator-mode)
-       (:when (and (featurep! :ui fill-column) (not EMACS27+))
-        :desc "Fill Column Indicator"       "c" #'hl-fill-column-mode)
+       (:when (featurep! :ui fill-column)
+        :desc "Fill Column Indicator"       "c" #'+fill-column-enable-h)
        :desc "Flymake"                      "f" #'flymake-mode
        (:when (featurep! :checkers syntax)
         :desc "Flycheck"                   "f" #'flycheck-mode)

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -650,6 +650,10 @@
       ;;; <leader> t --- toggle
       (:prefix-map ("t" . "toggle")
        :desc "Big mode"                     "b" #'doom-big-font-mode
+       (:when (and (featurep! :ui fill-column) EMACS27+)
+        :desc "Fill Column Indicator"       "c" #'display-fill-column-indicator-mode)
+       (:when (and (featurep! :ui fill-column) (not EMACS27+))
+        :desc "Fill Column Indicator"       "c" #'hl-fill-column-mode)
        :desc "Flymake"                      "f" #'flymake-mode
        (:when (featurep! :checkers syntax)
         :desc "Flycheck"                   "f" #'flycheck-mode)

--- a/modules/ui/doom/packages.el
+++ b/modules/ui/doom/packages.el
@@ -1,5 +1,5 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; ui/doom/packages.el
 
-(package! doom-themes :pin "24023de3c80c9f3afc3d012762d1ef0f8dbd326e")
-(package! solaire-mode :pin "cd63b675140232f399e7733d7ce95a0b931b1058")
+(package! doom-themes :pin "d6ee47dc8ed2cf9e585f62243214af03ba5b1687")
+(package! solaire-mode :pin "d751c1c4e97fe6a57740be4da74a2f4b77e3d96d")

--- a/modules/ui/fill-column/autoload.el
+++ b/modules/ui/fill-column/autoload.el
@@ -1,9 +1,12 @@
 ;;; ui/fill-column/autoload.el -*- lexical-binding: t; -*-
 
-;; DEPRECATED Replaced by `display-fill-column-indicator-mode' in Emacs 27+
-
 ;;;###autoload (autoload 'hl-fill-column-mode "hl-fill-column" nil t)
 
 ;;;###autoload
-(add-hook! '(text-mode-hook prog-mode-hook conf-mode-hook)
-           #'hl-fill-column-mode)
+;; Emacs 27 introduced `display-fill-column-indicator-mode' which should be
+;; used instead of `hl-fill-column-mode'
+(if (>= emacs-major-version 27)
+    (add-hook! '(text-mode-hook prog-mode-hook conf-mode-hook)
+               #'display-fill-column-indicator-mode)
+    (add-hook! '(text-mode-hook prog-mode-hook conf-mode-hook)
+               #'hl-fill-column-mode))

--- a/modules/ui/fill-column/autoload.el
+++ b/modules/ui/fill-column/autoload.el
@@ -5,7 +5,7 @@
 ;;;###autoload
 ;; Emacs 27 introduced `display-fill-column-indicator-mode' which should be
 ;; used instead of `hl-fill-column-mode'
-(if (>= emacs-major-version 27)
+(if EMACS27+
     (add-hook! '(text-mode-hook prog-mode-hook conf-mode-hook)
                #'display-fill-column-indicator-mode)
     (add-hook! '(text-mode-hook prog-mode-hook conf-mode-hook)

--- a/modules/ui/fill-column/autoload.el
+++ b/modules/ui/fill-column/autoload.el
@@ -5,8 +5,12 @@
 ;;;###autoload
 ;; Emacs 27 introduced `display-fill-column-indicator-mode' which should be
 ;; used instead of `hl-fill-column-mode'
-(if EMACS27+
-    (add-hook! '(text-mode-hook prog-mode-hook conf-mode-hook)
-               #'display-fill-column-indicator-mode)
-    (add-hook! '(text-mode-hook prog-mode-hook conf-mode-hook)
-               #'hl-fill-column-mode))
+(defun +fill-column-enable-h (&optional arg)
+  (interactive "p")
+  (if (fboundp 'display-fill-column-indicator-mode)
+      (display-fill-column-indicator-mode arg)
+    (hl-fill-column-mode arg)))
+
+;;;###autoload
+(add-hook! '(text-mode-hook prog-mode-hook conf-mode-hook)
+           #'+fill-column-enable-h)

--- a/modules/ui/fill-column/packages.el
+++ b/modules/ui/fill-column/packages.el
@@ -1,4 +1,6 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; ui/fill-column/packages.el
 
-(package! hl-fill-column :pin "5782a91ba0182c4e562fa0db6379ff9dd472856b")
+;; `hl-fill-column' is only used on Emacs versions before 27
+(when (< emacs-major-version 27)
+    (package! hl-fill-column :pin "5782a91ba0182c4e562fa0db6379ff9dd472856b"))

--- a/modules/ui/fill-column/packages.el
+++ b/modules/ui/fill-column/packages.el
@@ -2,5 +2,5 @@
 ;;; ui/fill-column/packages.el
 
 ;; `hl-fill-column' is only used on Emacs versions before 27
-(unless EMACS27+
-    (package! hl-fill-column :pin "5782a91ba0182c4e562fa0db6379ff9dd472856b"))
+(unless (fboundp 'display-fill-column-indicator-mode)
+  (package! hl-fill-column :pin "5782a91ba0182c4e562fa0db6379ff9dd472856b"))

--- a/modules/ui/fill-column/packages.el
+++ b/modules/ui/fill-column/packages.el
@@ -2,5 +2,5 @@
 ;;; ui/fill-column/packages.el
 
 ;; `hl-fill-column' is only used on Emacs versions before 27
-(when (< emacs-major-version 27)
+(unless EMACS27+
     (package! hl-fill-column :pin "5782a91ba0182c4e562fa0db6379ff9dd472856b"))

--- a/modules/ui/indent-guides/packages.el
+++ b/modules/ui/indent-guides/packages.el
@@ -1,4 +1,4 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; ui/indent-guides/packages.el
 
-(package! highlight-indent-guides :pin "a4f771418e4eed1f3f7879a43af28cf97747d41c")
+(package! highlight-indent-guides :pin "cf352c85cd15dd18aa096ba9d9ab9b7ab493e8f6")

--- a/modules/ui/minimap/packages.el
+++ b/modules/ui/minimap/packages.el
@@ -1,4 +1,4 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; ui/minimap/packages.el
 
-(package! minimap :pin "d8850be6fb7b3dbff0cd9b5a04d10a6dcc527326")
+(package! minimap :pin "37a0200b0ca5d7a9f9fb545d4011324ed0512fbd")

--- a/modules/ui/modeline/packages.el
+++ b/modules/ui/modeline/packages.el
@@ -2,7 +2,7 @@
 ;;; ui/modeline/packages.el
 
 (unless (featurep! +light)
-  (package! doom-modeline :pin "ffbaaee832f1c97ff608bc4959b408997d959b7d"))
+  (package! doom-modeline :pin "538017a399cb7b499853bdaf50928ca8b270693d"))
 (package! anzu :pin "7b8688c84d6032300d0c415182c7c1ad6cb7f819")
 (when (featurep! :editor evil)
   (package! evil-anzu :pin "d3f6ed4773b48767bd5f4708c7f083336a8a8a86"))

--- a/modules/ui/tabs/packages.el
+++ b/modules/ui/tabs/packages.el
@@ -1,4 +1,4 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; ui/tabs/packages.el
 
-(package! centaur-tabs :pin "7e0332b138f836b9d0b6d2134310f53369598cfd")
+(package! centaur-tabs :pin "5453317b6b9f68bfbd934eee3b883207bfa331e0")

--- a/modules/ui/treemacs/packages.el
+++ b/modules/ui/treemacs/packages.el
@@ -1,7 +1,7 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; ui/treemacs/packages.el
 
-(package! treemacs :pin "027e03b6fac5c0a870440d27c35d53bbe0215d81")
+(package! treemacs :pin "6c00fe74079a057ad4efc772eab9d73e4f09fa10")
 ;; These packages have no :pin because they're in the same repo
 (when (featurep! :editor evil +everywhere)
   (package! treemacs-evil))

--- a/modules/ui/window-select/packages.el
+++ b/modules/ui/window-select/packages.el
@@ -2,7 +2,7 @@
 ;;; ui/window-select/packages.el
 
 (if (featurep! +switch-window)
-    (package! switch-window :pin "8710f6304d843365fb59b6efe7e1f729d14e557c")
+    (package! switch-window :pin "277706b863c05b3931925ee9dae8970d605bf061")
   (package! ace-window :pin "c7cb315c14e36fded5ac4096e158497ae974bec9"))
 
 (when (featurep! +numbers)

--- a/modules/ui/workspaces/packages.el
+++ b/modules/ui/workspaces/packages.el
@@ -1,4 +1,4 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; ui/workspaces/packages.el
 
-(package! persp-mode :pin "14325c11f7a347717d7c3780f29b24a38c68fbfc")
+(package! persp-mode :pin "c132efe3094ce1368f54195028b29b82c65a64dc")

--- a/modules/ui/zen/packages.el
+++ b/modules/ui/zen/packages.el
@@ -2,4 +2,4 @@
 ;;; ui/zen/packages.el
 
 (package! writeroom-mode :pin "8a226a31a12a9203067094774ba6fd6175793e70")
-(package! mixed-pitch :pin "1cad46fddf741ed7ec5fc477d70e079e908e9ce6")
+(package! mixed-pitch :pin "d305108f9520e196b533f05d1dcc284cf535faaf")


### PR DESCRIPTION
Emacs 27 introduced `display-fill-column-indicator-mode` which replaces `hl-fill-column`. This commit adds some conditionals to use `display-fill-column-indicator-mode` on Emacs 27+, or falls back to `hl-fill-column-mode` on older versions.

This also fixes the deprecation message so I removed it. Once Emacs 27 is more common I would suggest marking it as deprecated again and removing the module entirely. I'll add the message back if you still want it there.

I suggest merging #3815 first since that adds documentation which I can update to match this change.

Any and all suggestions welcome! I'm not great at Elisp yet and in particular the `add-hook!` macro gave me trouble which led to a bit of repetition in the code.