### PR TITLE
Prevent native compilation for emacs-jupyter

### DIFF
--- a/core/core.el
+++ b/core/core.el
@@ -288,6 +288,8 @@ config.el instead."
 (after! comp
   ;; HACK Disable native-compilation for some troublesome packages
   (dolist (entry (list (concat "\\`" (regexp-quote doom-local-dir) ".*/evil-collection-vterm\\.el\\'")
+                       ;; https://github.com/nnicandro/emacs-jupyter/issues/297
+                       (concat "\\`" (regexp-quote doom-local-dir) ".*/jupyter-channel\\.el\\'")
                        (concat "\\`" (regexp-quote doom-local-dir) ".*/with-editor\\.el\\'")
                        (concat "\\`" (regexp-quote doom-autoloads-file) "'")))
     (add-to-list 'comp-deferred-compilation-black-list entry)))


### PR DESCRIPTION
Something in `jupyter-channel.el` of emacs-jupyter does not get compiled correctly and raises void-variable jupyter-channel errors, see https://github.com/nnicandro/emacs-jupyter/issues/297.

I initially fixed it for myself by putting this in my `packages.el`:
```elisp
(package! jupyter :recipe (:no-native-compile t))
```
But some more testing suggested that preventing native compilation for just `jupyter-channel.el` also works, so I put that in this PR.