### PR TITLE
Respect the :ignore property for packages installed as dependencies

### DIFF
--- a/core/core-packages.el
+++ b/core/core-packages.el
@@ -191,7 +191,8 @@ processed."
       (dolist (package doom-packages)
         (cl-destructuring-bind
             (name &key recipe disable ignore shadow &allow-other-keys) package
-          (unless ignore
+          (if ignore
+            (straight-override-recipe (cons name '(:type built-in)))
             (if disable
                 (cl-pushnew name doom-disabled-packages)
               (when shadow

--- a/core/core-packages.el
+++ b/core/core-packages.el
@@ -192,7 +192,7 @@ processed."
         (cl-destructuring-bind
             (name &key recipe disable ignore shadow &allow-other-keys) package
           (if ignore
-            (straight-override-recipe (cons name '(:type built-in)))
+              (straight-override-recipe (cons name '(:type built-in)))
             (if disable
                 (cl-pushnew name doom-disabled-packages)
               (when shadow


### PR DESCRIPTION
The `:ignore` (or `:built-in`) property for the `package!` macro currently doesn't work as intended when packages are installed as dependencies of another package. I noticed this behavior while attempting to replace Doom-managed packages with Nixpkgs ones:

```nix
# Nix expression used for installing Emacs
emacsWithPackages (epkgs: with epkgs; [ emacsql-sqlite3 pdf-tools ])
```

```elisp
;; packages.el
(package! emacsql-sqlite3 :built-in 'prefer)
(package! pdf-tools :built-in 'prefer)
```

```elisp
;; init.el
(doom!
...
  :tools
  pdf
...
  :lang
  (org +roam)
...
)
```

```console
$ doom -y install --no-config
...
  → Building saveplace-pdf-view...
  → Building saveplace-pdf-view → Cloning pdf-tools...
  → Building saveplace-pdf-view → Cloning pdf-tools...done
  → Building saveplace-pdf-view → Building pdf-tools...
  → Building saveplace-pdf-view → Building pdf-tools...done
...
  → Building org-roam → Building emacsql...done
  → Building org-roam → Cloning emacsql-sqlite3...
  → Building org-roam → Cloning emacsql-sqlite3...done
  → Building org-roam → Building emacsql-sqlite3...
  → Building org-roam → Building emacsql-sqlite3...done
...
```

This seems to happen because straight.el isn't made aware of the package `:ignore` property, which this PR aims to fix. I've confirmed this fix works with the example above.