### PR TITLE
Fix crash on alist in emulation-mode-map-alists

### DIFF
--- a/core/core-lib.el
+++ b/core/core-lib.el
@@ -100,7 +100,7 @@ at the values with which this function was called."
       (lookup-key keymap keys)
     (cl-loop for keymap
              in (append (cl-loop for alist in emulation-mode-map-alists
-                                 if (boundp alist)
+                                 if (and (symbolp alist)(boundp alist))
                                  append (mapcar #'cdr (symbol-value alist)))
                         (list (current-local-map))
                         (mapcar #'cdr minor-mode-overriding-map-alist)


### PR DESCRIPTION
Emulation-Mode-Map-Alists can contain alists as well as symbols.
If it is a symbol, dont crash.