### PR TITLE
Add org-agenda-priority keybindings to org config

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -684,7 +684,6 @@ between the two."
         "I" #'org-toggle-inline-images
         "n" #'org-store-link
         "o" #'org-set-property
-        "p" #'org-priority
         "q" #'org-set-tags-command
         "t" #'org-todo
         "T" #'org-todo-list
@@ -803,11 +802,11 @@ between the two."
          "s" #'org-sparse-tree
          "A" #'org-archive-subtree
          "N" #'widen
-         "S" #'org-sort
-         (:prefix ("p" . "Org Priority")
-          "d" #'org-priority-down
-          "p" #'org-priority
-          "u" #'org-priority-up)))
+         "S" #'org-sort)
+        (:prefix ("p" . "Org Priority")
+         "d" #'org-agenda-priority-down
+         "p" #'org-agenda-priority
+         "u" #'org-agenda-priority-up))
 
   (map! :after org-agenda
         :map org-agenda-mode-map
@@ -823,11 +822,10 @@ between the two."
          "o" #'org-agenda-clock-out
          "r" #'org-agenda-clockreport-mode
          "s" #'org-agenda-show-clocking-issues)
-        (:prefix ("P" . "Org Priority")
+        (:prefix ("p" . "Org Priority")
          "d" #'org-agenda-priority-down
          "p" #'org-agenda-priority
          "u" #'org-agenda-priority-up)
-        "p" #'org-agenda-priority
         "q" #'org-agenda-set-tags
         "r" #'org-agenda-refile
         "t" #'org-agenda-todo))

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -823,6 +823,11 @@ between the two."
          "o" #'org-agenda-clock-out
          "r" #'org-agenda-clockreport-mode
          "s" #'org-agenda-show-clocking-issues)
+        (:prefix ("P" . "Org Priority")
+         "d" #'org-agenda-priority-down
+         "p" #'org-agenda-priority
+         "u" #'org-agenda-priority-up)
+        "p" #'org-agenda-priority
         "q" #'org-agenda-set-tags
         "r" #'org-agenda-refile
         "t" #'org-agenda-todo))

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -789,7 +789,7 @@ between the two."
          "O" #'+org/refile-to-other-buffer
          "v" #'+org/refile-to-visible
          "r" #'org-refile) ; to all `org-refile-targets'
-        (:prefix ("s" . "Tree/Subtree")
+        (:prefix ("s" . "tree/subtree")
          "a" #'org-toggle-archive-tag
          "b" #'org-tree-to-indirect-buffer
          "d" #'org-cut-subtree
@@ -803,10 +803,10 @@ between the two."
          "A" #'org-archive-subtree
          "N" #'widen
          "S" #'org-sort)
-        (:prefix ("p" . "Org Priority")
-         "d" #'org-agenda-priority-down
-         "p" #'org-agenda-priority
-         "u" #'org-agenda-priority-up))
+        (:prefix ("p" . "priority")
+         "d" #'org-priority-down
+         "p" #'org-priority
+         "u" #'org-priority-up))
 
   (map! :after org-agenda
         :map org-agenda-mode-map
@@ -822,7 +822,7 @@ between the two."
          "o" #'org-agenda-clock-out
          "r" #'org-agenda-clockreport-mode
          "s" #'org-agenda-show-clocking-issues)
-        (:prefix ("p" . "Org Priority")
+        (:prefix ("p" . "priority")
          "d" #'org-agenda-priority-down
          "p" #'org-agenda-priority
          "u" #'org-agenda-priority-up)


### PR DESCRIPTION
Summary: This diff adds evil-esque keybindings for the org-agenda-priority
functions. These functions allow the org subtree priority to be set from
the agenda view.

Rationale: I love the existing `org-agenda-*` keybindings, but I find myself missing `org-agenda-priority` when doing exactly what you'd guess: trying to set an item's priority while in the agenda. This adds that keybinding in, along with a prefix menu for all of the `org-agenda-priority-*` functions.

I didn't see existing keybinding documentation for org-mode so I didn't add any myself, but let me know what is necessary to get this PR up to spec.