### PR TITLE
A workaround for formatting org mode

### DIFF
--- a/modules/editor/format/autoload/format.el
+++ b/modules/editor/format/autoload/format.el
@@ -225,9 +225,9 @@ If nil, BEG and/or END will default to the boundaries of the src block at point.
 (defun +format/buffer ()
   "Reformat the current buffer using LSP or `format-all-buffer'."
   (interactive)
-  (if (and (eq major-mode 'org-mode)
-           (org-in-src-block-p t))
-      (+format--org-region nil nil)
+  (if (eq major-mode 'org-mode)
+      (when (org-in-src-block-p t)
+        (+format--org-region nil nil))
     (call-interactively
      (cond ((and +format-with-lsp
                  (bound-and-true-p lsp-mode)


### PR DESCRIPTION
Only attempt to format the org source block if the point is in it, else do nothing.

`format-all-buffer` failing to look up the formatter for Org mode is causing issues like #4319 . Instead of just excluding this, this PR uses a compromise: only format the code block region the point is currently in, if any.

I don't like this workaround, but it is the best compromise I can think of and it prevents this common error.
I'm not sure what the idiomatic way to format normal org text on save would be, but `format-all-buffer` seems to be for LSP formatters, not for internal Emacs formatting (as far as I can tell).