### PR TITLE
Add shortcuts and descriptions for GDScript module

### DIFF
--- a/modules/lang/gdscript/config.el
+++ b/modules/lang/gdscript/config.el
@@ -20,15 +20,23 @@
         :map gdscript-mode-map
 
         (:prefix ("r" . "run")
-         "e" #'gdscript-godot-open-project-in-editor
-         "p" #'gdscript-godot-run-project
-         "d" #'gdscript-godot-run-project-debug
-         "s" #'gdscript-godot-run-current-scene)
+         :desc "Open project in Godot" "e" #'gdscript-godot-open-project-in-editor
+         :desc "Run project" "p" #'gdscript-godot-run-project
+         :desc "Run debug" "d" #'gdscript-godot-run-project-debug
+         :desc "Run current scene" "s" #'gdscript-godot-run-current-scene)
+
+        (:prefix ("d" . "debug")
+         :desc "Add breakpoint" "a"  #'gdscript-debug-add-breakpoint
+         :desc "Display breakpoint buffer" "b" #'gdscript-debug-display-breakpoint-buffer
+         :desc "Remove breakpoint" "d" #'gdscript-debug-remove-breakpoint
+         :desc "Continue execution" "c" #'gdscript-debug-continue
+         :desc "Next" "n" #'gdscript-debug-next
+         :desc "Step" "s" #'gdscript-debug-step)
 
         (:prefix ("h" . "help")
-         "b" #'gdscript-docs-browse-api
-         "f" #'gdscript-docs-browse-symbol-at-point)
+         :desc "Browse online API" "b" #'gdscript-docs-browse-api
+         :desc "Browse API at point" "f" #'gdscript-docs-browse-symbol-at-point)
 
         (:prefix ("f" . "format")
-         "b" #'gdscript-format-buffer
-         "r" #'gdscript-format-region)))
+         :desc "Format buffer" "b" #'gdscript-format-buffer
+         :desc "Format region" "r" #'gdscript-format-region)))


### PR DESCRIPTION
Added shortcuts for the new debugger support (add, remove breakpoint, continue execution...)

Also added descriptions for existing shortcuts, which should be more readable than the command named ("gdscript-debug-breakpoint-...")