### PR TITLE
fix minor it's -> its grammar typo in docs/faq.org

### DIFF
--- a/docs/faq.org
+++ b/docs/faq.org
@@ -149,7 +149,7 @@ To paraphrase (and expand upon) a [[https://www.reddit.com/r/emacs/comments/6pa0
   improve and produce tutorials/guides for it. Spacemacs is more likely to work
   right out of the box. Doom also holds your hand less. A little elisp, shell
   and git-fu will go a long way to ease you into Doom.
-+ *Doom is managed through it's command line interface.* The ~bin/doom~ script
++ *Doom is managed through its command line interface.* The ~bin/doom~ script
   allows you to script package management, manage your config, or utilize elisp
   functionality externally, like org tangling or batch processing.
 + *Doom's package manager is declarative and rolling release is opt-in.* Doom


### PR DESCRIPTION
Saw a simple `it's` to `its` typo in faq.org that needed fixing. 