### PR TITLE
Respect magit-display-buffer-noselect

### DIFF
--- a/modules/tools/magit/autoload.el
+++ b/modules/tools/magit/autoload.el
@@ -66,7 +66,8 @@ window that already exists in that direction. It will split otherwise."
                        +magit-open-windows-in-direction))
         (origin-window (selected-window)))
     (if-let (window (window-in-direction direction))
-        (select-window window)
+        (unless magit-display-buffer-noselect
+          (select-window window))
       (if-let (window (and (not (one-window-p))
                            (window-in-direction
                             (pcase direction
@@ -74,16 +75,19 @@ window that already exists in that direction. It will split otherwise."
                               (`left 'right)
                               ((or `up `above) 'down)
                               ((or `down `below) 'up)))))
-          (select-window window)
+        (unless magit-display-buffer-noselect
+          (select-window window))
         (let ((window (split-window nil nil direction)))
-          (when (memq direction '(right down below))
+          (when (and (not magit-display-buffer-noselect)
+                     (memq direction '(right down below)))
             (select-window window))
           (display-buffer-record-window 'reuse window buffer)
           (set-window-buffer window buffer)
           (set-window-parameter window 'quit-restore (list 'window 'window origin-window buffer))
           (set-window-prev-buffers window nil))))
-    (switch-to-buffer buffer t t)
-    (selected-window)))
+    (unless magit-display-buffer-noselect
+      (switch-to-buffer buffer t t)
+      (selected-window))))
 
 
 ;;


### PR DESCRIPTION
This fixes the behavior of e.g. magit-diff-show-or-scroll-down.
When in magit-log-mode, said action should not move focus to the diff
window because it would otherwise behave identical to pressing
magit-show-commit.

When reviewing the change history of a series of (especially small) commits, the current behavior of `+magit--display-buffer-in-direction` is annoying because the focus is always put into the diff with the changes and I have to move back to the magit-log window quite a lot. With the following bindings, I just have to press j/k and ,/; to quickly scroll through the changes of the diff and I can use my left hand to drink some coffee while doing so. :-) It's also the way magit behaves by default.

```elisp
(use-package! magit
  :bind
  (:map magit-log-mode-map
      ("," . magit-diff-show-or-scroll-down)
      (";" . magit-diff-show-or-scroll-up)))
```

When using `doom/sandbox`, you can see the difference in behavior with vanilla emacs or vanilla doom.

```elisp
(require 'magit)
(magit-status "~/.emacs.d")
(call-interactively #'magit-log-current)
(global-set-key (kbd ",") 'magit-diff-show-or-scroll-down)
(global-set-key (kbd ";") 'magit-diff-show-or-scroll-up)
```
