### PR TITLE
Update for the latest native-compile-async API

### DIFF
--- a/core/cli/packages.el
+++ b/core/cli/packages.el
@@ -225,9 +225,12 @@ list remains lean."
                                    collect path)
              for file in (doom-files-in paths :match "\\.el\\(?:\\.gz\\)?$")
              if (and (file-exists-p (byte-compile-dest-file file))
-                     (not (doom--find-eln-file (doom--eln-file-name file)))) do
+                     (not (doom--find-eln-file (doom--eln-file-name file)))
+                     (not (cl-some (lambda (re)
+                                     (string-match-p re file))
+                                   comp-deferred-compilation-deny-list))) do
              (doom-log "Compiling %s" file)
-             (native-compile-async file nil 'late))))
+             (native-compile-async file))))
 
 (defun doom--bootstrap-trampolines ()
   "Build the trampolines we need to prevent hanging."

--- a/core/packages.el
+++ b/core/packages.el
@@ -17,7 +17,7 @@
             :branch ,straight-repository-branch
             :local-repo "straight.el"
             :files ("straight*.el"))
-  :pin "0f283e2f92c106d5bbb558862d433954fc8db179")
+  :pin "3277e1c9648b41dd5bfb239c067b8374ed2ec2bb")
 
 ;; core-modules.el
 (package! use-package


### PR DESCRIPTION
Renamed `comp-deferred-compilation-black-list` to `comp-deferred-compilation-deny-list`.

Removed the `late` load flag which is no longer required.

Added a check against the deny list when compiling all Elisp on the load-path, so we don't inadvertently compile something we shouldn't.

This change depends on https://github.com/raxod502/straight.el/pull/637.  I've added a hacky commit here to depend on the patched version of straight; that needs to become a proper bump commit once it's merged upstream.