### PR TITLE
Bump iedit

### DIFF
--- a/modules/editor/multiple-cursors/packages.el
+++ b/modules/editor/multiple-cursors/packages.el
@@ -3,9 +3,7 @@
 
 (cond
  ((featurep! :editor evil)
-  ;; REVIEW Broken in 8abf2c1f4f0ade64cbb06c8f47055f04ab83e8d6 (latest commit at
-  ;;        time of writing). Revisit later.
-  (package! iedit :pin "77eb0a1e2e44b453e4ebf4c38409affa353f5139")
+  (package! iedit :pin "def0c19ff77aef32ccf11eb118771a11cff59584")
   (package! evil-multiedit :pin "9f271e0e6048297692f80ed6c5ae8994ac523abc")
   (package! evil-mc :pin "4d4c0172e4c7f80acc1d0e73d5fb3e536929b262"))
 


### PR DESCRIPTION
Bumping `iedit` version to fix `Symbol's function definition is void: iedit-lib-cleanup` error preventing exit of `iedit` mode. `iedit` was updated to have it's cleanup function renamed and `evil-iedit-state` was updated to account for this change. However, Doom's version of `iedit` did not contain the newer function, thus introducing this error.

Details of the issue can be found here: https://github.com/syl20bnr/evil-iedit-state/issues/27