### PR TITLE
Fix path separator in msys2

### DIFF
--- a/core/core-projects.el
+++ b/core/core-projects.el
@@ -145,10 +145,10 @@ c) are not valid projectile projects."
                     projectile-project-root-files)
             projectile-project-root-files-bottom-up nil)))
 
-  ;; Some utilities have issues with windows-style paths in MSYS, so emit
-  ;; unix-style paths instead.
+  ;; Some MSYS utilities auto expanded the `/' path separator, so we need to prevent it.
   (when IS-WINDOWS
-    (setenv "MSYS_NO_PATHCONV" "1"))
+    (setenv "MSYS_NO_PATHCONV" "1") ; Fix path in Git Bash
+    (setenv "MSYS2_ARG_CONV_EXCL" "--path-separator")) ; Fix path in MSYS2
 
   ;; HACK Don't rely on VCS-specific commands to generate our file lists. That's
   ;;      7 commands to maintain, versus the more generic, reliable and
@@ -185,7 +185,7 @@ And if it's a function, evaluate it."
            ;; Otherwise, resort to ripgrep, which is also faster than find
            ((executable-find "rg" t)
             (concat "rg -0 --files --follow --color=never --hidden -g!.git"
-                    (if IS-WINDOWS " --path-separator /")))
+                    (if IS-WINDOWS " --path-separator=/")))
            ("find . -type f -print0"))))
 
   (defadvice! doom--projectile-default-generic-command-a (orig-fn &rest args)

--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -222,15 +222,6 @@ results buffer.")
   (when (stringp counsel-rg-base-command)
     (setq counsel-rg-base-command (split-string counsel-rg-base-command)))
 
-  ;; REVIEW Fix #3215: prevents mingw on Windows throwing an error trying to
-  ;;        expand / to an absolute path. Remove this when it is fixed upstream
-  ;;        in counsel.
-  (when (and (memq system-type '(windows-nt ms-dos))
-             (listp counsel-rg-base-command)
-             (member "--path-separator" counsel-rg-base-command))
-    (setf (cadr (member "--path-separator" counsel-rg-base-command))
-          "/"))
-
   ;; Integrate with `helpful'
   (setq counsel-describe-function-function #'helpful-callable
         counsel-describe-variable-function #'helpful-variable)
@@ -299,7 +290,7 @@ results buffer.")
                        (cl-loop for dir in projectile-globally-ignored-directories
                                 collect "--glob"
                                 collect (concat "!" dir))
-                       (if IS-WINDOWS (list "--path-separator" "/"))))
+                       (if IS-WINDOWS '("--path-separator=/"))))
               ((cons find-program args)))
       (unless (listp args)
         (user-error "`counsel-file-jump-args' is a list now, please customize accordingly."))


### PR DESCRIPTION
Fix #3215 
With 523e945a3ae2347bae556ec4fe367d03ffddf8f0 we only prevent path auto expand in Git Bash.
To fix this on MSYS2, we need `MSYS2_ARG_CONV_EXCL=--path-separator`.
We need no space between `--path-separator` and `/` otherwise it still get auto expanded.
Detail https://github.com/sharkdp/fd/issues/537#issuecomment-636422669