### PR TITLE
input/japanese: Do not eval skk-mode-exit if ddskk not loaded

### DIFF
--- a/modules/input/japanese/config.el
+++ b/modules/input/japanese/config.el
@@ -34,9 +34,9 @@
         pangu-spacing-real-insert-separtor t))
 
 
-(use-package! ddskk
+(use-package! skk
   :general ("C-x j" #'skk-mode)
-  :init
+  :config
   (add-hook 'doom-escape-hook #'skk-mode-exit))
 
 


### PR DESCRIPTION
## Description

If we enable `:input/japanese` and press Esc before autoloading `skk`, an error occurs: 

```
Symbol's function definition is void: skk-mode-exit
```

This PR forces to load `skk` when calling `skk-mode-exit`.
