### PR TITLE
Remove eshell obsolete variable

### DIFF
--- a/modules/term/eshell/config.el
+++ b/modules/term/eshell/config.el
@@ -61,7 +61,6 @@ You should use `set-eshell-alias!' to change this.")
                              'face 'font-lock-keyword-face))
         eshell-scroll-to-bottom-on-input 'all
         eshell-scroll-to-bottom-on-output 'all
-        eshell-buffer-shorthand t
         eshell-kill-processes-on-exit t
         eshell-hist-ignoredups t
         ;; don't record command in history if prefixed with whitespace


### PR DESCRIPTION
`eshell-buffer-shorthand` was removed in Emacs 25, see https://github.com/emacs-mirror/emacs/blob/master/etc/NEWS.25#L1078-L1082