### PR TITLE
:lang cc: fix code-lenses

### DIFF
--- a/modules/lang/cc/config.el
+++ b/modules/lang/cc/config.el
@@ -271,7 +271,6 @@ If rtags or rdm aren't available, fail silently instead of throwing a breaking e
 (use-package! ccls
   :when (featurep! +lsp)
   :unless (featurep! :tools lsp +eglot)
-  :hook (lsp-lens-mode . ccls-code-lens-mode)
   :init
   (defvar ccls-sem-highlight-method 'font-lock)
   (after! projectile


### PR DESCRIPTION
Remove `ccls-code-lens-mode` from `lsp-lens-mode-hook`, as the former isn't
applicable for other language servers that also provide lenses.