### PR TITLE
[bepo] Map ace window to <leader>éé (from ww)

### DIFF
--- a/modules/input/layout/+bepo.el
+++ b/modules/input/layout/+bepo.el
@@ -27,6 +27,8 @@
   (map!
    :leader
    :desc "Window" "é" 'evil-window-map
+   (:prefix "é"
+    :desc "Ace window" "é" #'ace-window)
    (:when (featurep! :ui popup)
     :desc "Toggle last popup"     "#"    #'+popup/toggle)
    (:when (featurep! :ui workspaces)


### PR DESCRIPTION
w has the same location as é and é is not used so might as well go all the way