### PR TITLE
Fix various broken links

### DIFF
--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -66,7 +66,7 @@ directives. By default, this only recognizes C directives.")
   (put 'evil-define-key* 'lisp-indent-function 'defun)
 
   ;; stop copying each visual state move to the clipboard:
-  ;; https://bitbucket.org/lyro/evil/issue/336/osx-visual-state-copies-the-region-on
+  ;; https://github.com/emacs-evil/evil/issues/336
   ;; grokked from:
   ;; http://stackoverflow.com/questions/15873346/elisp-rename-macro
   (advice-add #'evil-visual-update-x-selection :override #'ignore)

--- a/modules/editor/file-templates/templates/emacs-lisp-mode/__package
+++ b/modules/editor/file-templates/templates/emacs-lisp-mode/__package
@@ -2,7 +2,7 @@
 ;;
 ;; Copyright (C) `(format-time-string "%Y")` `user-full-name`
 ;;
-;; Author: `user-full-name` <http://github/`user-login-name`>
+;; Author: `user-full-name` <https://github.com/`user-login-name`>
 ;; Maintainer: `user-full-name` <`user-mail-address`>
 ;; Created: `(format-time-string "%B %d, %Y")`
 ;; Modified: `(format-time-string "%B %d, %Y")`

--- a/modules/lang/fsharp/README.org
+++ b/modules/lang/fsharp/README.org
@@ -31,9 +31,9 @@ This module adds [[https://fsharp.org/][F#]] support.
 ** Module Flags
 + =+lsp= Enables lsp-fsharp (this requires ~:tools lsp~ to be enabled).
 ** Plugins
-+ [[https://github.com/fsharp/emacs-fsharp-mod+e][fsharp-mode]]
++ [[https://github.com/fsharp/emacs-fsharp-mode][fsharp-mode]]
 + =+lsp=
-  + [[https://github.com/emacs-lsp/lsp-mode/blob/master/lsp-fsharp.el][lsp-fsharp]]
+  + [[https://github.com/emacs-lsp/lsp-mode/blob/master/clients/lsp-fsharp.el][lsp-fsharp]]
 ** Hacks
 None so far.
 
@@ -47,7 +47,7 @@ Do *NOT* install mono via brew. See this [[https://github.com/fsharp/FsAutoCompl
 sudo pacman -S mono
 #+END_SRC
 ** LSP
-The language server is automatically installed by [[https://github.com/emacs-lsp/lsp-mode/blob/master/lsp-fsharp.el][lsp-fsharp]].
+The language server is automatically installed by [[https://github.com/emacs-lsp/lsp-mode/blob/master/clients/lsp-fsharp.el][lsp-fsharp]].
 * Features
 An in-depth list of features, how to use them, and their dependencies.
 

--- a/modules/lang/julia/config.el
+++ b/modules/lang/julia/config.el
@@ -6,7 +6,7 @@
   (set-repl-handler! 'julia-mode #'+julia/open-repl)
 
   ;; Borrow matlab.el's fontification of math operators. From
-  ;; <https://ogbe.net/emacsconfig.html>
+  ;; <https://web.archive.org/web/20170326183805/https://ogbe.net/emacsconfig.html>
   (dolist (mode '(julia-mode ess-julia-mode))
     (font-lock-add-keywords
      mode

--- a/modules/ui/doom/README.org
+++ b/modules/ui/doom/README.org
@@ -42,7 +42,7 @@ Although this module uses the ~doom-one~ theme by default, [[https://github.com/
 + *doom-one:* doom-themes' flagship theme, inspired by [[https://atom.io/][Atom's]] One Dark themes
 + *doom-vibrant:* a more vibrant version of doom-one
 + *doom-molokai:* based on Textmate's monokai
-+ *doom-nova:* adapted from [[https://trevordmiller.com/projects/nova][Nova]]
++ *doom-nova:* adapted from [[https://github.com/trevordmiller/nova-colors][Nova]]
 + *doom-one-light:* light version of doom-one
 + *doom-peacock:* based on Peacock from [[https://daylerees.github.io/][daylerees' themes]]
 + *doom-tomorrow-night:* by [[https://github.com/ChrisKempson/Tomorrow-Theme][Chris Kempson]]

--- a/modules/ui/unicode/README.org
+++ b/modules/ui/unicode/README.org
@@ -61,7 +61,7 @@ If your font does not provide some glyphs, this package will try its best to fin
 A list of fonts with good unicode coverage can be found on the page of the [[https://github.com/rolandwalker/unicode-fonts#minimum-useful-fonts][unicode-fonts]] package.
 
 ** Advanced configuration
-Consult the [[https://github.com/rolandwalker/unicode-font][unicode-fonts]] package documentation for a description of more advanced configuration. The configuration should be placed, as usual, in your private =config.el= wrapped in an ~(after! unicode-fonts)~ block. The variable ~unicode-fonts-blocks~ contains a list of all unicode block names and their character ranges. The default fonts to search for glyphs are in the variable ~unicode-fonts-block-font-mapping~.
+Consult the [[https://github.com/rolandwalker/unicode-fonts][unicode-fonts]] package documentation for a description of more advanced configuration. The configuration should be placed, as usual, in your private =config.el= wrapped in an ~(after! unicode-fonts)~ block. The variable ~unicode-fonts-blocks~ contains a list of all unicode block names and their character ranges. The default fonts to search for glyphs are in the variable ~unicode-fonts-block-font-mapping~.
 
 If you want to use the font =Symbola= for =Miscellaneous Symbols=  by default you could add
 #+BEGIN_SRC elisp


### PR DESCRIPTION
There were a few other links below that I was unsure of how to handle, but I think this is a strict improvement.

```
http://www.culater.net/software/SIMBL/SIMBL.php
https://github.com/hlissner/dotfiles/tree/master/shell/mu
https://github.com/maskray/ccls/blob/master/src/symbol.h
https://gitweb.gentoo.org/repo/gentoo.git/tree/net-mail/mu/files/70mu-gentoo.el
```

