### PR TITLE
Updated notmuch module's README.org

### DIFF
--- a/modules/email/notmuch/README.org
+++ b/modules/email/notmuch/README.org
@@ -41,7 +41,14 @@ This module requires:
 
 ** TODO MacOS
 
-** TODO Arch Linux
+** Arch Linux
+Run one of the following commands.
+#+BEGIN_SRC sh
+sudo pacman -S isync notmuch #mbsync
+# OR
+sudo pacman -S offlineimap notmuch
+#+END_SRC
+
 ** NixOS
 #+BEGIN_SRC nix
 environment.systemPackages = with pkgs; [
@@ -85,17 +92,13 @@ This module uses =Gmailier= by default. To use =mbsync=, change ~+notmuch-sync-b
 (setq +notmuch-sync-backend 'mbsync)
 #+END_SRC
 
-The steps needed to set up =mu4e= with =mbsync= are very similar to the ones for
+The steps needed to set up =notmuch= with =mbsync= are very similar to the ones for
 [[*offlineimap][offlineimap]].
 
 Start with writing a ~\~/.mbsyncrc~. An example for GMAIL can be found on
-[[http://pragmaticemacs.com/emacs/migrating-from-offlineimap-to-mbsync-for-mu4e/][pragmaticemacs.com]]. A non-GMAIL example is available as a gist [[https://gist.github.com/agraul/60977cc497c3aec44e10591f94f49ef0][here]]. The [[http://isync.sourceforge.net/mbsync.html][manual
-page]] contains all needed information to set up your own.
-
+[[https://wiki.archlinux.org/index.php/isync#Configuring][ArchWiki]] which also explains the integration with notmuch for auto synchronization. A non-GMAIL example is available as a gist [[https://gist.github.com/agraul/60977cc497c3aec44e10591f94f49ef0][here]]. 
 Next you can download your email with ~mbsync --all~. This may take a while, but
 should be quicker than =offlineimap= ;).
-
-You can now proceed with the [[*mu and mu4e][mu and mu4e]] section.
 
 ** notmuch
 You should have your email downloaded already. If you have not, you need to set


### PR DESCRIPTION
Corrected some typos, added prerequisite installation instructions for arch and changed the pragmatic emacs link which focused more on integration with mu4e with the arch wiki link which helps in understanding the integration process with notmuch more clearly.