### PR TITLE
Feature/bepo ace window

### DIFF
--- a/modules/input/layout/+bepo.el
+++ b/modules/input/layout/+bepo.el
@@ -9,7 +9,8 @@
 (add-hook 'evil-collection-setup-hook #'doom-bepo--evil-collection-hook)
 
 ;; Highlight non breaking spaces as error in prog modes only
-;; TODO: this variable is defined in a file called xdisp.c Will that work in non-X builds ?
+;; FIXME: this variable is defined in a file called xdisp.c Will that work in non-X builds ?
+;; From early observations in sway running pgtk fork, it does not.
 (setq nobreak-char-display t)
 (set-face-attribute 'nobreak-space nil :underline t)
 
@@ -24,6 +25,7 @@
     (setq switch-window-shortcut-style 'qwerty
           switch-window-qwerty-shortcuts '("a" "u" "i" "e" "," "c" "t" "s" "r")))
 
+  (map! "C-é" 'evil-window-map)
   (map!
    :leader
    :desc "Window" "é" 'evil-window-map

--- a/modules/input/layout/+bepo.el
+++ b/modules/input/layout/+bepo.el
@@ -27,8 +27,6 @@
   (map!
    :leader
    :desc "Window" "é" 'evil-window-map
-   (:prefix "é"
-    :desc "Ace window" "é" #'ace-window)
    (:when (featurep! :ui popup)
     :desc "Toggle last popup"     "#"    #'+popup/toggle)
    (:when (featurep! :ui workspaces)


### PR DESCRIPTION
I was utterly confused by a Discord message.

`ace-window` is just a clean remap of `other-window`

`other-window` was mapped to `evil-window-map C-w` and never `evil-window-map w`. So this is why I couldn't find it under `é` in `evil-window-map`

Therefore
- The changes in #4030 are reverted
- `evil-window-map` is additionally bound to `C-é` so that `C-é C-é` gives `other-window`

I also transformed an open question I had in FIXME, although to be honest it is not urgent at all.