### PR TITLE
Bump org-journal

### DIFF
--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -54,7 +54,7 @@
 (when (featurep! +jupyter)
   (package! jupyter :pin "360cae2c70ab28c7a7848c0c56473d984f0243e5"))
 (when (featurep! +journal)
-  (package! org-journal :pin "c0836483ae43e525bf7547b7a789d171eda84c84"))
+  (package! org-journal :pin "08d5fce95023c015372678d353388ad0dae8952b"))
 (when (featurep! +noter)
   (package! org-noter :pin "9ead81d42dd4dd5074782d239b2efddf9b8b7b3d"))
 (when (featurep! +pomodoro)


### PR DESCRIPTION
## What

Bump org-journal by 2 commits:

[Here is the diff](https://github.com/bastibe/org-journal/compare/c0836483ae43e525bf7547b7a789d171eda84c84...08d5fce95023c015372678d353388ad0dae8952b).

## Why

For the adventurous souls using emacs devel, a [change](https://github.com/emacs-mirror/emacs/commit/32c6732d16385f242b1109517f25e9aefd6caa5c) introduced recently broke some libraries. Org-journal people already fixed the issue, hence why it needs to be bumped.

More details on [Reddit](https://www.reddit.com/r/emacs/comments/kqb9s9/cannot_recompile_packagess_error_wrong_number_of/).