### PR TITLE
Fix typo

### DIFF
--- a/core/core-lib.el
+++ b/core/core-lib.el
@@ -689,7 +689,7 @@ REMOTE is non-nil, search on the remote host indicated by
                     command
                     (mapcar
                      (lambda (x) (concat (file-remote-p default-directory) x))
-                     (exec-path))
+                     exec-path)
                     exec-suffixes 'file-executable-p)))
           (when (stringp res) (file-local-name res)))
       ;; Use 1 rather than file-executable-p to better match the


### PR DESCRIPTION
I think this is a typo? At least I got my `magit-status` to work over TRAMP after this change.