### PR TITLE
Format with LSP if supported on save

### DIFF
--- a/modules/editor/format/config.el
+++ b/modules/editor/format/config.el
@@ -44,7 +44,7 @@ This is controlled by `+format-on-save-enabled-modes'."
                      (memq major-mode (cdr +format-on-save-enabled-modes)))
                     ((not (memq major-mode +format-on-save-enabled-modes))))
               (not (require 'format-all nil t)))
-    (format-all-mode +1)))
+    (add-hook 'before-save-hook #'+format/buffer nil t)))
 
 (when (featurep! +onsave)
   (add-hook 'after-change-major-mode-hook #'+format-enable-on-save-maybe-h))

--- a/modules/editor/format/config.el
+++ b/modules/editor/format/config.el
@@ -44,7 +44,7 @@ This is controlled by `+format-on-save-enabled-modes'."
                      (memq major-mode (cdr +format-on-save-enabled-modes)))
                     ((not (memq major-mode +format-on-save-enabled-modes))))
               (not (require 'format-all nil t)))
-    (add-hook 'before-save-hook #'+format/buffer nil t)))
+    (+format-enable-on-save-h)))
 
 (when (featurep! +onsave)
   (add-hook 'after-change-major-mode-hook #'+format-enable-on-save-maybe-h))


### PR DESCRIPTION
Fixes #3626

To fix this, 
```lisp
(format-all-mode +1)
```
Was replaced with:
```elisp
(+format-on-save-h)
```
This ensures that `+format/buffer` is used instead of `format-all-buffer`
In the function `+format-on-save-maybe-h` located in `modules/format/config.el` 