### PR TITLE
Module documentation: fix error if no description

### DIFF
--- a/modules/lang/emacs-lisp/autoload.el
+++ b/modules/lang/emacs-lisp/autoload.el
@@ -75,7 +75,8 @@ if it's callable, `apropos' otherwise."
                (re-search-forward
                 (if (caddr module)
                     "\\* Module Flags$"
-                  "\\* Description$"))
+                  "\\* Description$")
+                nil t)
                (when (caddr module)
                  (re-search-forward (format "=\\%s=" (caddr module))
                                     nil t))


### PR DESCRIPTION
`+emacs-lisp-lookup-documentation` does a `re-search-forward` for "*Description"
without NOERROR. This causes an `error` if the module has no "*Description", as
it the case for the `editorconfig` module.

To reproduce:
0. `M-x debug-on-error`
1. `M-x evil-lookup` on the editorconfig module errors