### PR TITLE
Enable smartparens for `edebug-eval-expression'

### DIFF
--- a/core/core-editor.el
+++ b/core/core-editor.el
@@ -498,13 +498,11 @@ files, so we replace calls to `pp' with the much faster `prin1'."
   (dolist (key '(:unmatched-expression :no-matching-tag))
     (setf (alist-get key sp-message-alist) nil))
 
-  (add-hook! 'minibuffer-setup-hook
+  (add-hook! 'eval-expression-minibuffer-setup-hook
     (defun doom-init-smartparens-in-minibuffer-maybe-h ()
-      "Enable `smartparens-mode' in the minibuffer, during `eval-expression',
-`pp-eval-expression' or `evil-ex'."
-      (and (memq this-command '(eval-expression pp-eval-expression evil-ex))
-           smartparens-global-mode
-           (smartparens-mode))))
+      "Enable `smartparens-mode' in the minibuffer for `eval-expression'.
+Only enable it if `smartparens-global-mode' is on."
+      (when smartparens-global-mode (smartparens-mode))))
 
   ;; You're likely writing lisp in the minibuffer, therefore, disable these
   ;; quote pairs, which lisps doesn't use for strings:


### PR DESCRIPTION
`doom-init-smartparens-in-minibuffer-maybe-h` is responsible for enabling
`smartparens` in the minibuffer, which it does by checking `this-command'.
However, the list of commands doesn't include `edebug-eval-expression`,
preventing the mode from being enabled for it.

Fix this by enabling `smartparens` in `eval-expression-minibuffer-setup-hook`,
unconditionally, which means that anything using `interactive' "x" or
`read--expression` will work correctly.

To reproduce this:
1. `M-x eval-expression`: parens auto-close themselves
2. `M-x edebug-eval-expression`: parens don't auto-close themselves
3. Even more fun to debug: `read--expression`, called directly in the `interactive` form of `edebug-eval-expression`, has auto-closing parens for some reason.

Do you know when `eval-expression-minibuffer-setup-hook` was added? I have it in Emacs 26.3 and 27.1, but I don't know whether older Emacsen need to be supported by DOOM.