### PR TITLE
Prevent formatting error message (org-mode) #4129

### DIFF
--- a/modules/editor/format/config.el
+++ b/modules/editor/format/config.el
@@ -4,6 +4,7 @@
   '(not emacs-lisp-mode  ; elisp's mechanisms are good enough
         sql-mode         ; sqlformat is currently broken
         tex-mode         ; latexindent is broken
+        org-mode         ; prevents error messages when saving org-mode
         latex-mode)
   "A list of major modes in which to reformat the buffer upon saving.
 


### PR DESCRIPTION
Prevent formatting error message (unsupported) when formatting org-mode #4129 . 

Running `format-all-buffer` yields the error message `format-all-buffer: Don’t know how to format org-mode code`. This same functionality is called when running the `before-save-hook` that comes from `(format +onsave)`. Although the document saves, the error message is unnecessary. Added `org-mode` to the exclusion list.