### PR TITLE
Enable god-mode support for which-key if required

### DIFF
--- a/modules/editor/god/config.el
+++ b/modules/editor/god/config.el
@@ -4,4 +4,7 @@
   :hook (doom-after-init-modules . god-mode-all)
   :config
   (add-hook 'post-command-hook #'+god--configure-cursor-and-modeline-h)
-  (add-hook 'overwrite-mode-hook #'+god--toggle-on-overwrite-h))
+  (add-hook 'overwrite-mode-hook #'+god--toggle-on-overwrite-h)
+
+  (after! which-key
+    (which-key-enable-god-mode-support)))

--- a/modules/editor/god/packages.el
+++ b/modules/editor/god/packages.el
@@ -1,4 +1,4 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; editor/god/packages.el
 
-(package! god-mode :pin "ad2e6745294843462f78768b5a1cd3b0d3563951")
+(package! god-mode :pin "f51c8f60e55393cced8cb0bd4a5bf0ab1612caa4")


### PR DESCRIPTION
In this change:

* Bump version pin of `god-mode`
* Call [`which-key-enable-god-mode-support`](https://github.com/justbur/emacs-which-key#god-mode) after loading `which-key` to enable support for `god-mode`. Prior to this change, keys entered in `god-local-mode` will not invoke `which-key` :no_entry:

As always, any feedback is more than welcome!