### PR TITLE
Enable poetry-tracking-mode

### DIFF
--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -289,7 +289,7 @@
   :when (featurep! +poetry)
   :after python
   :init
-  (add-hook! 'python-mode-hook (poetry-tracking-mode +1)))
+  (add-hook 'python-mode-hook #'poetry-tracking-mode))
 
 
 (use-package! cython-mode

--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -287,7 +287,9 @@
 
 (use-package! poetry
   :when (featurep! +poetry)
-  :after python)
+  :after python
+  :init
+  (add-hook! 'python-mode-hook (poetry-tracking-mode +1)))
 
 
 (use-package! cython-mode


### PR DESCRIPTION
# Description

Implements #3826.

Enable `poetry-tracking-mode` in the first `python-mode` buffer (if `python +poetry` enabled).