### PR TITLE
checkers/spell: fix default ispell dict

### DIFF
--- a/modules/checkers/spell/config.el
+++ b/modules/checkers/spell/config.el
@@ -32,7 +32,7 @@
                                "--dont-tex-check-comments"))
 
      (unless ispell-dictionary
-       (setq ispell-dictionary "en"))
+       (setq ispell-dictionary "english"))
      (unless ispell-aspell-dict-dir
        (setq ispell-aspell-dict-dir
              (ispell-get-aspell-config-value "dict-dir")))


### PR DESCRIPTION
Changes the default ispell dictionary from "en" to "english" since the
former isn't actually a default dictionary name listed in ispell. See
https://github.com/emacs-mirror/emacs/blob/9f30a6b1a417cebe795956a7eef44b8cd9b71557/lisp/textmodes/ispell.el#L471

Otherwise, enabling checkers/spell doesn't do anything even if aspell and the
aspell-en dictionary are installed according to the module README file.