### PR TITLE
Moved emojis to .local/

### DIFF
--- a/modules/ui/emoji/config.el
+++ b/modules/ui/emoji/config.el
@@ -8,4 +8,5 @@
          nil (list (if (featurep! +ascii) 'ascii)
                    (if (featurep! +github) 'github)
                    (if (featurep! +unicode) 'unicode))))
+  (setq emojify-emojis-dir (concat doom-local-dir "emojis"))
   (emojify-set-emoji-styles emojify-styles))


### PR DESCRIPTION
As soon as I enabled `ui/emoji` with images it downloaded images into `emojis` folder inside doom-emacs source tree and `git status` starts to complain.

Let move images to right place that is `.local/`.