### PR TITLE
Add ligratures for emacs-lisp-mode

### DIFF
--- a/modules/lang/emacs-lisp/config.el
+++ b/modules/lang/emacs-lisp/config.el
@@ -33,7 +33,25 @@ employed so that flycheck still does *some* helpful linting.")
     :definition    #'+emacs-lisp-lookup-definition
     :documentation #'+emacs-lisp-lookup-documentation)
   (set-docsets! '(emacs-lisp-mode lisp-interaction-mode) "Emacs Lisp")
-  (set-ligatures! 'emacs-lisp-mode :lambda "lambda")
+  (set-ligatures! 'emacs-lisp-mode
+    ;; Functional
+    :lambda        "lambda"
+    :def           "defun"
+    :map           "map"
+    ;; Types
+    :null          "null"
+    :true          "t"
+    :true          "T"
+    :false         "nil"
+    ;; Flow
+    :not           "not"
+    :in            "in"
+    :and           "and"
+    :or            "or"
+    :for           "for"
+    :return        "write"
+    ;; Other
+    :dot           ".")
   (set-rotate-patterns! 'emacs-lisp-mode
     :symbols '(("t" "nil")
                ("let" "let*")


### PR DESCRIPTION
It's a bit daring to propose changes for languages you don't know... But I did it anyways. I just want my few lines of config to be prettier...

Please double check every symbol and keyword... I simply guessed most of them since I'm not familiar with Lisps at all :D


Could also add `()` as a False symbol tho I doubted maybe that's a pushing... So I didn't