### PR TITLE
Fix eager macro expansion failed `hydra-ivy'

### DIFF
--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -100,7 +100,8 @@ results buffer.")
     ;; Ensure `ivy-dispatching-done' and `hydra-ivy/body' hydras can be
     ;; exited / toggled by the same key binding they were opened
     (add-to-list 'ivy-dispatching-done-hydra-exit-keys '("C-o" nil))
-    (defhydra+ hydra-ivy () ("M-o" nil)))
+    ;; Prevent eager macro expansion warnings
+    (eval '(defhydra+ hydra-ivy () ("M-o" nil))))
 
   (define-key! ivy-minibuffer-map
     [remap doom/delete-backward-word] #'ivy-backward-kill-word


### PR DESCRIPTION
With the `ivy` layer enabled, `M-x doom/reload` -> causes message `eager macro expansion failed, hydra-ivy`.