### PR TITLE
Bump org-mode

### DIFF
--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -19,7 +19,7 @@
              (insert "(fset 'org-release (lambda () \"9.5\"))\n"
                      "(fset 'org-git-version #'ignore)\n"
                      "(provide 'org-version)\n")))
-  :pin "6b83c6e4eaec4af47a90d05c3410d4637d8cb8da"
+  :pin "3916a574063887f145af2e42667fb6478a065440"
   ;; Prevents built-in Org from sneaking into the byte-compilation of
   ;; `org-plus-contrib', and inform other packages that `org-mode' satisfies the
   ;; `org' dependency: https://github.com/raxod502/straight.el/issues/352


### PR DESCRIPTION
emacs-straight/org-mode@3916a5 <- emacs-straight/org-mode@6b83c6

Known to have the fix for https://github.com/hlissner/doom-emacs/issues/4534