### PR TITLE
tools/magit: add magit-diff-refine-hunk to readme

### DIFF
--- a/modules/tools/magit/README.org
+++ b/modules/tools/magit/README.org
@@ -13,6 +13,7 @@
 - [[#features][Features]]
 - [[#configuration][Configuration]]
   - [[#enable-gravatars][Enable Gravatars]]
+  - [[#enable-granular-diff-highlights-for-all-hunks][Enable granular diff-highlights for all hunks]]
 - [[#troubleshooting][Troubleshooting]]
 
 * Description
@@ -60,6 +61,17 @@ Add these to =$DOOMDIR/config.el=.
 This will enable gravatars when viewing commits. The service used by default is [[https://www.libravatar.org/][Libravatar]].
 #+BEGIN_SRC emacs-lisp
 (setq magit-revision-show-gravatars '("^Author:     " . "^Commit:     "))
+#+END_SRC
+
+** Enable granular diff-highlights for all hunks
+
+By default, changes are highlighted *linewise* for all but the selected hunk. This
+has [[https://magit.vc/manual/magit/Performance.html][performance reasons]]. You can enable character-wise highlights for all
+visible hunks with:
+
+#+BEGIN_SRC emacs-lisp
+(after! magit
+  (setq magit-diff-refine-hunk 'all))
 #+END_SRC
 
 * TODO Troubleshooting


### PR DESCRIPTION
Mention how to turn on granular diffs for all hunks, as requested in #4109.