### PR TITLE
docs: add shell snippet to export ~/.emacs.d/bin to PATH in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,13 @@ git clone --depth 1 https://github.com/hlissner/doom-emacs ~/.emacs.d
 Then [read our Getting Started guide][getting-started] to be walked through
 installing, configuring and maintaining Doom Emacs.
 
-It's a good idea to add `~/.emacs.d/bin` to your `PATH`! Other `bin/doom`
-commands you should know about:
+It's a good idea to add `~/.emacs.d/bin` to your `PATH`! 
+
+``` sh
+export PATH="$HOME/.emacs.d/bin:$PATH"
+```
+
+Other `bin/doom` commands you should know about:
 
 + `doom sync` to synchronize your private config with Doom by installing missing
   packages, removing orphaned packages, and regenerating caches. Run this


### PR DESCRIPTION
Providing a shell snippet to add `~/.emacs.d/bin` to `$PATH` for people like me who doesn't familiar with shell environment. It can save their time on searching and debugging.

For example:

I used `export PATH="~/.emacs.d/bin:$PATH"` in `.zshrc` but it didn't work, then I spend some time to find how to add a directory to `PATH`.

<img width="842" alt="Screen Shot 2020-10-13 at 2 22 22 PM" src="https://user-images.githubusercontent.com/14329786/95823225-cbf7c900-0d5f-11eb-8252-ec3f2d22d5cd.png">

Finally I got 

```sh
export PATH="$HOME/.emacs.d/bin:$PATH"
```

So I think this might be helpful to add this line in README for other people. 😄