### PR TITLE
julia with lsp +eglot config

### DIFF
--- a/modules/lang/julia/README.org
+++ b/modules/lang/julia/README.org
@@ -8,9 +8,8 @@
   - [[#module-flags][Module Flags]]
   - [[#plugins][Plugins]]
 - [[#prerequisites][Prerequisites]]
-  - [[#language-server][Language Server]]
 - [[#features][Features]]
-  - [[#language-server-1][Language Server]]
+  - [[#language-server][Language Server]]
 - [[#configuration][Configuration]]
 
 * Description
@@ -27,28 +26,20 @@ Adds Julia support to Doom Emacs
 + [[https://github.com/JuliaEditorSupport/julia-emacs/][julia-repl]]
 + =+lsp= and =:tools lsp=
   + [[https://github.com/non-jedi/lsp-julia][lsp-julia]]*
+  + [[https://github.com/non-jedi/eglot-jl][eglot-jl]]*
   + [[https://github.com/emacs-lsp/lsp-mode][lsp]]
 
 * Prerequisites
 This module has no direct prerequisites.
 
-** Language Server
-
-~+lsp~ requires the a manual installation of ~lsp-julia~ as it comes with a
-packaged version of ~LanguageServer.jl~ and its dependencies.
-
-#+BEGIN_SRC elisp
-;; ~/.doom.d/packages.el
-(package! lsp-julia :recipe (:host github :repo "non-jedi/lsp-julia"))
-#+END_SRC
-
 * Features
   # An in-depth list of features, how to use them, and their dependencies.
 ** Language Server
-   ~+lsp~ adds code completion, syntax checking, formatting and other ~lsp-mode~
-   features. This requires a manual installation of ~lsp-julia~ as it bundles
-   ~LanguageServer.jl~ and its dependencies.
-  
+~+lsp~ adds code completion, syntax checking, formatting and other ~lsp-mode~
+features.
+~+lsp~ uses either ~lsp-julia~ when using ~lsp-mode~ or ~eglot-jl~ when using
+~eglot~ to provide ~LanguageServer.jl~ with its dependencies.
+
 * Configuration
 ~lsp-julia~ requires a variable be set for the Julia environment. This is set to
 v1.0 by default as it is the current LTS.
@@ -58,10 +49,15 @@ v1.0 by default as it is the current LTS.
 (setq lsp-julia-default-environment "~/.julia/environments/v1.0")
 #+END_SRC
 
+~eglot-jl~ automatically sets the Julia environment.
+
 If you would like to use your own installation of ~LanguageServer.jl~, put the
 following in your personal ~config.el~.
 
 #+BEGIN_SRC elisp
 ;; ~/.doom.d/config.el
+;; lsp-julia
 (setq lsp-julia-package-dir nil)
+;; eglot-jl
+(defcustom eglot-jl-language-server-project "/path/to/project")
 #+END_SRC

--- a/modules/lang/julia/README.org
+++ b/modules/lang/julia/README.org
@@ -32,6 +32,10 @@ Adds Julia support to Doom Emacs
 * Prerequisites
 This module has no direct prerequisites.
 
+Because ~lsp-julia~ and ~eglot-jl~ when first used install julia packages,
+temporarily setting the lsp timeout (~lsp-julia-timeout~ or ~eglot-connect-timeout~)
+to a large value is necessary.
+
 * Features
   # An in-depth list of features, how to use them, and their dependencies.
 ** Language Server

--- a/modules/lang/julia/config.el
+++ b/modules/lang/julia/config.el
@@ -66,9 +66,20 @@
 
 
 (use-package! lsp-julia
-  :when (featurep! +lsp)
+  :when (and (featurep! +lsp) (not (featurep! :tools lsp +eglot)))
   :after lsp-mode
   :preface
   (setq lsp-julia-default-environment "~/.julia/environments/v1.0")
-  (when (featurep! +lsp)
+  (when (and (featurep! +lsp) (not (featurep! :tools lsp +eglot)))
     (add-hook 'julia-mode-local-vars-hook #'lsp!)))
+
+
+(use-package! eglot-jl
+  :when (and (featurep! :lang julia +lsp) (featurep! :tools lsp +eglot))
+  :after eglot
+  :preface
+  (when (and (featurep! +lsp) (featurep! :tools lsp  +eglot))
+    (add-hook 'julia-mode-local-vars-hook #'lsp!))
+  :config
+  (after! eglot
+    (eglot-jl-init)))

--- a/modules/lang/julia/packages.el
+++ b/modules/lang/julia/packages.el
@@ -3,3 +3,8 @@
 
 (package! julia-mode :pin "8ea90c7927f6d87a291cfb0216f34dacf43c722e")
 (package! julia-repl :pin "d073acb6339e99edf77833f82277afd9a076f16a")
+
+(when (featurep! +lsp)
+  (if (featurep! :tools lsp +eglot)
+      (package! eglot-jl)
+    (package! lsp-julia)))


### PR DESCRIPTION
Update the README and config to consider the lsp +eglot option.
Additionally now the packages eglot-jl or lsp-julia are packaged
depending on the featurerep of lsp.
They are not pinned as they can be seen as more of a extended
configuration of the julia and emacs site 
(if you think even for these packages pinning would be preferred let me know).

Finally as the LanguageServer.jl needs comparably long to start even after the first run it might be nice to add a note to this in the README as well, where would you put this or do you think it would be worth it to change the defaults in julia buffers directly from the module config.el?