### PR TITLE
added remove ~/.emacs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ doctor` to check for any that you may have missed.
 ``` sh
 git clone --depth 1 https://github.com/hlissner/doom-emacs ~/.emacs.d
 ~/.emacs.d/bin/doom install
+rm ~/.emacs (if this file exsists it will overwrite the doom emacs config)
 ```
 
 Then [read our Getting Started guide][getting-started] to be walked through


### PR DESCRIPTION
When I first downloaded doom I was not aware that you need to delete .emacs so I added it to the read me in case anyone else is confused.