### PR TITLE
Add keybindings for roam tagging

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -173,6 +173,8 @@
          :desc "Insert"                        "i" #'org-roam-insert
          :desc "Insert (skipping org-capture)" "I" #'org-roam-insert-immediate
          :desc "Org Roam"                      "r" #'org-roam
+         :desc "Tag"                           "t" #'org-roam-tag-add
+         :desc "Un-tag"                        "T" #'org-roam-tag-delete
          (:prefix ("d" . "by date")
           :desc "Arbitrary date" "d" #'org-roam-dailies-date
           :desc "Today"          "t" #'org-roam-dailies-today

--- a/modules/lang/org/contrib/roam.el
+++ b/modules/lang/org/contrib/roam.el
@@ -33,6 +33,8 @@
         "i" #'org-roam-insert
         "I" #'org-roam-insert-immediate
         "m" #'org-roam
+        "t" #'org-roam-tag-add
+        "T" #'org-roam-tag-delete
         (:prefix ("d" . "by date")
          :desc "Find previous note" "b" #'org-roam-dailies-find-previous-note
          :desc "Find date"          "d" #'org-roam-dailies-find-date


### PR DESCRIPTION
"t" to tag a roam file with the `#+roam_tags` property.
"T" to untag the file