### PR TITLE
[4415] remove FIXME comment

### DIFF
--- a/modules/lang/emacs-lisp/autoload.el
+++ b/modules/lang/emacs-lisp/autoload.el
@@ -61,8 +61,6 @@ to a pop up buffer."
 (defun +emacs-lisp-lookup-definition (_thing)
   "Lookup definition of THING."
   (if-let (module (+emacs-lisp--module-at-point))
-      ;; FIXME: this is probably a bug in `counsel'. See
-      ;; https://github.com/abo-abo/swiper/pull/2752.
       (progn (doom/help-modules (car module) (cadr module) 'visit-dir) 'deferred)
     (call-interactively #'elisp-def)))
 

--- a/modules/lang/emacs-lisp/autoload.el
+++ b/modules/lang/emacs-lisp/autoload.el
@@ -61,7 +61,7 @@ to a pop up buffer."
 (defun +emacs-lisp-lookup-definition (_thing)
   "Lookup definition of THING."
   (if-let (module (+emacs-lisp--module-at-point))
-      (progn (doom/help-modules (car module) (cadr module) 'visit-dir) 'deferred)
+      (doom/help-modules (car module) (cadr module) 'visit-dir)
     (call-interactively #'elisp-def)))
 
 ;;;###autoload


### PR DESCRIPTION
Due to `ivy-call` still causing files to be opened in the
background (which is not a bug in `ivy`),
`+emacs-lisp-lookup-definition` still needs to return `deferred` for
modules. The comment is as such misleading and needs to be removed (it
has been resolved).