### PR TITLE
Workaround: fix goto definition on modules

### DIFF
--- a/modules/lang/emacs-lisp/autoload.el
+++ b/modules/lang/emacs-lisp/autoload.el
@@ -61,7 +61,9 @@ to a pop up buffer."
 (defun +emacs-lisp-lookup-definition (_thing)
   "Lookup definition of THING."
   (if-let (module (+emacs-lisp--module-at-point))
-      (doom/help-modules (car module) (cadr module) 'visit-dir)
+      ;; FIXME: this is probably a bug in `counsel'. See
+      ;; https://github.com/abo-abo/swiper/pull/2752.
+      (progn (doom/help-modules (car module) (cadr module) 'visit-dir) 'deferred)
     (call-interactively #'elisp-def)))
 
 ;;;###autoload


### PR DESCRIPTION
`+emacs-lisp-lookup-definition` does not work when browsing the directory of a
module, because, due to a possible bug in `counsel`, the visited buffer is not
immediately visible after calling `counsel-find-file` (unlike with `find-file`).
As such, the backend should return `deferred` for that case.

See abo-abo/swiper#2752. This should be removed once that PR is merged.