### PR TITLE
Add `json-mode` keybindings under the local leader

### DIFF
--- a/modules/lang/json/config.el
+++ b/modules/lang/json/config.el
@@ -11,7 +11,13 @@
   (map! :after json-mode
         :map json-mode-map
         :localleader
-        "p" #'jsons-print-path))
+        :desc "Copy path" "p" #'json-mode-show-path
+        "t" #'json-toggle-boolean
+        "d" #'json-mode-kill-path
+        "x" #'json-nullify-sexp
+        "+" #'json-increment-number-at-point
+        "-" #'json-decrement-number-at-point
+        "f" #'json-mode-beautify))
 
 
 


### PR DESCRIPTION
These are the keybindings currently under `C-c`, with some modifications to fit evil conventions.