### PR TITLE
insert-heading-respect-content for C-RET in org

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -648,14 +648,14 @@ between the two."
         "C-c C-i"    #'org-toggle-inline-images
         ;; textmate-esque newline insertion
         "S-RET"      #'+org/shift-return
-        "C-RET"      #'+org/insert-item-below
+        "C-RET"      #'org-insert-heading-respect-content
         "C-S-RET"    #'+org/insert-item-above
         "C-M-RET"    #'org-insert-subheading
-        [C-return]   #'+org/insert-item-below
+        [C-return]   #'org-insert-heading-respect-content
         [C-S-return] #'+org/insert-item-above
         [C-M-return] #'org-insert-subheading
         (:when IS-MAC
-         [s-return]   #'+org/insert-item-below
+         [s-return]   #'org-insert-heading-respect-content
          [s-S-return] #'+org/insert-item-above
          [s-M-return] #'org-insert-subheading)
         ;; Org-aware C-a/C-e


### PR DESCRIPTION
> Close #3306

According to https://orgmode.org/manual/Structure-Editing.html
C-RET should call `insert-heading-respect-content`.

I think this should work, but as this is my first PR for doom-emacs it might be completely wrong.
In particular I considered that I shouldn't use/create a function with the `+org` namespace.

Note I tried to add:

```
(map! :map org-mode-map
        "C-RET" #'org-insert-heading-respect-content
        [C-return]   #'org-insert-heading-respect-content
        (:when IS-MAC
         [s-return]   #'org-insert-heading-respect-content))
```

To my `config.el` and but this still does not work as I expected.
So I might have done something wrong here.
Mainly if I call `insert-heading-respect-content` it works as expected.
But when I type `control-return` it still add an item and not a new heading.