### PR TITLE
Add with-editor.el to the compilation black-list

### DIFF
--- a/core/core.el
+++ b/core/core.el
@@ -288,6 +288,7 @@ config.el instead."
 (after! comp
   ;; HACK Disable native-compilation for some troublesome packages
   (dolist (entry (list (concat "\\`" (regexp-quote doom-local-dir) ".*/evil-collection-vterm\\.el\\'")
+                       (concat "\\`" (regexp-quote doom-local-dir) ".*/with-editor\\.el\\'")
                        (concat "\\`" (regexp-quote doom-autoloads-file) "'")))
     (add-to-list 'comp-deferred-compilation-black-list entry)))
 


### PR DESCRIPTION
Sometimes compiling this file hangs; adding it to the compilation black-list prevents that.

Re: #3655 