### PR TITLE
Do not panic when xclip is not available

### DIFF
--- a/modules/os/tty/config.el
+++ b/modules/os/tty/config.el
@@ -22,7 +22,7 @@
       ;; wl-copy, termux-clipboard-get, or getclip (cygwin); depending on what
       ;; is available.
       (and (require 'xclip nil t)
-           (xclip-mode +1)))))
+           (with-demoted-errors "%s" (xclip-mode +1))))))
 
 (when (featurep! :editor evil)
   ;; Fix cursor shape-changing in the terminal. Only supported in XTerm, Gnome


### PR DESCRIPTION
`(xclip-mode +1)` will raise an error when `xlip` is not found, which can interrupt the whole initialization process.