### PR TITLE
[WIP] config/default: Replace magit-clone with +magit/clone

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -310,7 +310,7 @@
         :desc "Magit status here"          "G"   #'magit-status-here
         :desc "Magit file delete"          "x"   #'magit-file-delete
         :desc "Magit blame"                "B"   #'magit-blame-addition
-        :desc "Magit clone"                "C"   #'magit-clone
+        :desc "Magit clone"                "C"   #'+magit/clone
         :desc "Magit fetch"                "F"   #'magit-fetch
         :desc "Magit buffer log"           "L"   #'magit-log
         :desc "Git stage file"             "S"   #'magit-stage-file
@@ -340,7 +340,7 @@
          :desc "List notifications"        "n"   #'forge-list-notifications)
         (:prefix ("c" . "create")
          :desc "Initialize repo"           "r"   #'magit-init
-         :desc "Clone repo"                "R"   #'magit-clone
+         :desc "Clone repo"                "R"   #'+magit/clone
          :desc "Commit"                    "c"   #'magit-commit-create
          :desc "Fixup"                     "f"   #'magit-commit-fixup
          :desc "Issue"                     "i"   #'forge-create-issue

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -417,7 +417,7 @@
         :desc "Magit status here"         "G"   #'magit-status-here
         :desc "Magit file delete"         "D"   #'magit-file-delete
         :desc "Magit blame"               "B"   #'magit-blame-addition
-        :desc "Magit clone"               "C"   #'magit-clone
+        :desc "Magit clone"               "C"   #'+magit/clone
         :desc "Magit fetch"               "F"   #'magit-fetch
         :desc "Magit buffer log"          "L"   #'magit-log
         :desc "Git stage file"            "S"   #'magit-stage-file
@@ -447,7 +447,7 @@
          :desc "List notifications"        "n"   #'forge-list-notifications)
         (:prefix ("c" . "create")
          :desc "Initialize repo"           "r"   #'magit-init
-         :desc "Clone repo"                "R"   #'magit-clone
+         :desc "Clone repo"                "R"   #'+magit/clone
          :desc "Commit"                    "c"   #'magit-commit-create
          :desc "Fixup"                     "f"   #'magit-commit-fixup
          :desc "Branch"                    "b"   #'magit-branch-and-checkout


### PR DESCRIPTION
# Description

Replace `magit-clone` with `+magit/clone`.

# TODOs

- [ ] Handle the case `magit-clone-default-directory` is a function
  ```emacs-lisp
  (if (functionp magit-clone-default-directory)
      (funcall magit-clone-default-directory url-or-repo)
    magit-clone-default-directory)
  ```
- [ ] Declare `+magit-default-clone-url`