### PR TITLE
grammar: macports compatibility

### DIFF
--- a/modules/checkers/grammar/config.el
+++ b/modules/checkers/grammar/config.el
@@ -11,11 +11,17 @@
               langtool-language-tool-jar
               langtool-java-classpath)
     (cond (IS-MAC
-           (setq langtool-language-tool-jar
-                 (locate-file "libexec/languagetool-commandline.jar"
-                              (doom-files-in "/usr/local/Cellar/languagetool"
-                                             :type 'dirs
-                                             :depth 2))))
+           (cond
+            ;; is user using home brew?
+            ((file-directory-p "/usr/local/Cellar/languagetool")
+             (setq langtool-language-tool-jar
+                   (locate-file "libexec/languagetool-commandline.jar"
+                                (doom-files-in "/usr/local/Cellar/languagetool"
+                                               :type 'dirs
+                                               :depth 2))))
+            ;; macports compatibility
+            ((file-directory-p "/opt/local/share/java/LanguageTool")
+             (setq langtool-java-classpath "/opt/local/share/java/LanguageTool/*"))))
           (IS-LINUX
            (setq langtool-java-classpath "/usr/share/languagetool:/usr/share/java/languagetool/*")))))
 


### PR DESCRIPTION
Macports is quite popular a way to install some application to macOS and it is shame that it doesn't support such way by default.