### PR TITLE
upgrade.el: force fetch

### DIFF
--- a/core/cli/upgrade.el
+++ b/core/cli/upgrade.el
@@ -80,7 +80,7 @@ following shell commands:
           (let (result)
             (or (zerop (car (doom-call-process "git" "remote" "add" doom-repo-remote doom-repo-url)))
                 (error "Failed to add %s to remotes" doom-repo-remote))
-            (or (zerop (car (setq result (doom-call-process "git" "fetch" "--tags" doom-repo-remote (format "%s:%s" branch target-remote)))))
+            (or (zerop (car (setq result (doom-call-process "git" "fetch" "--force" "--tags" doom-repo-remote (format "%s:%s" branch target-remote)))))
                 (error "Failed to fetch from upstream"))
 
             (let ((this-rev (cdr (doom-call-process "git" "rev-parse" "HEAD")))


### PR DESCRIPTION
`doom-cli-upgrade` calls `git fetch` to fetch remote branch and tags and check output code of this command to complain when it failed.

It fails when remote server isn't available that is good.

But it also fails when it can't to fast-forward a branch that will be used to upgrade doom-emacs.

The last case created a loop and the only way to broke this loop is remote a branch that should be used for upgrade.

Unfortunately user has no idea about branch name and can't do anything, just enjoy crash with `Failed to fetch from upstream` message.

This commit added `--force` flag to `git fetch` that forces it to overwrite branch that is used to upgrade that prevent such loop.

It also fixed https://github.com/hlissner/doom-emacs/issues/4346