### PR TITLE
Changing elisp macro expand key to avoid collision with parinfer mode toggle

### DIFF
--- a/modules/lang/emacs-lisp/config.el
+++ b/modules/lang/emacs-lisp/config.el
@@ -111,7 +111,7 @@ employed so that flycheck still does *some* helpful linting.")
 
   (map! :localleader
         :map emacs-lisp-mode-map
-        :desc "Expand macro" "m" #'macrostep-expand
+        :desc "Expand macro" "b" #'macrostep-expand
         (:prefix ("d" . "debug")
           "f" #'+emacs-lisp/edebug-instrument-defun-on
           "F" #'+emacs-lisp/edebug-instrument-defun-off)


### PR DESCRIPTION
`Spc m m` toggles parinfer mode and expands macros in elisp mode.

This is just a proposed solution to change the macro expand to `Spc m b`.

If this would be too destructive to folks' workflows (I use macro expanding a lot myself; only discovered the parinfer conflict when helping someone out on discord just now), please close this unmerged.