### PR TITLE
Emacs-lisp eldoc: fix error if symbol unbound

### DIFF
--- a/modules/lang/emacs-lisp/config.el
+++ b/modules/lang/emacs-lisp/config.el
@@ -99,15 +99,17 @@ employed so that flycheck still does *some* helpful linting.")
     "Display variable value next to documentation in eldoc."
     :around #'elisp-get-var-docstring
     (when-let (ret (funcall orig-fn sym))
-      (concat ret " "
-              (let* ((truncated " [...]")
-                     (print-escape-newlines t)
-                     (str (symbol-value sym))
-                     (str (prin1-to-string str))
-                     (limit (- (frame-width) (length ret) (length truncated) 1)))
-                (format (format "%%0.%ds%%s" (max limit 0))
-                        (propertize str 'face 'warning)
-                        (if (< (length str) limit) "" truncated))))))
+      (if (fboundp sym)
+          (concat ret " "
+                  (let* ((truncated " [...]")
+                         (print-escape-newlines t)
+                         (str (symbol-value sym))
+                         (str (prin1-to-string str))
+                         (limit (- (frame-width) (length ret) (length truncated) 1)))
+                    (format (format "%%0.%ds%%s" (max limit 0))
+                            (propertize str 'face 'warning)
+                            (if (< (length str) limit) "" truncated))))
+        ret)))
 
   (map! :localleader
         :map emacs-lisp-mode-map


### PR DESCRIPTION
`+emacs-lisp-append-value-to-eldoc-a` `error`s if the symbol isn't
bound, because `symbol-value` errors in that case. Fix that bug by only
modifying the result of `elisp-get-var-docstring` if the symbol is
bound.