### PR TITLE
Revert Rails command change

### DIFF
--- a/modules/lang/ruby/README.org
+++ b/modules/lang/ruby/README.org
@@ -7,7 +7,6 @@
 - [[#description][Description]]
   - [[#module-flags][Module Flags]]
   - [[#packages][Packages]]
-  - [[#hacks][Hacks]]
 - [[#prerequisites][Prerequisites]]
   - [[#ubuntu][Ubuntu]]
   - [[#macos][MacOS]]
@@ -47,12 +46,6 @@ This module add Ruby and optional Ruby on Rails support to Emacs.
 + [[https://github.com/asok/projectile-rails][projectile-rails]] (=+rails=)
 + [[https://github.com/eschulte/jump.el/tree/e4f1372cf22e811faca52fc86bdd5d817498a4d8][inflections]]
 + [[https://github.com/plexus/chruby.el][chruby]] (=+chruby=)
-
-** Hacks
-+ =projectile-rails-custom-server-command= were changed to suppress extraneous output logged
-  to console. This was done to prevent a memory leak where the underlying
-  process would continue logging to an Emacs buffer, which would grow forever.  You can change to default behaviour by
-  setting this variable to =nil=.
 
 * Prerequisites
 Many of this modules plugins require ruby with some version manager (RVM or
@@ -96,4 +89,3 @@ The rspec-mode prefix is =SPC m t=.  Here is some examples:
 |-----------------------+------------------+-----------------------------------|
 | ~rspec-verify~        | =SPC m t v=      | Runs rspec on current file        |
 | ~rspec-verify-method~ | =SPC m t s=      | Runs rspec for the item on cursor |
-

--- a/modules/lang/ruby/config.el
+++ b/modules/lang/ruby/config.el
@@ -97,7 +97,7 @@
   (setq rake-completion-system 'default)
   (map! :after ruby-mode
         :localleader
-        :map ruby-mode-map 
+        :map ruby-mode-map
         :prefix ("k" . "rake")
         "k" #'rake
         "r" #'rake-rerun
@@ -185,7 +185,7 @@
   :hook (projectile-rails-mode . auto-insert-mode)
   :init
   (setq auto-insert-query nil)
-  (setq projectile-rails-custom-server-command "bundle exec spring rails server --no-log-to-stdout")
+  (setq projectile-rails-custom-server-command "bundle exec spring rails server")
   (setq inf-ruby-console-environment "development")
   (when (featurep! :lang web)
     (add-hook 'web-mode-hook #'projectile-rails-mode))

--- a/modules/lang/ruby/config.el
+++ b/modules/lang/ruby/config.el
@@ -185,7 +185,6 @@
   :hook (projectile-rails-mode . auto-insert-mode)
   :init
   (setq auto-insert-query nil)
-  (setq projectile-rails-custom-server-command "bundle exec spring rails server")
   (setq inf-ruby-console-environment "development")
   (when (featurep! :lang web)
     (add-hook 'web-mode-hook #'projectile-rails-mode))


### PR DESCRIPTION
Rails <= 5.2 dont have this options, the users cannot use this feature without searching in the doc.  I think is better to leave enabled. 

If possible, make something to limit the `projectile-rails-server-mode` @hlissner .  Like, if has more then 1.5k lines, when create new logs, erase the old ones.