### PR TITLE
Add `--exclude .git` to fd in `projectile-generic-command`

### DIFF
--- a/core/core-projects.el
+++ b/core/core-projects.el
@@ -179,7 +179,7 @@ And if it's a function, evaluate it."
                          (cl-find-if (doom-rpartial #'executable-find t)
                                      (list "fdfind" "fd"))
                        doom-projectile-fd-binary))
-              (concat (format "%s . -0 -H --color=never --type file --type symlink --follow"
+              (concat (format "%s . -0 -H --color=never --type file --type symlink --follow --exclude .git"
                               bin)
                       (if IS-WINDOWS " --path-separator=/"))))
            ;; Otherwise, resort to ripgrep, which is also faster than find


### PR DESCRIPTION
I have `projectile-index-method` set to `alien` as using `hybrid` is too slow in my project of around 3800 files when cache is disabled (I disable cache since I switch branches often and was constantly deleting my cache).

When using `alien` `.git` files are being included which would otherwise be filtered by `'hybrid` so this PR passes a flag to exclude `.git` to `fd`.

Note that this is already being done in the `rg` fallback below.