### PR TITLE
Add single quotes to ‘any quote’ text objects

### DIFF
--- a/modules/editor/evil/autoload/textobjects.el
+++ b/modules/editor/evil/autoload/textobjects.el
@@ -50,6 +50,7 @@ This excludes the protocol and querystring."
          '(("'" . "'")
            ("\"" . "\"")
            ("`" . "`")
+           ("‘" . "’")
            ("“" . "”"))))
     (evil-textobj-anyblock-inner-block count beg end type)))
 
@@ -60,5 +61,6 @@ This excludes the protocol and querystring."
          '(("'" . "'")
            ("\"" . "\"")
            ("`" . "`")
+           ("‘" . "’")
            ("“" . "”"))))
     (evil-textobj-anyblock-a-block count beg end type)))


### PR DESCRIPTION
Add typographic single quotation marks to ‘any quote’ text objects.

(It could be argued that «guillemets» should be added too, but what is considered the left and right varies between languages, so I decided against adding them.)