### PR TITLE
Prioritize company-capf back-end in org-journal

### DIFF
--- a/modules/lang/org/contrib/journal.el
+++ b/modules/lang/org/contrib/journal.el
@@ -45,6 +45,8 @@
 
   (set-popup-rule! "^\\*Org-journal search" :select t :quit t)
 
+  (set-company-backend! 'org-journal-mode 'company-capf 'company-dabbrev)
+
   (map! (:map org-journal-mode-map
          :n "]f"  #'org-journal-next-entry
          :n "[f"  #'org-journal-previous-entry


### PR DESCRIPTION
This allows functionality like completion of org-roam items seamlessly work in org-journal-mode files too.

Same setting is already set for org-mode itself.