### PR TITLE
popup.el: consider auto-saving indirect buffers too

### DIFF
--- a/modules/ui/popup/autoload/popup.el
+++ b/modules/ui/popup/autoload/popup.el
@@ -45,7 +45,9 @@ the buffer is visible, then set another timer and try again later."
 + And finally deletes the window!"
   (let ((buffer (window-buffer window))
         (inhibit-quit t))
-    (and (buffer-file-name buffer)
+    (and (or (buffer-file-name buffer)
+             (if-let (base-buffer (buffer-base-buffer buffer))
+                 (buffer-file-name base-buffer)))
          (buffer-modified-p buffer)
          (let ((autosave (+popup-parameter 'autosave window)))
            (cond ((eq autosave 't))


### PR DESCRIPTION
Function (buffer-file-name) always returns nil with indirect buffer as
an argument. Extracting base buffer and checking if base buffer visiting
file fixes data loss in indirect buffers showed in popups.

E-mail thread in the org-mode mailing list:

  https://lists.gnu.org/archive/html/emacs-orgmode/2020-12/msg00085.html