### PR TITLE
Bump :lang latex

### DIFF
--- a/modules/lang/latex/packages.el
+++ b/modules/lang/latex/packages.el
@@ -1,11 +1,11 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; lang/latex/packages.el
 
-(package! auctex :pin "59e251c4c82d878e605a13aec3752e544a99f21a")
+(package! auctex :pin "9e7406cddd87c1f318d943bd3f5edc73d82e349d")
 (package! adaptive-wrap :pin "319db649fb083db3ad07b4c71ee6c9429497043b")
 (package! latex-preview-pane :pin "5297668a89996b50b2b62f99cba01cc544dbed2e")
 (when (featurep! :editor evil +everywhere)
-  (package! evil-tex :pin "06234c9ea4a7ffac91f7b4f3fd683014bb8137af"))
+  (package! evil-tex :pin "a3b6875d4027c675cf490622026a15a12fe1a911"))
 
 ;; Optional module features:
 


### PR DESCRIPTION
jwiegley/auctex@59e251c -> jwiegley/auctex@9e7406c
iyefrat/evil-tex@06234c9 -> iyefrat/evil-tex@a3b6875

iyefrat/evil-tex#3 fixes selection/navigation in LaTeX files which are not the root document and makes section regex-matching more strict, to avoid partial matching.