### PR TITLE
ui/doom-dashboard: recenter bottom line of banner

### DIFF
--- a/modules/ui/doom-dashboard/config.el
+++ b/modules/ui/doom-dashboard/config.el
@@ -404,7 +404,7 @@ controlled by `+doom-dashboard-pwd-policy'."
             "||.=='    _-'                                                     `' |  /==.||"
             "=='    _-'                         E M A C S                          \\/   `=="
             "\\   _-'                                                                `-_   /"
-            "`''                                                                      ``'"))
+            " `''                                                                      ``' "))
          (longest-line (apply #'max (mapcar #'length banner))))
     (put-text-property
      (point)


### PR DESCRIPTION
The sequel to #4246. Then every line was centered individually, so the bottom line was centered correctly as it was two characters shorter than the other ones. However, the banner is centered as a block as of 86c2f05252a8f36b2e34948eb5a6a942bcebd4e6, making the banner look like this:
```
=================     ===============     ===============   ========  ======== 
\\ . . . . . . .\\   //. . . . . . .\\   //. . . . . . .\\  \\. . .\\// . . // 
||. . ._____. . .|| ||. . ._____. . .|| ||. . ._____. . .|| || . . .\/ . . .|| 
|| . .||   ||. . || || . .||   ||. . || || . .||   ||. . || ||. . . . . . . || 
||. . ||   || . .|| ||. . ||   || . .|| ||. . ||   || . .|| || . | . . . . .|| 
|| . .||   ||. _-|| ||-_ .||   ||. . || || . .||   ||. _-|| ||-_.|\ . . . . || 
||. . ||   ||-'  || ||  `-||   || . .|| ||. . ||   ||-'  || ||  `|\_ . .|. .|| 
|| . _||   ||    || ||    ||   ||_ . || || . _||   ||    || ||   |\ `-_/| . || 
||_-' ||  .|/    || ||    \|.  || `-_|| ||_-' ||  .|/    || ||   | \  / |-_.|| 
||    ||_-'      || ||      `-_||    || ||    ||_-'      || ||   | \  / |  `|| 
||    `'         || ||         `'    || ||    `'         || ||   | \  / |   || 
||            .===' `===.         .==='.`===.         .===' /==. |  \/  |   || 
||         .=='   \_|-_ `===. .==='   _|_   `===. .===' _-|/   `==  \/  |   || 
||      .=='    _-'    `-_  `='    _-'   `-_    `='  _-'   `-_  /|  \/  |   || 
||   .=='    _-'          '-__\._-'         '-_./__-'         `' |. /|  |   || 
||.=='    _-'                                                     `' |  /==.|| 
=='    _-'                         E M A C S                          \/   `== 
\   _-'                                                                `-_   / 
`''                                                                      ``'
```
I've now added an extra space on both sides so that it is centered correctly now, and also if the lines are centered individually again at some point in the future.