### PR TITLE
Fix conflicting text formats in "getting started" steps.

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -311,13 +311,13 @@ process.
 Before moving on to installing Emacs et co, a few steps to prepare Windows for
 Emacs are necessary:
 
-1. *Create a ~HOME~ [[https://mywindowshub.com/how-to-edit-system-environment-variables-for-a-user-in-windows-10/][system environment variable]].*
+1. Create a ~HOME~ [[https://mywindowshub.com/how-to-edit-system-environment-variables-for-a-user-in-windows-10/][system environment variable]].
   
    Set it to =C:\Users\USERNAME\=, otherwise Emacs will treat
    =C:\Users\USERNAME\AppData\Roaming= as your ~HOME~, which will cause issues
    later.
 
-2. *Add =C:\Users\USERNAME\.emacs.d\bin= to your ~PATH~.*
+2. Add =C:\Users\USERNAME\.emacs.d\bin= to your ~PATH~.
 
    This way, you don't have to type all of =C:\Users\USERNAME\.emacs.d\bin\doom=
    every time you need to run this script (and you'll need to, often).


### PR DESCRIPTION
Remove fat formatting that interferes with inner monospace/code formatted text.

This caused "=" and "~" signs to be displayed (at least in the browser, on the github readme page).