### PR TITLE
Elisp `eldoc': fix "Invalid format operation %-"

### DIFF
--- a/modules/lang/emacs-lisp/config.el
+++ b/modules/lang/emacs-lisp/config.el
@@ -105,7 +105,7 @@ employed so that flycheck still does *some* helpful linting.")
                      (str (symbol-value sym))
                      (str (prin1-to-string str))
                      (limit (- (frame-width) (length ret) (length truncated) 1)))
-                (format (format "%%0.%ds%%s" limit)
+                (format (format "%%0.%ds%%s" (min limit 0))
                         (propertize str 'face 'warning)
                         (if (< (length str) limit) "" truncated))))))
 

--- a/modules/lang/emacs-lisp/config.el
+++ b/modules/lang/emacs-lisp/config.el
@@ -105,7 +105,7 @@ employed so that flycheck still does *some* helpful linting.")
                      (str (symbol-value sym))
                      (str (prin1-to-string str))
                      (limit (- (frame-width) (length ret) (length truncated) 1)))
-                (format (format "%%0.%ds%%s" (min limit 0))
+                (format (format "%%0.%ds%%s" (max limit 0))
                         (propertize str 'face 'warning)
                         (if (< (length str) limit) "" truncated))))))
 


### PR DESCRIPTION
In `+emacs-lisp-append-value-to-eldoc-a`, if the `frame-width` of the minibuffer
is smaller than the length of the documentation + " [...]" + 1, a negative
maximum %s bound is passed, causing the error in the title.

Fix this by clamping the computed LIMIT to 0.

If needed, I can make a full issue, but I hope that from my description, the cause is clear: `limit` = `(frame-width)` (minibuffer, in eldoc) - `(length str + length " [...]" + 1)` -> can be negative -> error.