### PR TITLE
Update ocaml bindings docs

### DIFF
--- a/modules/lang/ocaml/README.org
+++ b/modules/lang/ocaml/README.org
@@ -74,17 +74,17 @@ tools.
 
 * Appendix
 ** Commands
-  | Command                      | Key       | Description                                               |
-  |------------------------------+-----------+-----------------------------------------------------------|
-  | =merlin-occurences=          | =SPC c D= | lookup references                                         |
-  | =merlin-document=            | =K=       | lookup documentation                                      |
-  | =merlin-imenu=               | =SPC / i= | symbol lookup in file                                     |
-  | =merlin-iedit-occurrences=   | =v R=     | visual refactor identifier under point (multiple cursors) |
-  | =utop=                       | =SPC o r= | open =utop= as REPL                                       |
-  | =utop-eval-region=           | =SPC c e= | evaluate selected region in =utop=                        |
+  | Command                      | Key               | Description                                               |
+  |------------------------------+-------------------+-----------------------------------------------------------|
   | =merlin-type-enclosing=      | =<localleader> t= | display type under point                                  |
   | =tuareg-find-alternate-file= | =<localleader> a= | switch between =.ml= and =.mli=                           |
   | =merlin-locate=              | =g d=             | lookup definition                                         |
+  | =merlin-occurences=          | =SPC c D=         | lookup references                                         |
+  | =merlin-document=            | =K=               | lookup documentation                                      |
+  | =merlin-imenu=               | =SPC s i=         | symbol lookup in file                                     |
+  | =merlin-iedit-occurrences=   | =v R=             | visual refactor identifier under point (multiple cursors) |
+  | =utop=                       | =SPC o r=         | open =utop= as REPL                                       |
+  | =utop-eval-region=           | =SPC c e=         | evaluate selected region in =utop=                        |
 
 ** Hacks
 + =set-ligatures!= is called with the full tuareg prettify symbol list, this

--- a/modules/lang/ocaml/README.org
+++ b/modules/lang/ocaml/README.org
@@ -76,8 +76,6 @@ tools.
 ** Commands
   | Command                      | Key       | Description                                               |
   |------------------------------+-----------+-----------------------------------------------------------|
-  | =merlin-type-enclosing=      | =SPC m t= | display type under point                                  |
-  | =tuareg-find-alternate-file= | =SPC m a= | switch between =.ml= and =.mli=                           |
   | =merlin-locate=              | =gd=      | lookup definition                                         |
   | =merlin-occurences=          | =SPC c D= | lookup references                                         |
   | =merlin-document=            | =K=       | lookup documentation                                      |
@@ -85,6 +83,8 @@ tools.
   | =merlin-iedit-occurrences=   | =v R=     | visual refactor identifier under point (multiple cursors) |
   | =utop=                       | =SPC o r= | open =utop= as REPL                                       |
   | =utop-eval-region=           | =SPC c e= | evaluate selected region in =utop=                        |
+  | =merlin-type-enclosing=      | =<localleader> t= | display type under point                                  |
+  | =tuareg-find-alternate-file= | =<localleader> a= | switch between =.ml= and =.mli=                           |
 
 ** Hacks
 + =set-ligatures!= is called with the full tuareg prettify symbol list, this

--- a/modules/lang/ocaml/README.org
+++ b/modules/lang/ocaml/README.org
@@ -76,7 +76,6 @@ tools.
 ** Commands
   | Command                      | Key       | Description                                               |
   |------------------------------+-----------+-----------------------------------------------------------|
-  | =merlin-locate=              | =gd=      | lookup definition                                         |
   | =merlin-occurences=          | =SPC c D= | lookup references                                         |
   | =merlin-document=            | =K=       | lookup documentation                                      |
   | =merlin-imenu=               | =SPC / i= | symbol lookup in file                                     |
@@ -85,6 +84,7 @@ tools.
   | =utop-eval-region=           | =SPC c e= | evaluate selected region in =utop=                        |
   | =merlin-type-enclosing=      | =<localleader> t= | display type under point                                  |
   | =tuareg-find-alternate-file= | =<localleader> a= | switch between =.ml= and =.mli=                           |
+  | =merlin-locate=              | =g d=             | lookup definition                                         |
 
 ** Hacks
 + =set-ligatures!= is called with the full tuareg prettify symbol list, this


### PR DESCRIPTION
This updates and corrects the documentation on bindings for the `ocaml` doom module.