### PR TITLE
Improving snippet lookup behavior

### DIFF
--- a/modules/editor/snippets/autoload/snippets.el
+++ b/modules/editor/snippets/autoload/snippets.el
@@ -33,23 +33,14 @@ ignored. This makes it easy to override built-in snippets with private ones."
         (make-directory dir t)
       (error "%S doesn't exist" (abbreviate-file-name dir)))))
 
-(defun +snippet--get-exact-template-by-uuid (mode uuid)
-  "Similar behavior to yas--get-template-by-uuid, but deal with empty tables better.
-Yas' behavior introduces a bug for this case (no table for mode)"
-  (when-let* ((table (gethash mode yas--tables))
-             (uuid-hash (yas--table-uuidhash table)))
-    (gethash uuid uuid-hash)))
-
 (defun +snippet--get-template-by-uuid (uuid &optional mode)
   "Look up the template by uuid in child-most to parent-most mode order.
 Finds correctly active snippets from parent modes (based on Yas' logic)."
-  (let* ((mode (or mode major-mode))
-         (active-modes (yas--modes-to-activate mode)))
-    (cl-loop
-     for active-mode in active-modes
-     for template = (+snippet--get-exact-template-by-uuid active-mode uuid)
-     if (not (null template))
-     return template)))
+  (cl-loop with mode = (or mode major-mode)
+           for active-mode in (yas--modes-to-activate mode)
+           if (gethash active-mode yas--tables)
+           if (gethash uuid (yas--table-uuidhash it))
+           return it))
 
 (defun +snippet--completing-read-uuid (prompt all-snippets &rest args)
   (plist-get


### PR DESCRIPTION
This enables snippets to be accessed by UUID in parent modes of the
current mode. Prior behavior was to only look up for the current mode,
but the active modes (and those suggested in the prompt) include
parent-mode snippets (e.g., text-mode snippets when major-mode is org-mode).

The method `+snippet--get-exact-template-by-uuid` was a necessary clone of `yas--get-template-by-uuid` because the latter method does not handle lookups for modes that don't have any loaded tables that may be a parent of the queried mode.

For example, folks may have snippets in org mode and text mode, but the mode / parent order produces by `yas-modes-to-activate` adds outline mode between, which likely does not have a table.

# testing

I tested a few modes by calling `+snippets/edit` to ensure that snippets for the `major-mode` were found (prior behavior) _and_ that snippets for parent modes were found. Specifically, I tested (in my config):

* org-mode (parent being text-mode and fundamental mode)
* cc-mode (parent being prog-mode and fundamental mode)