### PR TITLE
Include snippets in lsp completion

### DIFF
--- a/modules/tools/lsp/+lsp.el
+++ b/modules/tools/lsp/+lsp.el
@@ -1,6 +1,8 @@
 ;;; tools/lsp/+lsp.el -*- lexical-binding: t; -*-
 
-(defvar +lsp-company-backends 'company-capf
+(defvar +lsp-company-backends (if (featurep! :editor snippets)
+                                  '(:separate company-yasnippet company-capf)
+                                'company-capf)
   "The backends to prepend to `company-backends' in `lsp-mode' buffers.
 Can be a list of backends; accepts any value `company-backends' accepts.")
 


### PR DESCRIPTION
This gives completion of snippets along with normal LSP completion,
similar to how the old company-lsp backend worked.

![image](https://user-images.githubusercontent.com/522123/103887312-c39ef800-50da-11eb-90f0-5f5e039f4fff.png)
