### PR TITLE
Search compressed .el files in load history

### DIFF
--- a/core/autoload/help.el
+++ b/core/autoload/help.el
@@ -662,6 +662,7 @@ Uses the symbol at point or the current selection, if available."
   (doom--help-search
    (cl-loop for (file . _) in (cl-remove-if-not #'stringp load-history :key #'car)
             for filebase = (file-name-sans-extension file)
-            if (file-exists-p! (format "%s.el" filebase))
+            if (file-exists-p! (or (format "%s.el.gz" filebase)
+                                   (format "%s.el" filebase)))
             collect it)
    query "Search loaded files: "))


### PR DESCRIPTION
On many installations, the .el files that are builtin to emacs are
compressed. We should search these as well.