### PR TITLE
Add mathjax support for markdown preview

### DIFF
--- a/modules/lang/markdown/config.el
+++ b/modules/lang/markdown/config.el
@@ -44,6 +44,7 @@ capture, the end position, and the output buffer.")
         markdown-xhtml-header-content
         (concat "<meta name='viewport' content='width=device-width, initial-scale=1, shrink-to-fit=no'>"
                 "<style> body { box-sizing: border-box; max-width: 740px; width: 100%; margin: 40px auto; padding: 0 10px; } </style>"
+                "<script id='MathJax-script' async src='https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js'></script>"
                 "<script src='https://cdn.jsdelivr.net/gh/highlightjs/cdn-release/build/highlight.min.js'></script>"
                 "<script>document.addEventListener('DOMContentLoaded', () => { document.body.classList.add('markdown-body'); document.querySelectorAll('pre[lang] > code').forEach((code) => { code.classList.add(code.parentElement.lang); }); document.querySelectorAll('pre > code').forEach((code) => { hljs.highlightBlock(code); }); });</script>"))
 


### PR DESCRIPTION
Added Mathjax to html previews for markdown.  This can be tested by running `markdown-preview` on some markdown file.

Before:

![Screenshot_20201022_215750](https://user-images.githubusercontent.com/5473302/96951306-cdd53100-14b1-11eb-8559-b2f1521c0a38.png)


After:

![Screenshot_20201022_215823](https://user-images.githubusercontent.com/5473302/96951314-d2014e80-14b1-11eb-9339-cbc5e1891e09.png)

