### PR TITLE
Better ivy hydras usability

### DIFF
--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -59,6 +59,7 @@ results buffer.")
   (setq ivy-height 17
         ivy-wrap t
         ivy-fixed-height-minibuffer t
+        ivy-read-action-function #'ivy-hydra-read-action
         ivy-read-action-format-function #'ivy-read-action-format-columns
         projectile-completion-system 'ivy
         ;; don't show recent files in switch-buffer

--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -96,6 +96,12 @@ results buffer.")
   (after! yasnippet
     (add-hook 'yas-prompt-functions #'+ivy-yas-prompt-fn))
 
+  (after! ivy-hydra
+    ;; Ensure `ivy-dispatching-done' and `hydra-ivy/body' hydras can be
+    ;; exited / toggled by the same key binding they were opened
+    (add-to-list 'ivy-dispatching-done-hydra-exit-keys '("C-o" nil))
+    (defhydra+ hydra-ivy () ("M-o" nil)))
+
   (define-key! ivy-minibuffer-map
     [remap doom/delete-backward-word] #'ivy-backward-kill-word
     "C-c C-e" #'+ivy/woccur


### PR DESCRIPTION
There are two hydras that can be opened from ivy interface:

1. `ivy-dispatching-done` (doom key: `"C-o"`, vanilla key: `"M-o"`)
2. `hydra-ivy/body`           (doom key: `"M-o"`, vanilla key: `"C-o"`)

Original behavior is that they both can be exited / toggled by the same key they were opened.

This PR:

1. sets hydra as default interface for `ivy-dispatching-done`
Contrary to original assumption outlined in https://github.com/hlissner/doom-emacs/issues/4427 hydra works just fine as `ivy-dispatching-done` interface. Regression introduced in https://github.com/hlissner/doom-emacs/commit/c4a0174fe2d02741df73e1ff97fa56b2c3ea2a42 was a result of assigning function to the wrong kind of variable.

 2. restores the original toggle behavior but does it without reverting the decision to swap the `"C-o"` and `"M-o"` key bindings.