### PR TITLE
Fix syntax error

### DIFF
--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -98,7 +98,7 @@ If no viewers are found, `latex-preview-pane' is used.")
                #'lsp!))
   (map! :map LaTeX-mode-map
         :localleader
-        :desc "View" "v" #'TeX-view)))
+        :desc "View" "v" #'TeX-view))
 
 
 (use-package! tex-fold


### PR DESCRIPTION
**What actually happened?**
I got this error at startup
![screencap](https://user-images.githubusercontent.com/4178673/97786063-8d8b4800-1b6e-11eb-953e-a4fa4a8d21d2.png)

**Additional details:**
Vanilla config.

<details><pre>
Backtrace:
Debugger entered--Lisp error: (invalid-read-syntax ")")
  read(#<buffer  *load*-69153>)
  eval-buffer(#<buffer  *load*-69153> nil "/home/koba/.emacs.d/modules/lang/latex/config.el" nil t)  ; Reading at buffer position 3688
  load-with-code-conversion("/home/koba/.emacs.d/modules/lang/latex/config.el" "/home/koba/.emacs.d/modules/lang/latex/config.el" t t)
  load("/home/koba/.emacs.d/modules/lang/latex/config" t nomessage)
</pre></details>


**Steps to reproduce:**
Enable latex in init.el


**System information:**
<details><pre>
```
SYSTEM  type       gnu/linux
        config     x86_64-unknown-linux-gnu
        shell      /usr/bin/fish
        uname      Linux 5.8.17_1 #1 SMP Fri Oct 30 12:13:24 UTC 2020 x86_64
        path       (~/.local/bin ~/.emacs.d/bin ~/.local/bin ~/.emacs.d/bin /usr/local/bin /bin /usr/bin /usr/libexec/emacs/27.1/x86_64-unknown-linux-gnu)
EMACS   dir        ~/.emacs.d/
        version    27.1
        build      ago 12, 2020
        buildopts  --with-x-toolkit=gtk3 --with-xwidgets --prefix=/usr --sysconfdir=/etc --sbindir=/usr/bin --bindir=/usr/bin --mandir=/usr/share/man --infodir=/usr/share/info --localstatedir=/var --with-file-notification=inotify --with-modules --with-jpeg --with-tiff --with-gif --with-png --with-xpm --with-rsvg --without-imagemagick --with-xml2 --with-gnutls --with-sound --with-m17n-flt --with-json --without-harfbuzz --without-cairo --with-libgmp --host=x86_64-unknown-linux-gnu --build=x86_64-unknown-linux-gnu 'CFLAGS=-fno-PIE -mtune=generic -O2 -pipe   -g' 'CPPFLAGS=   ' 'LDFLAGS=-no-pie -Wl,--as-needed    '
        features   XPM JPEG TIFF GIF PNG RSVG SOUND DBUS GSETTINGS GLIB NOTIFY INOTIFY ACL GNUTLS LIBXML2 FREETYPE M17N_FLT LIBOTF XFT ZLIB TOOLKIT_SCROLL_BARS GTK3 X11 XDBE XIM MODULES THREADS XWIDGETS JSON PDUMPER LCMS2 GMP
        traits     (batch envvar-file)
DOOM    dir        ~/.doom.d/
        version    2.0.9
        build      HEAD -> develop c96e901b6 2020-10-31 03:43:55 -0400
        elc-files  0
        modules    (:completion company ivy :ui doom doom-dashboard doom-quit (emoji +unicode) hl-todo (ligatures +extra +iosevka) modeline ophints (popup +defaults) treemacs unicode vc-gutter vi-tilde-fringe window-select workspaces zen :editor (evil +everywhere) file-templates fold (format +onsave) multiple-cursors parinfer rotate-text snippets :emacs dired electric undo vc :checkers syntax :tools direnv (eval +overlay) lookup lsp magit :lang data emacs-lisp latex markdown org (python +lsp) sh :config (default +bindings +smartparens))
        packages   (n/a)
        unpin      (n/a)
        elpa       (n/a)
```
</pre></details>