### PR TITLE
Fix behaviour without aspell

### DIFF
--- a/modules/checkers/spell/autoload/+spell-fu.el
+++ b/modules/checkers/spell/autoload/+spell-fu.el
@@ -50,12 +50,20 @@
 (defun +spell/correct ()
   "Correct spelling of word at point."
   (interactive)
-  ;; HACK Fake awareness for our personal dictionary by stopping short if
-  ;;      spell-fu hasn't highlighted the current word. This is necessary
-  ;;      because ispell/aspell struggles to find our
-  ;;      `ispell-personal-dictionary' if it's not in $HOME.
-  (unless (memq 'spell-fu-incorrect-face (face-at-point nil t))
-    (user-error "%S is correct" (thing-at-point 'word t)))
+  ;; spell-fu fails to initialize correctly if it can't find aspell or a similar
+  ;; program. We want to signal the error, not tell the user that every word is
+  ;; spelled correctly.
+  (unless (;; This is what spell-fu uses to check for the aspell executable
+           or (and ispell-really-aspell ispell-program-name)
+              (executable-find "aspell"))
+    (user-error "Aspell is required for spell checking"))
+  ;; HACK When spell-fu fails to initialize correctly, the init form for the
+  ;;      spell-fu use-package! is not called. This leaves emacs to assume that
+  ;;      certain variables are initialized when they are not. We bind what we
+  ;;      need.
+  (unless (boundp '+spell-correct-interface)
+    (+spell-defun-correct-interface))
+
   (ispell-set-spellchecker-params)
   (save-current-buffer
     (ispell-accept-buffer-local-defs))

--- a/modules/checkers/spell/autoload/+spell-fu.el
+++ b/modules/checkers/spell/autoload/+spell-fu.el
@@ -57,12 +57,6 @@
            or (and ispell-really-aspell ispell-program-name)
               (executable-find "aspell"))
     (user-error "Aspell is required for spell checking"))
-  ;; HACK When spell-fu fails to initialize correctly, the init form for the
-  ;;      spell-fu use-package! is not called. This leaves emacs to assume that
-  ;;      certain variables are initialized when they are not. We bind what we
-  ;;      need.
-  (unless (boundp '+spell-correct-interface)
-    (+spell-defun-correct-interface))
 
   (ispell-set-spellchecker-params)
   (save-current-buffer

--- a/modules/checkers/spell/config.el
+++ b/modules/checkers/spell/config.el
@@ -70,19 +70,21 @@
 
 (eval-if! (not (featurep! +flyspell))
 
-    (use-package! spell-fu
-      :when (executable-find "aspell")
-      :hook (text-mode . spell-fu-mode)
-      :general ([remap ispell-word] #'+spell/correct)
-      :init
+    (defun +spell-defun-correct-interface ()
       (defvar +spell-correct-interface
         (cond ((featurep! :completion ivy)
                #'+spell-correct-ivy-fn)
               ((featurep! :completion helm)
                #'+spell-correct-helm-fn)
               (#'+spell-correct-generic-fn))
-        "Function to use to display corrections.")
+        "Function to use to display corrections."))
 
+    (use-package! spell-fu
+      :when (executable-find "aspell")
+      :hook (text-mode . spell-fu-mode)
+      :general ([remap ispell-word] #'+spell/correct)
+      :init
+      (+spell-defun-correct-interface)
       (defvar +spell-excluded-faces-alist
         '((markdown-mode
            . (markdown-code-face

--- a/modules/checkers/spell/config.el
+++ b/modules/checkers/spell/config.el
@@ -70,21 +70,20 @@
 
 (eval-if! (not (featurep! +flyspell))
 
-    (defun +spell-defun-correct-interface ()
+    (use-package! spell-fu
+      :when (executable-find "aspell")
+      :hook (text-mode . spell-fu-mode)
+      :general ([remap ispell-word] #'+spell/correct)
+      :preface
       (defvar +spell-correct-interface
         (cond ((featurep! :completion ivy)
                #'+spell-correct-ivy-fn)
               ((featurep! :completion helm)
                #'+spell-correct-helm-fn)
               (#'+spell-correct-generic-fn))
-        "Function to use to display corrections."))
+        "Function to use to display corrections.")
 
-    (use-package! spell-fu
-      :when (executable-find "aspell")
-      :hook (text-mode . spell-fu-mode)
-      :general ([remap ispell-word] #'+spell/correct)
       :init
-      (+spell-defun-correct-interface)
       (defvar +spell-excluded-faces-alist
         '((markdown-mode
            . (markdown-code-face


### PR DESCRIPTION
If aspell (or a spell-fu acceptable equivalent) cannot be found, 
warn the user. If +spell-correct-interface is not bound, bind it.

Remove previous hack. It prevents use of +spell/correct if spell-fu does
not try to highlight a word. This is extreamly common is docstrings, for
example. I think having +spell/correct should check any word it is
called upon, even without general text highlighting.