### PR TITLE
fix: add explanation for php document

### DIFF
--- a/modules/lang/php/README.org
+++ b/modules/lang/php/README.org
@@ -68,7 +68,7 @@ To get started with PHP, you'll need ~php~ (5.3+) and ~composer~.
 
 Note for =+lsp=:
 1. In order to make full use of phpactor server, ~php~ (7.3+) is recommended.
-2. If you use intelephense, ~node~ and ~npm~ is needed.
+2. If you use intelephense, ~node~ and ~npm~ are needed.
 
 *** MacOS
 PHP 5.5 comes prepackaged with newer versions of MacOS. These instructions are provided for reference:

--- a/modules/lang/php/README.org
+++ b/modules/lang/php/README.org
@@ -45,9 +45,8 @@ This module has no dedicated maintainers.
 
 ** Module Flags
 + =+hack= Add support for the [[https://hacklang.org/][Hack dialect of PHP]] by Facebook.
-+ =+lsp= Enable LSP support through phpactor. Requires the ~:tools lsp~ module
-  and the [[https://phpactor.readthedocs.io/en/develop/usage/standalone.html][phpactor server]] to be installed on your system.
-
++ =+lsp= Enable LSP support through phpactor or intelephense. Requires the
+  ~:tools lsp~ module and the [[https://phpactor.readthedocs.io/en/develop/usage/standalone.html][phpactor server]] to be installed on your system.
 ** Plugins
 + [[https://github.com/tomterl/php-boris][async]]
 + [[https://github.com/tomterl/php-boris][php-boris]]
@@ -67,7 +66,9 @@ This module has no dedicated maintainers.
 ** PHP
 To get started with PHP, you'll need ~php~ (5.3+) and ~composer~.
 
-Note: in order to make full use of phpactor server, ~php~ (7.3+) is recommended.
+Note for =+lsp=:
+1. In order to make full use of phpactor server, ~php~ (7.3+) is recommended.
+2. If you use intelephense, ~node~ and ~npm~ is needed.
 
 *** MacOS
 PHP 5.5 comes prepackaged with newer versions of MacOS. These instructions are provided for reference:
@@ -76,16 +77,26 @@ PHP 5.5 comes prepackaged with newer versions of MacOS. These instructions are p
 brew tap homebrew/homebrew-php
 brew install php71  # or php53, php54, php55
 brew install composer
+
+# If you use intelephense:
+brew install node
+brew install npm
 #+END_SRC
 
 *** Arch Linux
 #+BEGIN_SRC sh :dir /sudo:: :tangle (if (doom-system-os 'arch) "yes")
 sudo pacman --needed --noconfirm -S php composer  # or php53, php54, php55
+
+# If you use intelephense:
+sudo pacman -S nodejs npm
 #+END_SRC
 
 *** openSUSE
 #+BEGIN_SRC sh :dir /sudo::
 sudo zypper install php-composer
+
+# If you use intelephense:
+sudo zypper install nodejs npm
 #+END_SRC
 
 ** Dependencies
@@ -110,6 +121,8 @@ Ensure that ~\~/.composer/vendor/bin~ is in ~PATH~:
 export PATH="~/.composer/vendor/bin:$PATH"
 #+END_SRC
 
+By the way, if you use intelephense, running =M-x lsp-install-server= and
+choose ~iph~ to install lsp-intelephense.
 * TODO Features
 # An in-depth list of features, how to use them, and their dependencies.
 

--- a/modules/lang/php/README.org
+++ b/modules/lang/php/README.org
@@ -46,7 +46,7 @@ This module has no dedicated maintainers.
 ** Module Flags
 + =+hack= Add support for the [[https://hacklang.org/][Hack dialect of PHP]] by Facebook.
 + =+lsp= Enable LSP support through phpactor. Requires the ~:tools lsp~ module
-  and the phpactor server to be installed on your system.
+  and the [[https://phpactor.readthedocs.io/en/develop/usage/standalone.html][phpactor server]] to be installed on your system.
 
 ** Plugins
 + [[https://github.com/tomterl/php-boris][async]]
@@ -65,7 +65,9 @@ This module has no dedicated maintainers.
 
 * Prerequisites
 ** PHP
-To get started with PHP, you'll need ~php~ (5.3+) and ~composer~:
+To get started with PHP, you'll need ~php~ (5.3+) and ~composer~.
+
+Note: in order to make full use of phpactor server, ~php~ (7.3+) is recommended.
 
 *** MacOS
 PHP 5.5 comes prepackaged with newer versions of MacOS. These instructions are provided for reference:


### PR DESCRIPTION
Add some explanation for phpactor server and its prerequisites in `modules/lang/php/README.org`.