### PR TITLE
`+workspace-new': don't show `doom-fallback-buffer'

### DIFF
--- a/modules/ui/workspaces/autoload/workspaces.el
+++ b/modules/ui/workspaces/autoload/workspaces.el
@@ -136,7 +136,7 @@ Otherwise return t on success, nil otherwise."
       (let ((ignore-window-parameters t)
             (+popup--inhibit-transient t))
         (persp-delete-other-windows))
-      (switch-to-buffer (doom-fallback-buffer))
+      (persp-add-buffer (doom-fallback-buffer))
       (setf (persp-window-conf persp)
             (funcall persp-window-state-get-function (selected-frame))))
     persp))


### PR DESCRIPTION
`+workspace-new` shows `doom-fallback-buffer` using `switch-to-buffer` to add it
to the workspace, which is annoying, as that buffer is usually not interesting
in new workspaces. Use `persp-add-buffer` instead.

Fixes #3990.