### PR TITLE
Remove unicode input mode default from Racket REPL

### DIFF
--- a/modules/lang/racket/README.org
+++ b/modules/lang/racket/README.org
@@ -12,6 +12,7 @@
 - [[#features][Features]]
 - [[#configuration][Configuration]]
   - [[#racket-smart-open-bracket-mode][racket-smart-open-bracket-mode]]
+  - [[#unicode-input][Unicode Input]]
 - [[#troubleshooting][Troubleshooting]]
 
 * Description
@@ -41,5 +42,15 @@ or check your package manger.
   (add-hook! racket-mode
              #'racket-smart-open-bracket-mode))
 #+END_SRC
+** Unicode Input
+The optional ~racket-unicode~ input method lets you type unicode characters such as λ or π.
+To enable unicode input for a single buffer, run ~racket-unicode-input-method-enable~.
+To enable unicode input by default on all racket buffers, add the following hooks
+to your ~config.el~:
+#+BEGIN_SRC elisp
+(add-hook 'racket-mode-hook      #'racket-unicode-input-method-enable)
+(add-hook 'racket-repl-mode-hook #'racket-unicode-input-method-enable)
+#+END_SRC
+Once enabled, unicode input can be toggled by pressing C-\ or running ~toggle-input-method~.
 
 * TODO Troubleshooting

--- a/modules/lang/racket/config.el
+++ b/modules/lang/racket/config.el
@@ -9,7 +9,6 @@
 
 (use-package! racket-mode
   :mode "\\.rkt\\'"  ; give it precedence over :lang scheme
-  :hook (racket-repl-mode . racket-unicode-input-method-enable)
   :config
   (set-repl-handler! 'racket-mode #'+racket/open-repl)
   (set-lookup-handlers! '(racket-mode racket-repl-mode)


### PR DESCRIPTION
`racket-mode` has an optional unicode input mode that replaces Greek letter names with unicode Greek characters (ex: 'pi' -> 'π'). Doom enables this input mode by default for `racket-repl-mode` buffers, but not for `racket-mode` buffers. This PR removes the `racket-repl-mode` hook and adds some documentation about `racket-mode`'s unicode input mode to Doom's Racket plugin readme. An alternative would be to enable unicode input for both modes, but some Racket DSLs don't interpret `λ` as `lambda`.