### PR TITLE
Fix latex item indent ignore `LaTeX item indent`

### DIFF
--- a/modules/lang/latex/autoload.el
+++ b/modules/lang/latex/autoload.el
@@ -37,11 +37,10 @@ function uses."
                  indent))
             ((looking-at (concat re-end re-env "}"))
              (save-excursion
-                   (beginning-of-line)
-                   (ignore-errors
-                     (LaTeX-find-matching-begin)
-                     (current-column)
-                  )))
+               (beginning-of-line)
+               (ignore-errors
+                 (LaTeX-find-matching-begin)
+                 (current-column))))
             ((looking-at "\\\\item")
              (+ LaTeX-indent-level indent))
             ((+ contin LaTeX-indent-level indent))))))

--- a/modules/lang/latex/autoload.el
+++ b/modules/lang/latex/autoload.el
@@ -17,7 +17,7 @@ function uses."
                      (when (looking-at (concat re-beg re-env "}"))
                        (end-of-line))
                      (LaTeX-find-matching-begin)
-                     (current-column)))
+                     (+ LaTeX-item-indent (current-column))))
            (contin (pcase +latex-indent-item-continuation-offset
                      (`auto LaTeX-indent-level)
                      (`align 6)
@@ -29,13 +29,19 @@ function uses."
                    (ignore-errors
                      (LaTeX-find-matching-begin)
                      (+ (current-column)
+                        LaTeX-item-indent
                         LaTeX-indent-level
                         (if (looking-at (concat re-beg re-env "}"))
                             contin
                           0))))
                  indent))
             ((looking-at (concat re-end re-env "}"))
-             indent)
+             (save-excursion
+                   (beginning-of-line)
+                   (ignore-errors
+                     (LaTeX-find-matching-begin)
+                     (current-column)
+                  )))
             ((looking-at "\\\\item")
              (+ LaTeX-indent-level indent))
             ((+ contin LaTeX-indent-level indent))))))


### PR DESCRIPTION
Latex item indent ignore the existing variable `LaTeX-item-indent`.
This pull request fix this.