### PR TITLE
Created PR to backport emacs-lisp org-babel evaluation to manage the UI

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -231,7 +231,16 @@ Is relative to `org-directory', unless it is absolute. Is used in Doom's default
   (add-hook 'org-babel-after-execute-hook #'org-redisplay-inline-images)
 
   (after! python
-    (setq org-babel-python-command python-shell-interpreter)))
+    (setq org-babel-python-command python-shell-interpreter))
+
+  ;; NOTE Backported from Emacs 27.1
+  ;; DEPRECATED Remove when 26.x support is dropped
+  (unless EMACS27+
+    (defadvice! +org--dont-suppress-window-changes-a (orig-fn &rest args)
+      :around #'org-babel-execute:emacs-lisp
+      (letf! ((#'current-window-configuration #'ignore)
+              (#'set-window-configuration #'ignore))
+        (apply orig-fn args)))))
 
 
 (defun +org-init-babel-lazy-loader-h ()


### PR DESCRIPTION
As of emacs 27.1 we can evaluate org-babel emacs-lisp src blocks that manage the UI. This PR comes from a discussion in the upcoming discourse to backport that functionality. 

This also preludes an experimental project to provide an interactive guide for doom-emacs to better introduce users to customizing their emacs experience with emacs-lisp in Doom.