### PR TITLE
exwm module

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -107,6 +107,7 @@
        :os
        (:if IS-MAC macos)  ; improve compatibility with macOS
        ;;tty               ; improve the terminal Emacs experience
+       ;;exwm              ; the truely doomed window manager
 
        :lang
        ;;agda              ; types of types of types of types...

--- a/modules/os/exwm/README.org
+++ b/modules/os/exwm/README.org
@@ -1,0 +1,94 @@
+#+TITLE:   os/exwm
+#+DATE:    September 25, 2020
+#+SINCE:   <replace with next tagged release version>
+#+STARTUP: inlineimages nofold
+
+* Table of Contents :TOC_3:noexport:
+- [[#description][Description]]
+  - [[#maintainers][Maintainers]]
+  - [[#module-flags][Module Flags]]
+  - [[#plugins][Plugins]]
+- [[#features][Features]]
+- [[#prerequisites][Prerequisites]]
+- [[#keybindings][Keybindings]]
+- [[#configuration][Configuration]]
+  - [[#step-1-enable-the-module][Step 1: Enable the module]]
+  - [[#step-2-the-xinitrc-file][Step 2: The =xinitrc= file]]
+  - [[#step-3-sync--reboot][Step 3: Sync & Reboot]]
+- [[#troubleshooting][Troubleshooting]]
+  - [[#issues][Issues]]
+
+* Description
+First class integration for EXWM (Emacs X Window Manager) allowing you to run Doom Emacs as your window manager.
+
+** Maintainers
++ @[[https:github.com/chayward1][chayward1]] (Author)
+
+** Module Flags
++ =+status= Enable a rudmentary statusbar via =doom/modeline=
++ =+firefox= Enable support for firefox integration with exwm.
+
+** Plugins
++ exwm
++ =+firefox=
+  + =:editor +evil=
+    + exwm-firefox-evil
+  + =else=
+    + exwm-firefox
+
+* Features
++ Multi-monitor support
++ Automatic pluggable HDMI handling
++ Evil/Non-evil Browser support (+firefox)
++ Rudamentary statubar via =doom/modeline=
+
+* Prerequisites
++ =xorg-xserver=
++ =xorg-xinit=
++ =xorg-randr=
+
+* Keybindings
+
+| Keys      | Description                      |
+|-----------+----------------------------------|
+| =s-r=     | Exit character / fullscreen mode |
+| =s-w=     | Switch workplaces interactively  |
+| =s-[0-9]= | Switch workplaces by index       |
+| =s-&=     | Launch application interactively |
+
+* Configuration
+** Step 1: Enable the module
+Enable the module in your =init.el= file:
+
+#+BEGIN_SRC emacs-lisp
+:os
+exwm             ; doomed window manager
+#+END_SRC
+
+** Step 2: The =xinitrc= file
+*Create* or *Modify* your =xinitrc= file which should be located in yout =$HOME= directory in either the standard, or daemon configuration:
+
+#+BEGIN_SRC sh
+# ...
+exec emacs
+#+END_SRC
+
+If you prefer to use the emacs-daemon, you can use this =.xinitrc= file configuration instead:
+#+BEGIN_SRC sh
+# ...
+emacs --daemon -f exwm-enable
+exec emacsclient -c
+#+END_SRC
+
+** Step 3: Sync & Reboot
+Don't forget to run =doom/sync= to initialize the module! Reboot your machine and select the =xinitrc= session from your session manager. Your computer should now launch =xorg= with emacs as your window manager!
+
+* Troubleshooting
++ https://github.com/ch11ng/exwm
++ https://wiki.archlinux.org/index.php/EXWM
++ https://github.com/ieure/exwm-firefox
++ https://github.com/walseb/exwm-firefox-evil
++ https://github.com/ch11ng/exwm/wiki/Configuration-Example
+
+** Issues
++ [[https://github.ccom/walseb/exwm-firefox-evil/issues/1][Mouse clicks don't work in NORMAL mode]]

--- a/modules/os/exwm/config.el
+++ b/modules/os/exwm/config.el
@@ -1,0 +1,103 @@
+;;; os/exwm/config.el -*- lexical-binding: t; -*-
+
+;; Here we configure `exwm' a fully functional X window manager:
+;;
+;; Use the `ido' configuration for a few configuration fixes that alter
+;; 'C-x b' workplace switching behaviour
+(require 'exwm)
+(require 'exwm-config)
+(exwm-config-ido)
+(ido-mode +1)
+
+;; Here we configure `exwm-randr' to support multi-monitor setups
+;; as well as hot-plugging HDMI outputs:
+(require 'exwm-randr)
+
+;; Here we configure automated behaviour to only enable the
+;; connected external screen, and to automatically revert to the
+;; initial screen after disconnection:
+;; https://github.com/ch11ng/exwm/wiki#randr-multi-screen
+(add-hook 'exwm-randr-screen-change-hook
+          (lambda ()
+            (let ((xrandr-output-regexp "\n\\([^ ]+\\) connected ")
+                  default-output)
+              (with-temp-buffer
+                (call-process "xrandr" nil t nil)
+                (goto-char (point-min))
+                (re-search-forward xrandr-output-regexp nil 'noerror)
+                (setq default-output (match-string 1))
+                (forward-line)
+                (if (not (re-search-forward xrandr-output-regexp nil 'noerror))
+                    (call-process
+                     "xrandr" nil nil nil
+                     "--output" default-output
+                     "--auto")
+                  (call-process
+                   "xrandr" nil nil nil
+                   "--output" (match-string 1) "--primary" "--auto"
+                   "--output" default-output "--off")
+                  (setq exwm-randr-workspace-monitor-plist
+                        (list 0 (match-string 1))))))))
+(exwm-randr-enable)
+
+;; Here we enable a rudmentary status bar by displaying the time
+;; and battery information (for systems with battery power) in the
+;; modeline:
+(if (featurep! +status)
+    (and (setq display-time-default-load-average nil)
+         (display-time-mode +1)
+         (display-battery-mode +1)))
+
+;; Here we configure global key bindings:
+;;
+;; - `s-r' to exit char / fullscreen mode
+;; - `s-w' to switch workplaces interactively
+;; - `s-0' to `s-9' to switch workplaces by index
+;; - `s-&' to launch applications
+(setq exwm-input-global-keys
+      `(([?\s-r] . exwm-reset)
+        ([?\s-w] . exwm-worksplace-switch)
+        ([?\s-&] . (lambda (command)
+                     (interactive (list (read-shell-command "$ ")))
+                     (start-process-shell-command command nil command)))
+        ,@(mapcar (lambda (i)
+                    `(,(kbd (format "s-%d" i)) .
+                      (lambda ()
+                        (interactive)
+                        (exwm-workspace-switch-create ,i))))
+                  (number-sequence 0 9))))
+
+;; Here we conigure `exwm-firefox-*' for the correct configuration based
+;; on if the user has `evil-mode' activated in their configuration.
+;;
+;; - Add the <ESC> key to the exwm input keys for firefox buffers
+;; - Add "firefox" to the list of firefox class names (evil users)
+(if (featurep! +firefox)
+    (and (dolist (k `(escape))
+           (cl-pushnew k exwm-input-prefix-keys))
+         (if (featurep! :editor evil)
+             (and (require 'exwm-firefox-evil)
+                  (add-hook 'exwm-manage-finish-hook 'exwm-firefox-evil-activate-if-firefox)
+                  (dolist (k `("firefox"))
+                    (cl-pushnew k exwm-firefox-evil-firefox-class-name)))))
+  (and (require 'exwm-firefox)
+       (exwm-firefox-mode +1)))
+
+;; Here we configure the default buffer behaviour. All buffers created in
+;; EXWM mode are named "*EXWM*". You may want to change it in
+;; `exwm-update-class-hook' and `exwm-update-title-hook', which are run
+;; when a new X window class name or title is available:
+(add-hook 'exwm-update-class-hook
+          (lambda ()
+            (unless (or (string-prefix-p "sun-awt-X11-" exwm-instance-name)
+                        (string= "gimp" exwm-instance-name))
+              (exwm-workspace-rename-buffer exwm-class-name))))
+(add-hook 'exwm-update-title-hook
+          (lambda ()
+            (when (or (not exwm-instance-name)
+                      (string-prefix-p "sun-awt-X11-" exwm-instance-name)
+                      (string= "gimp" exwm-instance-name))
+              (exwm-workspace-rename-buffer exwm-title))))
+
+;; Here we enable `exwm' to launch when everything is ready:
+(exwm-enable)

--- a/modules/os/exwm/packages.el
+++ b/modules/os/exwm/packages.el
@@ -4,13 +4,8 @@
 ;; Here we require the `exwm' package for the window manager itself
 ;; and the `exwm-firefox-evil' package for firefox integration with
 ;; evil mode keybindings:
-;; NOTE This section is for testing:
 (package! exwm)
-(package! exwm-firefox-evil)
-
-;; NOTE This section is for when the module is function within the
-;; =doom/modules= directory:
-;; (if (featurep! :firefox)
-;;     (if (featurep! :editor evil)
-;;         (package! exwm-firefox-evil)
-;;       (package! exwm-firefox)))
+(if (featurep! +firefox)
+    (if (featurep! :editor evil)
+        package! exwm-firefox-evil)
+  (package! exwm-firefox))

--- a/modules/os/exwm/packages.el
+++ b/modules/os/exwm/packages.el
@@ -1,0 +1,16 @@
+;; -*- no-byte-compile: t; -*-
+;;; os/exwm/packages.el
+
+;; Here we require the `exwm' package for the window manager itself
+;; and the `exwm-firefox-evil' package for firefox integration with
+;; evil mode keybindings:
+;; NOTE This section is for testing:
+(package! exwm)
+(package! exwm-firefox-evil)
+
+;; NOTE This section is for when the module is function within the
+;; =doom/modules= directory:
+;; (if (featurep! :firefox)
+;;     (if (featurep! :editor evil)
+;;         (package! exwm-firefox-evil)
+;;       (package! exwm-firefox)))


### PR DESCRIPTION
https://github.com/hlissner/doom-emacs/issues/3117

Here is my implementation of an exwm module for doom emacs, some of the features:

- Multi-monitor support
- Auto Pluggable HDMI support

(Optional)
- Firefox browser support for evil/non-evil users via exwm-firefox-*
- Statusbar via doom/modeline and display-time-mode and display-battery-mode both of which are included in emacs