### PR TITLE
Don't hide the menu bar by default.

### DIFF
--- a/core/core-ui.el
+++ b/core/core-ui.el
@@ -297,12 +297,11 @@ windows, switch to `doom-fallback-buffer'. Otherwise, delegate to original
 (setq window-resize-pixelwise t
       frame-resize-pixelwise t)
 
-(unless (assq 'menu-bar-lines default-frame-alist)
+(unless (assq 'tool-bar-lines default-frame-alist)
   ;; We do this in early-init.el too, but in case the user is on Emacs 26 we do
   ;; it here too: disable tool and scrollbars, as Doom encourages
   ;; keyboard-centric workflows, so these are just clutter (the scrollbar also
   ;; impacts performance).
-  (add-to-list 'default-frame-alist '(menu-bar-lines . 0))
   (add-to-list 'default-frame-alist '(tool-bar-lines . 0))
   (add-to-list 'default-frame-alist '(vertical-scroll-bars)))
 

--- a/early-init.el
+++ b/early-init.el
@@ -13,7 +13,6 @@
 (advice-add #'package--ensure-init-file :override #'ignore)
 
 ;; Prevent the glimpse of un-styled Emacs by disabling these UI elements early.
-(push '(menu-bar-lines . 0) default-frame-alist)
 (push '(tool-bar-lines . 0) default-frame-alist)
 (push '(vertical-scroll-bars) default-frame-alist)
 


### PR DESCRIPTION
Keep menu-bar-lines at the default to not hide the menu bar.
Fixes #3926