### PR TITLE
Fix doom upgrade

### DIFF
--- a/core/cli/upgrade.el
+++ b/core/cli/upgrade.el
@@ -58,7 +58,7 @@ following shell commands:
            (branch (replace-regexp-in-string
                     "^\\(?:[^/]+/[^/]+/\\)?\\(.+\\)\\(?:~[0-9]+\\)?$" "\\1"
                     (cdr (doom-call-process "git" "name-rev" "--name-only" "HEAD"))))
-           (target-remote (format "%s/%s" doom-repo-remote branch)))
+           (target-remote (format "%s_%s" doom-repo-remote branch)))
       (unless branch
         (error! (if (file-exists-p! ".git" doom-emacs-dir)
                     "Couldn't find Doom's .git directory. Was Doom cloned properly?"
@@ -80,7 +80,7 @@ following shell commands:
           (let (result)
             (or (zerop (car (doom-call-process "git" "remote" "add" doom-repo-remote doom-repo-url)))
                 (error "Failed to add %s to remotes" doom-repo-remote))
-            (or (zerop (car (setq result (doom-call-process "git" "fetch" "--tags" doom-repo-remote branch))))
+            (or (zerop (car (setq result (doom-call-process "git" "fetch" "--tags" doom-repo-remote (format "%s:%s" branch target-remote)))))
                 (error "Failed to fetch from upstream"))
 
             (let ((this-rev (cdr (doom-call-process "git" "rev-parse" "HEAD")))


### PR DESCRIPTION
Previously, `doom upgrade` would emit:

```
New revision: fatal: amb (fatal: ambiguous argument '_upgrade/HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
```

It appears it's not possible to remote revisions with
`<remote>/<revision>`. Instead, we fetch the upgrade remote into a named
revision and then use it.