### PR TITLE
`doom/help-modules': C-u -> browse directory

### DIFF
--- a/core/autoload/help.el
+++ b/core/autoload/help.el
@@ -351,13 +351,15 @@ module derived from a `featurep!' or `require!' call, c) the module that the
 current file is in, or d) the module associated with the current major mode (see
 `doom--help-major-mode-module-alist')."
   (interactive
-   (mapcar #'intern
-           (split-string
-            (completing-read "Describe module: "
-                             (doom--help-modules-list)
-                             nil t nil nil
-                             (doom--help-current-module-str))
-            " " t)))
+   (nconc
+    (mapcar #'intern
+            (split-string
+             (completing-read "Describe module: "
+                              (doom--help-modules-list)
+                              nil t nil nil
+                              (doom--help-current-module-str))
+             " " t))
+    (list current-prefix-arg)))
   (cl-check-type category symbol)
   (cl-check-type module symbol)
   (cl-destructuring-bind (module-string path)


### PR DESCRIPTION
If called with a C-u prefix, `doom/help-modules` now browses the module's
directory instead of opening its documentation. This exposes the VISIT-DIR
argument to `interactive` use.