### PR TITLE
Add find replace all keybindings

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -586,6 +586,8 @@
        :desc "Switch project"               "p" #'projectile-switch-project
        :desc "Find recent project files"    "r" #'projectile-recentf
        :desc "Run project"                  "R" #'projectile-run-project
+       :desc "Find and replace all"         "C-r" #'projectile-replace
+       :desc "Find and replace all regexp"  "C-R" #'projectile-replace-regexp
        :desc "Save project files"           "s" #'projectile-save-project-buffers
        :desc "List project todos"           "t" #'magit-todos-list
        :desc "Test project"                 "T" #'projectile-test-project


### PR DESCRIPTION
For an easy find in project and replace I use `projectile-replace` which works very nice, I noticed there's no keybinding for this command in doom, this is a suggestion.