### PR TITLE
Add keybinding for testing all project functions with pytest

### DIFF
--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -189,6 +189,7 @@ called.")
         :localleader
         :map python-mode-map
         :prefix ("t" . "test")
+        "a" #'python-pytest
         "f" #'python-pytest-file-dwim
         "F" #'python-pytest-file
         "t" #'python-pytest-function-dwim


### PR DESCRIPTION
Added a keybinding for a "test all functions" for pytest analogue to "a" #'nosetests-all.
