### PR TITLE
A comment for users and tide package pin

### DIFF
--- a/core/templates/packages.example.el
+++ b/core/templates/packages.example.el
@@ -32,6 +32,11 @@
 ;(package! builtin-package :recipe (:nonrecursive t))
 ;(package! builtin-package-2 :recipe (:repo "myfork/package"))
 
+;; Remember to run 'doom sync -u' after changing recipes for existing packages.
+;; At the time of writing, 'doom sync' alone will not pick up on recipe changes.
+;; And for existing packages remember to unpin the package if you need a
+;; different commit.
+
 ;; Specify a `:branch' to install a package from a particular branch or tag.
 ;; This is required for some packages whose default branch isn't 'master' (which
 ;; our package manager can't deal with; see raxod502/straight.el#279)

--- a/modules/lang/javascript/packages.el
+++ b/modules/lang/javascript/packages.el
@@ -17,6 +17,6 @@
 (package! skewer-mode :pin "e5bed351939c92a1f788f78398583c2f83f1bb3c")
 
 ;; Programming environment
-(package! tide :pin "fa617f54629dc53a3182251dd8076c9e7ac9effa")
+(package! tide :pin "ac5f070138fbc3657082412c3911d46a1107f39d")
 (when (featurep! :tools lookup)
   (package! xref-js2 :pin "6f1ed5dae0c2485416196a51f2fa92f32e4b8262"))


### PR DESCRIPTION
Pinning the new tide commit due to: https://github.com/ananthakumaran/tide/issues/401#event-3888907902
And adding the `doom sync -u` command as a comment on the packages.el settings file because it went over my head when I was trying to change the recipe for the tide package. The comment about using `doom sync -u` is in the docs tho: https://github.com/hlissner/doom-emacs/blob/develop/docs/getting_started.org#changing-a-recipe-for-a-included-package
