### PR TITLE
Clear jump list when creating new perspective / workspace

### DIFF
--- a/core/packages.el
+++ b/core/packages.el
@@ -32,7 +32,7 @@
 (package! restart-emacs :pin "e5707491d7ac20879465bb52e282ad1416748378")
 
 ;; core-editor.el
-(package! better-jumper :pin "fe548d22c9228b60d9c8a2a452a6c2e03dfdf238")
+(package! better-jumper :pin "66acc6d592d47509a0530a8ee366151a25a370e1")
 (package! dtrt-indent :pin "a7ade6d244eeeda2ada9f7eca565491cea4b622a")
 (package! helpful :pin "584ecc887bb92133119f93a6716cdf7af0b51dca")
 (package! pcre2el :pin "0b5b2a2c173aab3fd14aac6cf5e90ad3bf58fa7d")

--- a/modules/ui/workspaces/config.el
+++ b/modules/ui/workspaces/config.el
@@ -71,6 +71,11 @@ stored in `persp-save-dir'.")
                                     +workspaces-main)
                                 frame))))))
 
+  ;; Clear initial jump list when creating new perspective
+  (add-hook! 'persp-created-functions
+    (defun +worspaces-clear-initial-jump-list (&rest _)
+      (better-jumper-clear-jumps)))
+
   (add-hook! 'persp-mode-hook
     (defun +workspaces-init-first-workspace-h (&rest _)
       "Ensure a main workspace exists."


### PR DESCRIPTION
This pull request will clear the `better-jumper` jump list when a new perspective is created. This will fix #2826

A `better-jumper` version bump is included that adds a new helper function to clear a jump list: `better-jumper-clear-jumps`