### PR TITLE
Fix `+eshell/split-window' error

### DIFF
--- a/modules/term/eshell/autoload/eshell.el
+++ b/modules/term/eshell/autoload/eshell.el
@@ -28,7 +28,7 @@
       (switch-to-buffer (doom-fallback-buffer)))
     (when +eshell-enable-new-shell-on-split
       (let ((default-directory directory))
-        (when-let (win (get-buffer-window (+eshell/here t)))
+        (when-let (win (get-buffer-window (+eshell/here)))
           (set-window-dedicated-p win dedicated-p))))))
 
 (defun +eshell--setup-window (window &optional flag)


### PR DESCRIPTION
`+eshell/split-window` eventually calls `+eshell--bury-buffer`, which
invoked `+eshell/here` with `t` instead of a command string, erroring.