### PR TITLE
Bumping ocamlformat package to latest

### DIFF
--- a/modules/lang/ocaml/packages.el
+++ b/modules/lang/ocaml/packages.el
@@ -17,7 +17,7 @@
 (when (featurep! :editor format)
   (package! ocamlformat
     :recipe (:host github :repo "ocaml-ppx/ocamlformat" :files ("emacs/*.el"))
-    :pin "cd0eaa8bbb7df431276cf65741c53eaa913f7807"))
+    :pin "1dec6c3ffb2572b21d43e99653cabdf0406e7eef"))
 
 (package! dune
   :recipe (:host github :repo "ocaml/dune" :files ("editor-integration/emacs/*.el"))


### PR DESCRIPTION
Bumping to the latest version because the current pinned version of ocamlformat in doom is broken on macos, formatting does some weird things. This PR fixes the issue https://github.com/ocaml-ppx/ocamlformat/pull/1481 and we may as well go to the latest anyways.