### PR TITLE
magit: fix mismatched paren in parent

### DIFF
--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -215,7 +215,7 @@ ensure it is built when we actually use Forge."
         (:map magit-status-mode-map
          :nv "gz" #'magit-refresh)
         (:map magit-diff-mode-map
-         :nv "gd" #'magit-jump-to-diffstat-or-diff)))
+         :nv "gd" #'magit-jump-to-diffstat-or-diff))
 
   ;; A more intuitive behavior for TAB in magit buffers:
   (define-key! 'normal


### PR DESCRIPTION
"Fix blacklisted evil-collection-magit keybinds" had one too many
closing parens. 2828281af7d0c5fc05a94d2b1c0a3417b318f414