### PR TITLE
Optimize dired-all-the-icons by unlimiting memoization limit

### DIFF
--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -123,7 +123,14 @@ we have to clean it up ourselves."
 
     (defadvice! +dired-restore-icons-after-wdired-mode-a (&rest _)
       :after #'wdired-change-to-dired-mode
-      (all-the-icons-dired-mode +wdired-icons-enabled))))
+      (all-the-icons-dired-mode +wdired-icons-enabled)))
+
+  (defadvice! +dired-unlimited-icon-memoization-a (orig-fn &rest args)
+    "Make `memoize-default-timeout' temporarily unlimited so its
+expansive time checks would not be performed."
+    :around #'all-the-icons-dired--refresh
+    (let ((memoize-default-timeout nil))
+      (apply orig-fn args))))
 
 
 (use-package! dired-x


### PR DESCRIPTION
This has annoyed me for a long time. Lead by the profiler, I managed to reap a few low-hanging fruits and improve performance quite a bit :) .

My `/nix/store` has 7,867 files, and running these benchmarks for `find-file` we get:

> 66.92s with 332 gc runs that took 33.22s - No modifications
> 24.35s with 2 gc runs that took 0.22s - Disabled memoization limit
> 14.72s with 3 gc runs that took 0.28s - Simple memoization for ‘dired-subdir-hidden-p’

The first advice disables the memoization time limit for `'all-the-icons-dired--refresh` since its time comparisons create a lot of garbage. It shouldn't hurt actual performance in any way since the run time of `'all-the-icons-dired--refresh` should never be more than the default 2 hours. I'm really not sure what purpose the memoize package serves if it's so slow.

The second one caches successive calls to `'dired-subdir-hidden-p` since it seems to be called on the same parent dir for each dir listing. I'm less certain about including this one in Doom, I'll want investigate further why its called so many times in the first place. (Which is why it's not included in this PR.)

Code:
``` emacs-lisp
(defvar benchmark-dired-dir "/nix/store")
(defun benchmark-dired (message)
  (message (concat (apply #'format "%.2fs with %d gc runs that took %.2fs"
                          (benchmark-run 1
                            (save-excursion
                              (find-file benchmark-dired-dir))))
                   " - " message)))


(benchmark-dired "No modifications")

(defadvice! +dired-unlimited-icon-memoization (orig-fn &rest args)
  "Make `memoize-default-timeout' temporarily unlimited so its
expansive time checks would not be performed."
  :around #'all-the-icons-dired--refresh
  (let ((memoize-default-timeout nil))
    (apply orig-fn args)))

(benchmark-dired "Disabled memoization limit")

(defvar +dired-hidden-subdir-p-prev-result nil
  "Previous argument and result of `dired-subdir-hidden-p', held
in a cons cell of (dir . hidden?).")

(defadvice! +dired-cache-subdir-hidden-p (orig-fn dir)
  "Cache the previous result of `dired-subdir-hidden-p' using
`+dired-hidden-subdir-p-prev-result'"
  :around #'dired-subdir-hidden-p
  (unless (equal dir (car +dired-hidden-subdir-p-prev-result))
    (setq +dired-hidden-subdir-p-prev-result
          (cons dir (funcall orig-fn dir)))
    (cdr +dired-hidden-subdir-p-prev-result)))

(benchmark-dired "Simple memoization for `dired-subdir-hidden-p'")

```