### PR TITLE
disable native compilation for rustic-flycheck.el

### DIFF
--- a/core/core.el
+++ b/core/core.el
@@ -291,6 +291,7 @@ config.el instead."
                        ;; https://github.com/nnicandro/emacs-jupyter/issues/297
                        (concat "\\`" (regexp-quote doom-local-dir) ".*/jupyter-channel\\.el\\'")
                        (concat "\\`" (regexp-quote doom-local-dir) ".*/with-editor\\.el\\'")
+                       (concat "\\`" (regexp-quote doom-local-dir) ".*/rustic-flycheck\\.el\\'")
                        (concat "\\`" (regexp-quote doom-autoloads-file) "'")))
     (add-to-list 'comp-deferred-compilation-black-list entry)))
 


### PR DESCRIPTION
```
Fatal error 11: Segmentation fault
Backtrace:
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x52749e]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x422df9]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x423316]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x5258cd]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x52594c]
/nix/store/5didcr1sjp2rlx8abbzv92rgahsarqd9-glibc-2.32/lib/libpthread.so.0(+0x12700)[0x7f535a171700]
/home/andre/.emacs.d/.local/cache/eln/28.0.50-x86_64-pc-linux-gnu-1c65607c170d4b71b2aeeadab8887a82/rustic-flycheck-d50e4ffb569c20d5f0bf861ce60b9a11-2b3ee739a537263e2a1578c2f75ed4d2.eln(F7275737469632d666c79636865636b2d646972732d6c697374_rustic_flycheck_dirs_list_0+0x4b)[0x7f53445c1fcb]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x589e1b]
/home/andre/.emacs.d/.local/cache/eln/28.0.50-x86_64-pc-linux-gnu-1c65607c170d4b71b2aeeadab8887a82/rustic-flycheck-d50e4ffb569c20d5f0bf861ce60b9a11-2b3ee739a537263e2a1578c2f75ed4d2.eln(F7275737469632d666c79636865636b2d66696e642d636172676f2d746172676574_rustic_flycheck_find_cargo_target_0+0x37e)[0x7f53445c297e]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x589e1b]
/home/andre/.emacs.d/.local/cache/eln/28.0.50-x86_64-pc-linux-gnu-1c65607c170d4b71b2aeeadab8887a82/rustic-flycheck-d50e4ffb569c20d5f0bf861ce60b9a11-2b3ee739a537263e2a1578c2f75ed4d2.eln(F7275737469632d666c79636865636b2d7365747570_rustic_flycheck_setup_0+0xef)[0x7f53445c2eef]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x589e1b]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x589e39]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x58951d]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x589628]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x589654]
/home/andre/.emacs.d/.local/cache/eln/28.0.50-x86_64-pc-linux-gnu-1c65607c170d4b71b2aeeadab8887a82/flycheck-d9e8c1d255a814e6f9e0721602e0958e-51a85af89879557367869f0b3840276d.eln(F666c79636865636b2d6d6f6465_flycheck_mode_0+0x27d)[0x7f5345ab797d]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x589e1b]
/home/andre/.emacs.d/.local/cache/eln/28.0.50-x86_64-pc-linux-gnu-1c65607c170d4b71b2aeeadab8887a82/flycheck-d9e8c1d255a814e6f9e0721602e0958e-51a85af89879557367869f0b3840276d.eln(F666c79636865636b2d6d6f64652d6f6e2d73616665_flycheck_mode_on_safe_0+0x54)[0x7f5345aba2d4]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x589e1b]
/home/andre/.emacs.d/.local/cache/eln/28.0.50-x86_64-pc-linux-gnu-1c65607c170d4b71b2aeeadab8887a82/flycheck-d9e8c1d255a814e6f9e0721602e0958e-51a85af89879557367869f0b3840276d.eln(F676c6f62616c2d666c79636865636b2d6d6f64652d656e61626c652d696e2d62756666657273_global_flycheck_mode_enable_in_buffers_0+0x1bc)[0x7f5345abaa1c]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x589e1b]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x589e39]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x58951d]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x589628]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x589654]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x589e1b]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/../lib/emacs/28.0.50/native-lisp/28.0.50-x86_64-pc-linux-gnu-1c65607c170d4b71b2aeeadab8887a82/subr-13adf6a6032ab09af5683e709aba3706-a9e966da869e434eb7d3dd4c793c8069.eln(F72756e2d6d6f64652d686f6f6b73_run_mode_hooks_0+0x2e7)[0x7f5356593587]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x589e1b]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/../lib/emacs/28.0.50/native-lisp/28.0.50-x86_64-pc-linux-gnu-1c65607c170d4b71b2aeeadab8887a82/elisp-mode-90dbfe4058cdba6c1160139b19921553-0d77416e21330603c60133986fe5ac4f.eln(F656d6163732d6c6973702d6d6f6465_emacs_lisp_mode_0+0x6ca)[0x7f5355fc3e7a]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x589e1b]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x58a1e8]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x589e1b]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x5c6c30]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x589ce0]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x58a1e8]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x589e1b]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x5c6c30]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x589ce0]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x5c6c30]
/nix/store/nxbfwdhfr2y29xl5dchnsp1b881ccf7h-emacs-gcc-20201116.0/bin/emacs[0x58c048]
...
[1]    30479 segmentation fault (core dumped)  emacs -nw
```

Got the following crash when opening a certain file. It doesn't happen with all files and I wasn't able to figure out what the issue is.