### PR TITLE
fix nix aspell installation instructions

### DIFF
--- a/modules/checkers/spell/README.org
+++ b/modules/checkers/spell/README.org
@@ -70,10 +70,7 @@ with anything other than =aspell= yet.
   #+BEGIN_SRC nix
   {
     environment.systemPackages = with pkgs; [
-      aspell
-      aspellDicts.en
-      aspellDicts.en-computers
-      aspellDicts.en-science
+      (aspellWithDicts (dicts: with dicts; [ en en-computers en-science ]))
     ];
   }
   #+END_SRC


### PR DESCRIPTION
The original instruction made nix install the language packages in different directories than the `aspell` package.

Use solution provided here https://github.com/hlissner/doom-emacs/issues/4138#issuecomment-717266771


closes https://github.com/hlissner/doom-emacs/issues/4138