### PR TITLE
Enable `smartparens' for `evil'

### DIFF
--- a/core/core-editor.el
+++ b/core/core-editor.el
@@ -505,10 +505,19 @@ files, so we replace calls to `pp' with the much faster `prin1'."
     (setf (alist-get key sp-message-alist) nil))
 
   (add-hook! 'eval-expression-minibuffer-setup-hook
-    (defun doom-init-smartparens-in-minibuffer-maybe-h ()
+    (defun doom-init-smartparens-in-eval-expression-h ()
       "Enable `smartparens-mode' in the minibuffer for `eval-expression'.
-Only enable it if `smartparens-global-mode' is on."
-      (when smartparens-global-mode (smartparens-mode))))
+This includes everything that calls `read--expression', e.g.
+`edebug-eval-expression' Only enable it if
+`smartparens-global-mode' is on."
+      (when smartparens-global-mode (smartparens-mode +1))))
+  (add-hook! 'minibuffer-setup-hook
+    (defun doom-init-smartparens-in-minibuffer-maybe-h ()
+      "Enable `smartparens' for non-`eval-expression' commands.
+Only enable `smartparens-mode' if `smartparens-global-mode' is
+on."
+      (when (and smartparens-global-mode (memq this-command '(evil-ex)))
+        (smartparens-mode +1))))
 
   ;; You're likely writing lisp in the minibuffer, therefore, disable these
   ;; quote pairs, which lisps doesn't use for strings:


### PR DESCRIPTION
febf960 introduced a regression, in that it caused `smartparens-mode` to
no longer be enabled for `evil-ex`. This is because the latter doesn't
call `read--expression`, but calls the minibuffer directly instead.

Return `doom-init-smartparens-in-minibuffer-maybe-h`, enabling
`smartparens` for `evil-ex`. The hook responsibly for enabling it in
`eval-expression-minibuffer-setup-hook` was renamed to
`doom-init-smartparens-in-eval-expression-h`, since otherwise the naming
would have been awkward.

Also explicity enable `smartparens-mode` instead of toggling it.