### PR TITLE
feat: run golang tests when build tags are set

### DIFF
--- a/modules/lang/go/autoload.el
+++ b/modules/lang/go/autoload.el
@@ -32,13 +32,29 @@
   (interactive)
   (+go--run-tests "./..."))
 
+
+;;;###autoload
+(defun +go--extract-test-tag ()
+  (save-excursion
+    (if-let (tag (progn
+                   (re-search-backward "^//[ ]*\\+build[ ]*\\([[:alnum:]]+\\)"
+                                       nil
+                                       t)
+                   (match-string-no-properties 1)))
+        tag
+      "")))
+
 ;;;###autoload
 (defun +go/test-single ()
   (interactive)
   (if (string-match "_test\\.go" buffer-file-name)
-      (save-excursion
-        (re-search-backward "^func[ ]+\\(([[:alnum:]]*?[ ]?[*]?[[:alnum:]]+)[ ]+\\)?\\(Test[[:alnum:]_]+\\)(.*)")
-        (+go--run-tests (concat "-run" "='" (match-string-no-properties 2) "'")))
+      (let
+          ((test-func-name (save-excursion
+                             (re-search-backward
+                              "^func[ ]+\\(([[:alnum:]]*?[ ]?[*]?[[:alnum:]]+)[ ]+\\)?\\(Test[[:alnum:]_]+\\)(.*)")
+                             (match-string-no-properties 2)))
+           (test-tag (+go--extract-test-tag)))
+        (+go--run-tests (concat "-tags=" test-tag  " " "-run" "='" test-func-name "'")))
     (error "Must be in a _test.go file")))
 
 ;;;###autoload


### PR DESCRIPTION
---
name: General Contribution
about: A general code or documentation PR
---

Golang tests with build tags at the top of the file will only run if the `go test` command is invoked with the corresponding tag (`go test -tags=...`). This is commonly used to avoid running integration tests on every test run. 

This means that `+go/test-single` does not work when trying to run a test in such a file. 

This PR does some dirty-regex hacking to add the correct flag to the go-test-single args. I'm currently using it at work 🙂 .

