### PR TITLE
Bump better-jumper. Fixes #2826

### DIFF
--- a/core/packages.el
+++ b/core/packages.el
@@ -32,7 +32,7 @@
 (package! restart-emacs :pin "e5707491d7ac20879465bb52e282ad1416748378")
 
 ;; core-editor.el
-(package! better-jumper :pin "fe548d22c9228b60d9c8a2a452a6c2e03dfdf238")
+(package! better-jumper :pin "e3a6546aa626b9a79ae451c88f44cf26f9d1a919")
 (package! dtrt-indent :pin "a7ade6d244eeeda2ada9f7eca565491cea4b622a")
 (package! helpful :pin "584ecc887bb92133119f93a6716cdf7af0b51dca")
 (package! pcre2el :pin "0b5b2a2c173aab3fd14aac6cf5e90ad3bf58fa7d")


### PR DESCRIPTION
When utilizing workspaces, upon creating a new perspective and switching to that perspective, `persp-mode` will use the current window (and all of it's associated properties) as a basis for the new perspective and as a result, the current window's jump list is leaked into the new perspective. This causes jumps to be shared between multiple perspectives instead of being properly isolated between them.

The new version of better jumper contains added protections to ensure that a jump list is never leaked into a new perspective. Anytime a new perspective is created, better jumper will initialize it with an empty jump list when it is activated.

More details here: #2826