### PR TITLE
remove company-org-roam from lang/org/README.org

### DIFF
--- a/modules/lang/org/README.org
+++ b/modules/lang/org/README.org
@@ -129,7 +129,6 @@ https://www.mfoot.com/blog/2015/11/22/literate-emacs-configuration-with-org-mode
   + [[https://github.com/harrybournis/org-fancy-priorities][org-fancy-priorities]]
 + =+roam=
   + [[https://github.com/org-roam/org-roam][org-roam]]
-  + [[https://github.com/org-roam/company-org-roam][company-org-roam]]
 + =+noter=
   + [[https://github.com/weirdNox/org-noter][org-noter]]
 


### PR DESCRIPTION
This was removed in https://github.com/hlissner/doom-emacs/pull/4081.