### PR TITLE
Add keybind to close calendar details in evil mode

### DIFF
--- a/modules/app/calendar/config.el
+++ b/modules/app/calendar/config.el
@@ -22,7 +22,11 @@
         cfw:fchar-top-left-corner ?┏
         cfw:fchar-top-right-corner ?┓)
 
+  ;; Keybindings
   (define-key cfw:calendar-mode-map "q" #'+calendar/quit)
+  (when (featurep! :editor evil +everywhere)
+    (evil-define-key 'normal cfw:details-mode-map
+      "q" #'cfw:details-kill-buffer-command))
 
   (add-hook 'cfw:calendar-mode-hook #'doom-mark-buffer-as-real-h)
   (add-hook 'cfw:calendar-mode-hook 'hide-mode-line-mode)


### PR DESCRIPTION
Currently, after pressing SPC to open the details for a selected day in a calfw calendar, an evil user cannot quit the details buffer conveniently with 'q'.
This PR adds this.