### PR TITLE
Demote overly aggressive completion styles

### DIFF
--- a/modules/completion/helm/config.el
+++ b/modules/completion/helm/config.el
@@ -89,13 +89,18 @@ be negative.")
           helm-semantic-fuzzy-match fuzzy)
     ;; Make sure that we have helm-multi-matching or fuzzy matching,
     ;; (as prescribed by the fuzzy flag) also in the following cases:
+    ;;
     ;; - helmized commands that use `completion-at-point' and similar functions
     ;; - native commands that fall back to `completion-styles' like `helm-M-x'
-    (push (if EMACS27+
-              (if fuzzy 'flex 'helm)
-            (if fuzzy 'helm-flex 'helm))
-          completion-styles))
-
+    ;;
+    ;; However, do not add helm completion styles to the front of
+    ;; `completion-styles', since that would be overly intrusive. E.g., it
+    ;; results in `company-capf' returning far to many completion candidates.
+    ;; Instead, append those styles so that they act as a fallback.
+    (add-to-list 'completion-styles
+                 (if EMACS27+
+                     (if fuzzy 'flex 'helm)
+                   (if fuzzy 'helm-flex 'helm)) t))
   :config
   (set-popup-rule! "^\\*helm" :vslot -100 :size 0.22 :ttl nil)
 


### PR DESCRIPTION
This PR addresses the issue discussed [here](https://discord.com/channels/406534637242810369/406554085794381833/773488497515429889).

The suggested solution of changing `helm-completion-style` did not work for all cases, since some helm commands (e.g. `helm-M-x`) use `completion-styles` nonetheless. I opted for moving the helm styles to the back of `completion-styles` to have them act as a fallback.