### PR TITLE
Add keybinding for tear-off-window

### DIFF
--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -512,7 +512,8 @@ directives. By default, this only recognizes C directives.")
        "o"       #'doom/window-enlargen
        ;; Delete window
        "d"       #'evil-window-delete
-       "C-C"     #'ace-delete-window)
+       "C-C"     #'ace-delete-window
+       "T"       #'tear-off-window)
 
       ;; text objects
       :textobj "a" #'evil-inner-arg                    #'evil-outer-arg


### PR DESCRIPTION
Added they Evil keybinding `SPC w T` for `tear-off-window` since that is a fairly useful windowing function.

This is just a simple 2-line change, but I thought it would be a nice addition.