### PR TITLE
Fix/bepo exhaustive remaps

### DIFF
--- a/modules/input/layout/README.org
+++ b/modules/input/layout/README.org
@@ -11,18 +11,21 @@
 - [[#prerequisites][Prerequisites]]
 - [[#features][Features]]
   - [[#bépo][Bépo]]
+    - [[#easymotion][Easymotion]]
     - [[#leaving-mnemonics-alone-when-possible][Leaving mnemonics alone when possible]]
     - [[#possible-contributions][Possible contributions]]
+    - [[#org-mode][Org-mode]]
 - [[#configuration][Configuration]]
   - [[#bépo-1][Bépo]]
 - [[#troubleshooting][Troubleshooting]]
+  - [[#how-to-investigate-an-issue-][How to investigate an issue ?]]
   - [[#how-to-deactivate-the-new-bindings-and-go-back-to-the-old-ones-][How to deactivate the new bindings and go back to the old ones ?]]
 
 * Description
 This module provides barebones support for using Doom with non-qwerty layouts.
 
 ** Maintainers
-+ @gagbo (Author)
++ @gagbo (Author, Bépo)
 
 ** Module Flags
 + =+bepo= Enables modifications for the BÉPO layout (customized with version 1.1 in mind)
@@ -43,14 +46,23 @@ Support for the bépo layout includes:
 - Setting Avy keys to the correct home row keys
 - Changing navigation keys to =ctsr=
   + old =t= is mapped to =j=
-  + old =s= is mapped to =k= (i.e. staging in the magit status buffer is done with =k=)
+  + old =s= is mapped to =k= (i.e. staging in the magit status buffer is done
+    with =k=)
   + See [[*Configuration][Configuration]] to see where old =c= and =r= functions
     are remapped
 - Bind =<>= functions to =«»= keys when possible
-- Bind =[]= functions to =()= keys when possible
+- Bind =[]= functions to =()= keys when possible (the "unimpaired-like"
+  bindings)
 - Bind =é= key to =w= functions when possible
 - Bind =è= key to useful functions when possible
 - Bind =`~= functions to =$#= keys when possible
+
+*** Easymotion
+
+If you use =evil-easymotion=, then all the bindings that were on =gs= have been
+moved to =gé=.
+
+In short : =g s j= -> =g é t= (evilem-motion-next-line). And so on.
 
 *** Leaving mnemonics alone when possible
 Exchanging =hjkl= to =ctsr= has the effect of destroying a few mnemonics: the
@@ -73,6 +85,16 @@ bindings. This is *not* implemented for the time being.
 Also, implementing all those changes as a minor we could flip on and off would
 help with adoption
 
+*** Org-mode
+=evil-org= allows to define =evil-org-movement-bindings= to automatically map
+movement bindings on non-hjkl keys. It maps automatically keys to =C-c= and
+=C-r= in normal and insert states though, and it's not really user friendly in
+Emacs to remap those.
+
+Therefore, in org-mode:
+- =org-shiftright= is bound to =C-»=
+- =org-shiftleft= is bound to =C-«=
+
 * Configuration
 ** Bépo
 =doom-bepo-cr-rotation-style= controls whether:
@@ -86,6 +108,17 @@ actually put all the =c= functions on the key that does not need a curl.
 
 * Troubleshooting
 # Common issues and their solution, or places to look for help.
+** How to investigate an issue ?
+If a key is misbehaving, use =describe-key= (=C-h k= or =SPC h k= or =F1 k=) to
+see the functions bound to the key, and more importantly in which map it is
+bound.
+
+You should ignore all =evil-collection-...-backup-map= keymaps, as they are
+artifacts from =evil-collection-translate-key= and those maps are actually not
+active.
+
+Most likely the solution is to call one of the "key rotation" functions on the
+relevant keymaps.
 ** How to deactivate the new bindings and go back to the old ones ?
 If you are learning a new layout you might want to go back to tho old one to
 "get work done". Sadly the only way is to comment out the module, run =doom

--- a/modules/input/layout/README.org
+++ b/modules/input/layout/README.org
@@ -78,12 +78,21 @@ while =t=, =s=, =j=, and =k= are flipped:
 - staging a file/region has been moved to =k=
 
 *** Possible contributions
+**** Avoid =g= and =z= to be used too often
 A nice addition in the future might be to have all the normal mode bindings that
 start with =g= start with =,= instead to avoid the curl on these common
 bindings. This is *not* implemented for the time being.
 
+The same thing could be done to =z=, potentially using =à= instead.
+
+**** Proper minor mode
 Also, implementing all those changes as a minor we could flip on and off would
 help with adoption
+
+**** Put "word" text objects to é instead of w
+"inside word" and "around word" are =iw= and =aw=, which use the very poorly
+rated =w= key in the bépo layout. Finding a way to use =é= or even =è= more for
+these would be a welcome change
 
 *** Org-mode
 =evil-org= allows to define =evil-org-movement-bindings= to automatically map

--- a/modules/input/layout/autoload/bepo.el
+++ b/modules/input/layout/autoload/bepo.el
@@ -117,7 +117,7 @@ See `doom-bepo-cr-rotation-style' for the meaning of CR-STYLE"
   "Remap evil-{normal,operator,motion,...}-state-map
   to be more natural with Bépo keyboard layout.
 See `doom-bepo-cr-rotation-style' for the meaning of CR-STYLE."
-  (evil-collection-translate-key nil '(evil-normal-state-map evil-motion-state-map evil-visual-state-map)
+  (evil-collection-translate-key nil '(evil-normal-state-map evil-motion-state-map evil-visual-state-map evil-operator-state-map)
     "c" "h"
     "C" "H"
     "t" "j"
@@ -131,13 +131,13 @@ See `doom-bepo-cr-rotation-style' for the meaning of CR-STYLE."
     "k" "s"
     "K" "S")
   (cond ((eq cr-style 'ergodis)
-         (evil-collection-translate-key nil '(evil-normal-state-map evil-motion-state-map evil-visual-state-map)
+         (evil-collection-translate-key nil '(evil-normal-state-map evil-motion-state-map evil-visual-state-map evil-operator-state-map)
            "h" "r"
            "H" "R"
            "l" "c"
            "L" "C"))
         (t
-         (evil-collection-translate-key nil '(evil-normal-state-map evil-motion-state-map evil-visual-state-map)
+         (evil-collection-translate-key nil '(evil-normal-state-map evil-motion-state-map evil-visual-state-map evil-operator-state-map)
            "h" "c"
            "H" "C"
            "l" "r"
@@ -171,18 +171,18 @@ See `doom-bepo-cr-rotation-style' for the meaning of CR-STYLE."
 
 
   ;; <> as direct access
-  (evil-collection-translate-key nil '(evil-normal-state-map evil-motion-state-map)
+  (evil-collection-translate-key nil '(evil-normal-state-map evil-motion-state-map evil-operator-state-map)
     "«" "<"
     "»" ">")
 
   ;; " è replaces ^0 to go at BOL
-  (evil-collection-translate-key nil '(evil-normal-state-map evil-motion-state-map)
+  (evil-collection-translate-key nil '(evil-normal-state-map evil-motion-state-map evil-operator-state-map)
     "è" "^"
     "È" "0")
 
   ;; [W] -> [É]
   ;; [C-W] -> [W]
-  (evil-collection-translate-key nil '(evil-normal-state-map evil-motion-state-map evil-operator-state-map)
+  (evil-collection-translate-key nil '(evil-normal-state-map evil-motion-state-map evil-operator-state-map evil-operator-state-map)
     "é" "w"
     "É" "W"
     "w" (kbd "C-w")
@@ -195,7 +195,7 @@ See `doom-bepo-cr-rotation-style' for the meaning of CR-STYLE."
   (let* ((cr-style (or cr-style 'ergodis))
          (doom-bepo-hook (lambda (_mode mode-keymaps &rest _rest)
                            (dolist (keymap mode-keymaps)
-                             (evil-collection-translate-key '(normal motion visual) keymap
+                             (evil-collection-translate-key '(normal motion visual operator) keymap
                                "c" "h"
                                "C" "H"
                                "t" "j"
@@ -207,19 +207,59 @@ See `doom-bepo-cr-rotation-style' for the meaning of CR-STYLE."
                                "j" "t"
                                "J" "T"
                                "k" "s"
-                               "K" "S")
+                               "K" "S"
+                               (kbd "C-c") (kbd "C-h")
+                               (kbd "C-C") (kbd "C-H")
+                               (kbd "C-t") (kbd "C-j")
+                               (kbd "C-T") (kbd "C-J")
+                               (kbd "C-s") (kbd "C-k")
+                               (kbd "C-S") (kbd "C-K")
+                               (kbd "C-r") (kbd "C-l")
+                               (kbd "C-R") (kbd "C-L")
+                               (kbd "C-j") (kbd "C-t")
+                               (kbd "C-J") (kbd "C-T")
+                               (kbd "C-k") (kbd "C-s")
+                               (kbd "C-K") (kbd "C-S")
+                               (kbd "M-c") (kbd "M-h")
+                               (kbd "M-C") (kbd "M-H")
+                               (kbd "M-t") (kbd "M-j")
+                               (kbd "M-T") (kbd "M-J")
+                               (kbd "M-s") (kbd "M-k")
+                               (kbd "M-S") (kbd "M-K")
+                               (kbd "M-r") (kbd "M-l")
+                               (kbd "M-R") (kbd "M-L")
+                               (kbd "M-j") (kbd "M-t")
+                               (kbd "M-J") (kbd "M-T")
+                               (kbd "M-k") (kbd "M-s")
+                               (kbd "M-K") (kbd "M-S"))
                              (cond ((eq cr-style 'ergodis)
-                                    (evil-collection-translate-key '(normal motion visual) keymap
+                                    (evil-collection-translate-key '(normal motion visual operator) keymap
                                       "h" "r"
                                       "H" "R"
                                       "l" "c"
-                                      "L" "C"))
+                                      "L" "C"
+                                      (kbd "C-h") (kbd "C-r")
+                                      (kbd "C-H") (kbd "C-R")
+                                      (kbd "C-l") (kbd "C-c")
+                                      (kbd "C-L") (kbd "C-C")
+                                      (kbd "M-h") (kbd "M-r")
+                                      (kbd "M-H") (kbd "M-R")
+                                      (kbd "M-l") (kbd "M-c")
+                                      (kbd "M-L") (kbd "M-C")))
                                    (t
-                                    (evil-collection-translate-key '(normal motion visual) keymap
+                                    (evil-collection-translate-key '(normal motion visual operator) keymap
                                       "h" "c"
                                       "H" "C"
                                       "l" "r"
-                                      "L" "R")))
+                                      "L" "R"
+                                      (kbd "C-h") (kbd "C-c")
+                                      (kbd "C-H") (kbd "C-C")
+                                      (kbd "C-l") (kbd "C-r")
+                                      (kbd "C-L") (kbd "C-R")
+                                      (kbd "M-h") (kbd "M-c")
+                                      (kbd "M-H") (kbd "M-C")
+                                      (kbd "M-l") (kbd "M-r")
+                                      (kbd "M-L") (kbd "M-R"))))
 
 
                              (evil-collection-translate-key '(insert) keymap
@@ -234,27 +274,48 @@ See `doom-bepo-cr-rotation-style' for the meaning of CR-STYLE."
                                (kbd "C-j") (kbd "C-t")
                                (kbd "C-J") (kbd "C-T")
                                (kbd "C-k") (kbd "C-s")
-                               (kbd "C-K") (kbd "C-S"))
+                               (kbd "C-K") (kbd "C-S")
+                               (kbd "M-c") (kbd "M-h")
+                               (kbd "M-C") (kbd "M-H")
+                               (kbd "M-t") (kbd "M-j")
+                               (kbd "M-T") (kbd "M-J")
+                               (kbd "M-s") (kbd "M-k")
+                               (kbd "M-S") (kbd "M-K")
+                               (kbd "M-r") (kbd "M-l")
+                               (kbd "M-R") (kbd "M-L")
+                               (kbd "M-j") (kbd "M-t")
+                               (kbd "M-J") (kbd "M-T")
+                               (kbd "M-k") (kbd "M-s")
+                               (kbd "M-K") (kbd "M-S"))
                              (cond ((eq cr-style 'ergodis)
                                     (evil-collection-translate-key '(insert) keymap
                                       (kbd "C-h") (kbd "C-r")
                                       (kbd "C-H") (kbd "C-R")
                                       (kbd "C-l") (kbd "C-c")
-                                      (kbd "C-L") (kbd "C-C")))
+                                      (kbd "C-L") (kbd "C-C")
+                                      (kbd "M-h") (kbd "M-r")
+                                      (kbd "M-H") (kbd "M-R")
+                                      (kbd "M-l") (kbd "M-c")
+                                      (kbd "M-L") (kbd "M-C")))
                                    (t
                                     (evil-collection-translate-key '(insert) keymap
                                       (kbd "C-h") (kbd "C-c")
                                       (kbd "C-H") (kbd "C-C")
                                       (kbd "C-l") (kbd "C-r")
-                                      (kbd "C-L") (kbd "C-R"))))
+                                      (kbd "C-L") (kbd "C-R")
+                                      (kbd "M-h") (kbd "M-c")
+                                      (kbd "M-H") (kbd "M-C")
+                                      (kbd "M-l") (kbd "M-r")
+                                      (kbd "M-L") (kbd "M-R")
+                                      )))
 
                              ;; <> en direct
-                             (evil-collection-translate-key '(normal motion visual) keymap
+                             (evil-collection-translate-key '(normal motion visual operator) keymap
                                "«" "<"
                                "»" ">")
 
                              ;; è pour aller au début de ligne
-                             (evil-collection-translate-key '(normal motion visual) keymap
+                             (evil-collection-translate-key '(normal motion visual operator) keymap
                                "è" "^"
                                "È" "0")
 

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -975,60 +975,69 @@ compelling reason, so..."
              #'+org-cycle-only-current-subtree-h
              ;; Clear babel results if point is inside a src block
              #'+org-clear-babel-results-h)
-  (map! :map evil-org-mode-map
-        :ni [C-return]   #'+org/insert-item-below
-        :ni [C-S-return] #'+org/insert-item-above
-        ;; navigate table cells (from insert-mode)
-        :i  "C-l"     (cmds! (org-at-table-p) #'org-table-next-field
+  (let-alist evil-org-movement-bindings
+    (let ((Cright (concat "C-" .right))
+          (Cleft (concat "C-" .left))
+          (Cup (concat "C-" .up))
+          (Cdown (concat "C-" .down))
+          (CSright (concat "C-" (capitalize .right)))
+          (CSleft (concat "C-" (capitalize .left)))
+          (CSup (concat "C-" (capitalize .up)))
+          (CSdown (concat "C-" (capitalize .down))))
+      (map! :map evil-org-mode-map
+            :ni [C-return]   #'+org/insert-item-below
+            :ni [C-S-return] #'+org/insert-item-above
+            ;; navigate table cells (from insert-mode)
+            :i Cright (cmds! (org-at-table-p) #'org-table-next-field
                              #'org-end-of-line)
-        :i  "C-h"     (cmds! (org-at-table-p) #'org-table-previous-field
+            :i Cleft  (cmds! (org-at-table-p) #'org-table-previous-field
                              #'org-beginning-of-line)
-        :i  "C-k"     (cmds! (org-at-table-p) #'+org/table-previous-row
+            :i Cup    (cmds! (org-at-table-p) #'+org/table-previous-row
                              #'org-up-element)
-        :i  "C-j"     (cmds! (org-at-table-p) #'org-table-next-row
+            :i Cdown  (cmds! (org-at-table-p) #'org-table-next-row
                              #'org-down-element)
-        :ni "C-S-l"   #'org-shiftright
-        :ni "C-S-h"   #'org-shiftleft
-        :ni "C-S-k"   #'org-shiftup
-        :ni "C-S-j"   #'org-shiftdown
-        ;; more intuitive RET keybinds
-        :n [return]   #'+org/dwim-at-point
-        :n "RET"      #'+org/dwim-at-point
-        :i [return]   (cmd! (org-return electric-indent-mode))
-        :i "RET"      (cmd! (org-return electric-indent-mode))
-        :i [S-return] #'+org/shift-return
-        :i "S-RET"    #'+org/shift-return
-        ;; more vim-esque org motion keys (not covered by evil-org-mode)
-        :m "]h"  #'org-forward-heading-same-level
-        :m "[h"  #'org-backward-heading-same-level
-        :m "]l"  #'org-next-link
-        :m "[l"  #'org-previous-link
-        :m "]c"  #'org-babel-next-src-block
-        :m "[c"  #'org-babel-previous-src-block
-        :n "gQ"  #'org-fill-paragraph
-        ;; sensible vim-esque folding keybinds
-        :n "za"  #'+org/toggle-fold
-        :n "zA"  #'org-shifttab
-        :n "zc"  #'+org/close-fold
-        :n "zC"  #'outline-hide-subtree
-        :n "zm"  #'+org/hide-next-fold-level
-        :n "zM"  #'+org/close-all-folds
-        :n "zn"  #'org-tree-to-indirect-buffer
-        :n "zo"  #'+org/open-fold
-        :n "zO"  #'outline-show-subtree
-        :n "zr"  #'+org/show-next-fold-level
-        :n "zR"  #'+org/open-all-folds
-        :n "zi"  #'org-toggle-inline-images
+            :ni CSright   #'org-shiftright
+            :ni CSleft    #'org-shiftleft
+            :ni CSup      #'org-shiftup
+            :ni CSdown    #'org-shiftdown
+            ;; more intuitive RET keybinds
+            :n [return]   #'+org/dwim-at-point
+            :n "RET"      #'+org/dwim-at-point
+            :i [return]   (cmd! (org-return electric-indent-mode))
+            :i "RET"      (cmd! (org-return electric-indent-mode))
+            :i [S-return] #'+org/shift-return
+            :i "S-RET"    #'+org/shift-return
+            ;; more vim-esque org motion keys (not covered by evil-org-mode)
+            :m "]h"  #'org-forward-heading-same-level
+            :m "[h"  #'org-backward-heading-same-level
+            :m "]l"  #'org-next-link
+            :m "[l"  #'org-previous-link
+            :m "]c"  #'org-babel-next-src-block
+            :m "[c"  #'org-babel-previous-src-block
+            :n "gQ"  #'org-fill-paragraph
+            ;; sensible vim-esque folding keybinds
+            :n "za"  #'+org/toggle-fold
+            :n "zA"  #'org-shifttab
+            :n "zc"  #'+org/close-fold
+            :n "zC"  #'outline-hide-subtree
+            :n "zm"  #'+org/hide-next-fold-level
+            :n "zM"  #'+org/close-all-folds
+            :n "zn"  #'org-tree-to-indirect-buffer
+            :n "zo"  #'+org/open-fold
+            :n "zO"  #'outline-show-subtree
+            :n "zr"  #'+org/show-next-fold-level
+            :n "zR"  #'+org/open-all-folds
+            :n "zi"  #'org-toggle-inline-images
 
-        :map org-read-date-minibuffer-local-map
-        "C-h"   (cmd! (org-eval-in-calendar '(calendar-backward-day 1)))
-        "C-l"   (cmd! (org-eval-in-calendar '(calendar-forward-day 1)))
-        "C-k"   (cmd! (org-eval-in-calendar '(calendar-backward-week 1)))
-        "C-j"   (cmd! (org-eval-in-calendar '(calendar-forward-week 1)))
-        "C-S-h" (cmd! (org-eval-in-calendar '(calendar-backward-month 1)))
-        "C-S-l" (cmd! (org-eval-in-calendar '(calendar-forward-month 1)))
-        "C-S-k" (cmd! (org-eval-in-calendar '(calendar-backward-year 1)))
-        "C-S-j" (cmd! (org-eval-in-calendar '(calendar-forward-year 1)))))
+            :map org-read-date-minibuffer-local-map
+            Cleft  (cmd! (org-eval-in-calendar '(calendar-backward-day 1)))
+            Cright   (cmd! (org-eval-in-calendar '(calendar-forward-day 1)))
+            Cup       (cmd! (org-eval-in-calendar '(calendar-backward-week 1)))
+            Cdown    (cmd! (org-eval-in-calendar '(calendar-forward-week 1)))
+            CSleft   (cmd! (org-eval-in-calendar '(calendar-backward-month 1)))
+            CSright  (cmd! (org-eval-in-calendar '(calendar-forward-month 1)))
+            CSup     (cmd! (org-eval-in-calendar '(calendar-backward-year 1)))
+            CSdown   (cmd! (org-eval-in-calendar '(calendar-forward-year 1)))))))
 
 
 (use-package! evil-org-agenda


### PR DESCRIPTION
Related issues : #4391 #4393 

## Draft status
This is a draft pull request because it adds a lot of changes that I'm not sure of. I'll use the module like that for a week or 2 before switching that to a PR for merge

## Summary
- Add `C-` and `M-` remaps to normal/visual/motion/operator states
- Add operator state remaps wherever normal/visual/motion was remapped
- Unbind `s` from `notmuch-common-map`

The rest is mostly comments.

## Test

You can always pull the PR to test it yourself : `git fetch origin refs/pull/{number}/head && git checkout FETCH_HEAD` will put you on this branch if you really need to try anything now