### PR TITLE
Add emacs bindings and documentation in fold module 

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -568,3 +568,13 @@
       (:when (featurep! :ui treemacs)
         "<f9>"   #'+treemacs/toggle
         "<C-f9>" #'treemacs-find-file))
+
+(map! :leader
+      (:when (featurep! :editor fold)
+       (:prefix ("C-f" . "fold")
+        "C-d"     #'vimish-fold-delete
+        "C-a C-d" #'vimish-fold-delete-all
+        "C-f"     #'+fold/toggle
+        "C-a C-f" #'+fold/close-all
+        "C-u"     #'+fold/open
+        "C-a C-u" #'+fold/open-all)))

--- a/modules/editor/fold/README.org
+++ b/modules/editor/fold/README.org
@@ -29,16 +29,16 @@ This module has no prerequisites.
 * Features
 
 Emacs keybinds when evil +everywhere is disabled.
-| Keybind            | Description               |
-|--------------------+---------------------------|
-| =C-c f v=          | Fold region               |
-| =C-c f a v=        | Refold all regions        |
-| =C-c u v= or =C `= | Unfold region             |
-| =C-c u a v=        | Unfold all regions        |
-| =C-c d v=          | Delete folded region      |
-| =C-c d a v=        | Delete all folded regions |
+| Keybind                | Description               |
+|------------------------+---------------------------|
+| =C-c C-f C-f=          | Fold region               |
+| =C-c C-f C-u= or =C `= | Unfold region             |
+| =C-c C-f C-d=          | Delete folded region      |
+| =C-c C-a C-f=          | Refold all regions        |
+| =C-c C-a C-u=          | Unfold all regions        |
+| =C-c C-a C-d=          | Delete all folded regions |
 
 * TODO Configuration
 
 * Troubleshooting
-Sometimes an unfolded region does not fold back with =C-c f v=. To bypass this bug you must delete the folded region (=C-c d v=) and then fold it(=C-c f v=) again.
+Sometimes an unfolded region does not fold back with =C-c C-f C-f=. To bypass this bug you must delete the folded region (=C-c C-f C-d=) and then fold it(=C-c C-f C-f=) again.

--- a/modules/editor/fold/README.org
+++ b/modules/editor/fold/README.org
@@ -4,13 +4,13 @@
 #+STARTUP: inlineimages
 
 * Table of Contents :TOC_3:noexport:
-- [[Description][Description]]
-  - [[Module Flags][Module Flags]]
-  - [[Plugins][Plugins]]
-- [[Prerequisites][Prerequisites]]
-- [[Features][Features]]
-- [[Configuration][Configuration]]
-- [[Troubleshooting][Troubleshooting]]
+- [[#description][Description]]
+  - [[#module-flags][Module Flags]]
+  - [[#plugins][Plugins]]
+- [[#prerequisites][Prerequisites]]
+- [[#features][Features]]
+- [[#configuration][Configuration]]
+- [[#troubleshooting][Troubleshooting]]
 
 * Description
 This module marries hideshow, vimish-fold and outline-minor-mode to bring you
@@ -20,13 +20,25 @@ marker, indent and syntax-based code folding for as many languages as possible.
 This module provides no flags.
 
 ** Plugins
-+ evil-vimish-fold*
++[[https://github.com/alexmurray/evil-vimish-fold][evil-vimish-fold]]
++[[https://github.com/matsievskiysv/vimish-fold][vimish-fold]]
 
 * Prerequisites
 This module has no prerequisites.
 
-* TODO Features
+* Features
+
+Emacs keybinds when evil +everywhere is disabled.
+| Keybind            | Description               |
+|--------------------+---------------------------|
+| =C-c f v=          | Fold region               |
+| =C-c f a v=        | Refold all regions        |
+| =C-c u v= or =C `= | Unfold region             |
+| =C-c u a v=        | Unfold all regions        |
+| =C-c d v=          | Delete folded region      |
+| =C-c d a v=        | Delete all folded regions |
 
 * TODO Configuration
 
-* TODO Troubleshooting
+* Troubleshooting
+Sometimes an unfolded region does not fold back with =C-c f v=. To bypass this bug you must delete the folded region (=C-c d v=) and then fold it(=C-c f v=) again.

--- a/modules/editor/fold/config.el
+++ b/modules/editor/fold/config.el
@@ -85,7 +85,3 @@
     "zE" #'vimish-fold-delete-all)
   :config
   (vimish-fold-global-mode +1))
-
-(use-package! vimish-fold
-  :unless (featurep! :editor evil)
-  :defer t)

--- a/modules/editor/fold/config.el
+++ b/modules/editor/fold/config.el
@@ -85,3 +85,14 @@
     "zE" #'vimish-fold-delete-all)
   :config
   (vimish-fold-global-mode +1))
+
+(when (not (featurep! :editor evil))
+  (use-package! vimish-fold
+    :init
+    (define-key! 'global
+      "C-c f v"   #'vimish-fold
+      "C-c f a v" #'vimish-fold-refold-all
+      "C-c u v"   #'vimish-fold-unfold
+      "C-c u a v" #'vimish-fold-unfold-all
+      "C-c d v"   #'vimish-fold-delete
+      "C-c d a v" #'vimish-fold-delete-all)))

--- a/modules/editor/fold/config.el
+++ b/modules/editor/fold/config.el
@@ -86,13 +86,6 @@
   :config
   (vimish-fold-global-mode +1))
 
-(when (not (featurep! :editor evil))
-  (use-package! vimish-fold
-    :init
-    (define-key! 'global
-      "C-c f v"   #'vimish-fold
-      "C-c f a v" #'vimish-fold-refold-all
-      "C-c u v"   #'vimish-fold-unfold
-      "C-c u a v" #'vimish-fold-unfold-all
-      "C-c d v"   #'vimish-fold-delete
-      "C-c d a v" #'vimish-fold-delete-all)))
+(use-package! vimish-fold
+  :unless (featurep! :editor evil)
+  :defer t)


### PR DESCRIPTION
This PR adds emacs bindings for vimish-fold when evil is disabled. It also adds documentation for the bindings. Finally, it reports a weird bug and explains a way to bypass it.