### PR TITLE
Fix +evil--insert-new-line advice when opening new line inside a comment

### DIFF
--- a/modules/editor/evil/autoload/advice.el
+++ b/modules/editor/evil/autoload/advice.el
@@ -106,7 +106,7 @@ more information on modifiers."
         (cond ((sp-point-in-comment pos)
                (setq evil-auto-indent nil)
                (if comment-line-break-function
-                   (funcall comment-line-break-function)
+                   (funcall comment-line-break-function nil)
                  (comment-indent-new-line)))
               ;; TODO Find a better way to do this
               ((and (eq major-mode 'haskell-mode)


### PR DESCRIPTION
`comment-line-break-function` requires a single `soft-newlines` argument.

Follow up on 64222c69c88c230424d630ddb452c6786d3c0d27

How to replicate
---

When hitting `o` within `nxml-mode` in this document in NORMAL evil mode:
```xml
<?xml version="1.0" encoding="utf-8"?>
<Root>
  <!--
  <ItemOne></ItemOne>       <--- cursor at the end of this line, inside a comment
  <ItemTwo></ItemTwo>
   -->
</Root>
```

I get this error:
```
Debugger entered--Lisp error: (wrong-number-of-arguments (1 . 1) 0)
  nxml-newline-and-indent()
  funcall(nxml-newline-and-indent)
  (if comment-line-break-function (funcall comment-line-break-function) (comment-indent-new-line))
  (cond ((sp-point-in-comment pos) (setq evil-auto-indent nil) (if comment-line-break-function (funcall comment-line-break-function) (comment-indent-new-line))) ((and (eq major-$
  (if above (if (save-excursion (nth 4 (sp--syntax-ppss pos))) (let ((goal-column goal-column) (temporary-goal-column temporary-goal-column)) (setq evil-auto-indent nil) (goto-c$
  (let ((evil-restriction-stack (cons (cons (point-min) (point-max)) evil-restriction-stack))) (evil-narrow (field-beginning) (field-end)) (if above (if (save-excursion (nth 4 ($
  (save-restriction (let ((evil-restriction-stack (cons (cons (point-min) (point-max)) evil-restriction-stack))) (evil-narrow (field-beginning) (field-end)) (if above (if (save-$
  (let ((pos (save-excursion (beginning-of-line-text) (point))) comment-auto-fill-only-comments) (require 'smartparens) (save-restriction (let ((evil-restriction-stack (cons (co$
  +evil--insert-newline()
  evil-insert-newline-below()
  #f(compiled-function (count) "Insert a new line below point and switch to Insert state.\nThe insertion will be repeated COUNT times." (interactive "p") #<bytecode 0x1ff1116580$
  funcall(#f(compiled-function (count) "Insert a new line below point and switch to Insert state.\nThe insertion will be repeated COUNT times." (interactive "p") #<bytecode 0x1f$
  (let ((evil-auto-indent evil-auto-indent)) (funcall orig-fn count))
  (progn (fset #'evil-insert-newline-below vnew) (ignore evil-insert-newline-below) (let ((evil-auto-indent evil-auto-indent)) (funcall orig-fn count)))
  (unwind-protect (progn (fset #'evil-insert-newline-below vnew) (ignore evil-insert-newline-below) (let ((evil-auto-indent evil-auto-indent)) (funcall orig-fn count))) (fset #'$
  (let* ((vnew #'(lambda nil (+evil--insert-newline))) (old (symbol-function #'evil-insert-newline-below))) (unwind-protect (progn (fset #'evil-insert-newline-below vnew) (ignor$
  (let ((evil-insert-newline-below (symbol-function #'evil-insert-newline-below))) (let* ((vnew #'(lambda nil (+evil--insert-newline))) (old (symbol-function #'evil-insert-newli$
  (if (or (not +evil-want-o/O-to-continue-comments) (not (eq this-command 'evil-open-below)) (evil-insert-state-p) (evil-emacs-state-p)) (funcall orig-fn count) (let ((evil-inse$
  +evil--insert-newline-below-and-respect-comments-a(#f(compiled-function (count) "Insert a new line below point and switch to Insert state.\nThe insertion will be repeated COUN$
  apply(+evil--insert-newline-below-and-respect-comments-a #f(compiled-function (count) "Insert a new line below point and switch to Insert state.\nThe insertion will be repeate$
  evil-open-below(1)
  funcall-interactively(evil-open-below 1)
  call-interactively(evil-open-below nil nil)
  command-execute(evil-open-below)
```