### PR TITLE
Adding a keyboard shortcut for CMake mode help

### DIFF
--- a/modules/lang/cc/config.el
+++ b/modules/lang/cc/config.el
@@ -161,6 +161,10 @@ This is ignored by ccls.")
   :after cmake-mode
   :config (set-company-backend! 'cmake-mode 'company-cmake))
 
+(map! :after cmake-mode
+      :map cmake-mode-map
+      :localleader
+      (:desc "CMake Help" :n "h" #'cmake-help))
 
 (use-package! demangle-mode
   :hook llvm-mode)

--- a/modules/lang/cc/config.el
+++ b/modules/lang/cc/config.el
@@ -154,17 +154,13 @@ This is ignored by ccls.")
 ;; Major modes
 
 (after! cmake-mode
-  (set-docsets! 'cmake-mode "CMake"))
+  (set-docsets! 'cmake-mode "CMake")
+  (set-lookup-handlers! 'cmake-mode :documentation #'cmake-help))
 
 (use-package! company-cmake  ; for `cmake-mode'
   :when (featurep! :completion company)
   :after cmake-mode
   :config (set-company-backend! 'cmake-mode 'company-cmake))
-
-(map! :after cmake-mode
-      :map cmake-mode-map
-      :localleader
-      (:desc "CMake Help" :n "h" #'cmake-help))
 
 (use-package! demangle-mode
   :hook llvm-mode)


### PR DESCRIPTION
Adding a command in normal mode `Spc m h` (via localleader) to access the built-in cmake help.

This is a really good way to access the documentation for CMake commands without leaving to go to the browser.

I just tested this by making sure the command was available in the cmake mode after opening a cmake file, and that it did the correct thing (open the help command).