### PR TITLE
Add "python3" to possible names for the python binary

### DIFF
--- a/modules/lang/python/README.org
+++ b/modules/lang/python/README.org
@@ -36,7 +36,7 @@ Adds Python support to Doom Emacs.
 + [[https://github.com/pythonic-emacs/anaconda-mode][anaconda-mode]]*
 + [[https://github.com/Wilfred/pyimport][pyimport]]*
 + [[https://github.com/paetzke/py-isort.el][py-isort]]*
-+ [[https://melpa.org/#/nose][nose]]*
++ [[https://github.com/emacsattic/nose/][nose]]*
 + [[https://github.com/wbolster/emacs-python-pytest][python-pytest]]*
 + [[https://github.com/Wilfred/pip-requirements.el][pip-requirements]]*
 + [[https://github.com/pwalsh/pipenv.el][pipenv]]*

--- a/modules/lang/python/doctor.el
+++ b/modules/lang/python/doctor.el
@@ -4,10 +4,12 @@
              (featurep! :tools lsp))
          "This module requires (:tools lsp)")
 
-(if (not (executable-find "python"))
+(if (not (or (executable-find "python")
+             (executable-find "python3")))
     (error! "Couldn't find python in your PATH")
   (unless (featurep! +lsp)
-    (unless (zerop (shell-command "python -c 'import setuptools'"))
+    (unless (or (zerop (shell-command "python -c 'import setuptools'"))
+                (zerop (shell-command "python3 -c 'import setuptools'")))
       (warn! "setuptools wasn't detected, which anaconda-mode requires"))))
 
 (when (featurep! +pyenv)


### PR DESCRIPTION
Followed lang/python/config.el which already checks for python3
when setting the python-shell-interpreter.

Python version naming is a hot mess:
https://www.python.org/dev/peps/pep-0394/