### PR TITLE
Fix Issue #4212; Use Back-Slash for Win FileShares

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -412,7 +412,7 @@ relative to `org-directory', unless it is an absolute path."
    :face (lambda (path)
            (if (or (file-remote-p path)
                    ;; filter out network shares on windows (slow)
-                   (and IS-WINDOWS (string-prefix-p "\\" path))
+                   (and IS-WINDOWS (string-prefix-p "\\\\" path))
                    (file-exists-p path))
                'org-link
              'error)))

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -412,7 +412,7 @@ relative to `org-directory', unless it is an absolute path."
    :face (lambda (path)
            (if (or (file-remote-p path)
                    ;; filter out network shares on windows (slow)
-                   (and IS-WINDOWS (string-prefix-p "//" path))
+                   (and IS-WINDOWS (string-prefix-p "\\" path))
                    (file-exists-p path))
                'org-link
              'error)))


### PR DESCRIPTION
Fixes Windows file share paths from a forward slash to a back slash.
Has been tested and resolves #4212