### PR TITLE
Improvements to native-comp support

### DIFF
--- a/core/cli/autoloads.el
+++ b/core/cli/autoloads.el
@@ -10,6 +10,7 @@ one wants that.")
 (defvar doom-autoloads-cached-vars
   '(doom-modules
     doom-disabled-packages
+    comp-deferred-compilation-black-list
     load-path
     auto-mode-alist
     interpreter-mode-alist
@@ -42,8 +43,9 @@ one wants that.")
              (signal 'doom-error
                      (list "The installed version of Doom has changed since last 'doom sync' ran"
                            "Run 'doom sync' to bring Doom up to speed"))))
-         (mapcar (lambda (var) `(set ',var ',(symbol-value var)))
-                 doom-autoloads-cached-vars)
+         (cl-loop for var in doom-autoloads-cached-vars
+                  when (boundp var)
+                  collect `(set ',var ',(symbol-value var)))
          (doom-autoloads--scan
           (append (cl-loop for dir
                            in (append (list doom-core-dir)

--- a/core/core.el
+++ b/core/core.el
@@ -285,7 +285,9 @@ config.el instead."
 
 (after! comp
   ;; HACK Disable native-compilation for some troublesome packages
-  (add-to-list 'comp-deferred-compilation-black-list "/evil-collection-vterm\\.el\\'"))
+  (dolist (entry (list (concat "\\`" doom-local-dir ".*/evil-collection-vterm\\.el\\'")
+                       (concat "\\`" doom-local-dir "autoloads\\.el\\'")))
+    (add-to-list 'comp-deferred-compilation-black-list entry)))
 
 
 ;;

--- a/core/core.el
+++ b/core/core.el
@@ -284,13 +284,6 @@ config.el instead."
   (add-to-list 'comp-eln-load-path (concat doom-cache-dir "eln/")))
 
 (after! comp
-  ;; HACK `comp-eln-load-path' isn't fully respected yet, because native
-  ;;      compilation occurs in another emacs process that isn't seeded with our
-  ;;      value for `comp-eln-load-path', so we inject it ourselves:
-  (setq comp-async-env-modifier-form
-        `(progn
-           ,comp-async-env-modifier-form
-           (setq comp-eln-load-path ',(bound-and-true-p comp-eln-load-path))))
   ;; HACK Disable native-compilation for some troublesome packages
   (add-to-list 'comp-deferred-compilation-black-list "/evil-collection-vterm\\.el\\'"))
 

--- a/core/packages.el
+++ b/core/packages.el
@@ -18,7 +18,7 @@
             :local-repo "straight.el"
             :files ("straight*.el")
             :no-build t)
-  :pin "0c7c7571349b628d87acde474a754f05e86ca876")
+  :pin "728ea18ea590fcd8fb48f5bed30e135942d97221")
 
 ;; core-modules.el
 (package! use-package


### PR DESCRIPTION
Adds ahead-of-time compilation of all packages on load-path, ensuring all core and site Elisp is actually native-compiled.

Exports `comp-deferred-compilation-black-list` to runtime, bringing us one step closer to properly supporting deferred compilation.

WARNING: There are currently some upstream bugs which makes testing this PR difficult:

1. Ensure that `~/.emacs.d/eln-cache` exists.
2. Run `emacs -q`, wait for async compilations to finish.
3. Ensure that `~/.emacs.d/.local/cache/eln` exists.
4. Run `doom sync`.
5. Run `doom build -r`, kill it when it hangs on "Waiting for NNN async jobs".
6. Run `doom build -r` again, it will work this time, wait until it finishes.
7. Run `doom build -r` again, it should have nothing to rebuild.
8. Run emacs!