### PR TITLE
Upgrade: remove leftover ref

### DIFF
--- a/core/cli/upgrade.el
+++ b/core/cli/upgrade.el
@@ -122,4 +122,5 @@ following shell commands:
                    (print! (info "%s") (cdr result))
                    t))))))
         (ignore-errors
+          (doom-call-process "git" "branch" "-D" target-remote)
           (doom-call-process "git" "remote" "remove" doom-repo-remote))))))


### PR DESCRIPTION
The upgrade process leaves a left over ref:

```
$ git branch
...
  _upgrade_HEAD
...
```

This commit deletes that.