### PR TITLE
Add SPC / in evil-bindings

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -274,6 +274,7 @@
             ((featurep! :completion helm)  #'helm-resume))
 
       :desc "Search for symbol in project" "*" #'+default/search-project-for-symbol-at-point
+      :desc "Search project"               "/" #'+default/search-project
 
       :desc "Find file in project"  "SPC"  #'projectile-find-file
       :desc "Jump to bookmark"      "RET"  #'bookmark-jump


### PR DESCRIPTION
Add SPC / alias for "Search project" (SPC s p)

- Searching is one recurring action by developers

- Spacemacs has the same keybinding,
  so it close one gap between Spacemacs and Doom keybindings (#2542)

- It's consistent with SPC * "Search for symbol in projet"
  as it's Vim "*" and "/" equivalent but project-wide