### PR TITLE
(org +roam): use company-capf instead of company-org-roam

### DIFF
--- a/modules/lang/org/contrib/roam.el
+++ b/modules/lang/org/contrib/roam.el
@@ -51,6 +51,9 @@
               ((featurep! :completion ido) 'ido)
               ('default)))
 
+  (when (featurep! :completion company)
+    (set-company-backend! 'org-mode '(company-capf company-yasnippet company-dabbrev)))
+
   ;; Normally, the org-roam buffer doesn't open until you explicitly call
   ;; `org-roam'. If `+org-roam-open-buffer-on-find-file' is non-nil, the
   ;; org-roam buffer will be opened for you when you use `org-roam-find-file'
@@ -82,10 +85,3 @@
 ;; detected), we can safely chain `org-roam-protocol' to it.
 (use-package! org-roam-protocol
   :after org-protocol)
-
-
-(use-package! company-org-roam
-  :when (featurep! :completion company)
-  :after org-roam
-  :config
-  (set-company-backend! 'org-mode '(company-org-roam company-yasnippet company-dabbrev)))

--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -75,9 +75,7 @@
              :files ("css" "dist" "js" "plugin"))
     :pin "15815efe05ca69c35ce66cfdbf93316e1db66ecb"))
 (when (featurep! +roam)
-  (package! org-roam :pin "c33867e6bc282ff0a69d4ef4a020db82604039bb")
-  (when (featurep! :completion company)
-    (package! company-org-roam :pin "1132663bd68022aa7ea005ff53c7c7571890769d")))
+  (package! org-roam :pin "0cce9d116580665d9eb9284d3317ae1beda56bc1"))
 
 ;;; Babel
 (package! ob-async :pin "80a30b96a007d419ece12c976a81804ede340311")


### PR DESCRIPTION
company-org-roam is now deprecated, completions are provided via capf instead.

I updated the pin to the latest Org-roam (release v1.2.2), which has some fixes for completions.