### PR TITLE
Disable lsp indentation in scala mode

### DIFF
--- a/modules/lang/scala/config.el
+++ b/modules/lang/scala/config.el
@@ -16,6 +16,7 @@
     comment-line-break-function #'+scala-comment-indent-new-line-fn)
 
   (when (featurep! +lsp)
+    (setq-hook! 'scala-mode-hook lsp-enable-indentation nil)
     (add-hook 'scala-mode-local-vars-hook #'lsp!))
 
   (set-ligatures! 'scala-mode


### PR DESCRIPTION
Metals (the scala LSP server) does not support formatting blocks of code and does appear to be interested in adding it in the future. This pull requests disables lsp indentation when using `+lsp` in `scala-mode` so that emacs will fall back to using indentation provided by `scala-mode` versus providing no indentation at all.

Relevant issue on formatting within Metals: https://github.com/scalameta/metals/issues/1649