### PR TITLE
Add detection for projects that are ansible roles

### DIFF
--- a/modules/tools/ansible/config.el
+++ b/modules/tools/ansible/config.el
@@ -30,4 +30,4 @@
 (def-project-mode! +ansible-yaml-mode
   :modes '(yaml-mode)
   :add-hooks '(ansible ansible-auto-decrypt-encrypt ansible-doc-mode)
-  :files ("roles/"))
+  :files (or "roles/" "tasks/main.yml"))


### PR DESCRIPTION
Ansible roles _often_ have a `tasks/main.yml` file in them, and benefit
from some of the nice ansible syntax highlighting.