### PR TITLE
smartparens: more electricity for C-style comments

### DIFF
--- a/modules/config/default/config.el
+++ b/modules/config/default/config.el
@@ -164,7 +164,7 @@
       ;; Needed so downstream `advice'
       ;; (`+default--newline-indent-and-continue-comments-a') can receive the
       ;; prefix ARG for some reaosn.
-      (interactive "*P")
+      (interactive "*p")
       ;; `javascript-mode' uses `c-do-auto-fill'. For the other cases,
       ;; `c-literal-limits' only works in cc buffers, erroring otherwise.
       (when (and (or c-buffer-is-cc-mode (derived-mode-p 'javascript-mode 'js2-mode)))
@@ -268,7 +268,7 @@ Useful in `smartparens' pairs."
 Continues comments if executed from a commented line. Consults
 `doom-point-in-comment-functions' to determine if in a comment."
   :before-until #'newline-and-indent
-  (interactive "*P")
+  (interactive "*p")
   (when (and +default-want-RET-continue-comments
              (doom-point-in-comment-p)
              (fboundp comment-line-break-function))

--- a/modules/config/default/config.el
+++ b/modules/config/default/config.el
@@ -167,7 +167,7 @@
       (interactive "*p")
       ;; `javascript-mode' uses `c-do-auto-fill'. For the other cases,
       ;; `c-literal-limits' only works in cc buffers, erroring otherwise.
-      (when (and (or c-buffer-is-cc-mode (derived-mode-p 'javascript-mode 'js2-mode)))
+      (when (or c-buffer-is-cc-mode (derived-mode-p 'javascript-mode 'js2-mode))
         (when-let ((bounds (c-literal-limits)))
           (when (and
                  (eq (c-literal-type bounds) 'c)
@@ -195,8 +195,8 @@ Useful in `smartparens' pairs."
       (save-excursion (insert " ")))
     (sp-local-pair
      '(js2-mode typescript-mode rjsx-mode rust-mode c-mode c++-mode objc-mode
-       csharp-mode java-mode php-mode css-mode scss-mode less-css-mode
-       stylus-mode scala-mode)
+                csharp-mode java-mode php-mode css-mode scss-mode less-css-mode
+                stylus-mode scala-mode)
      "/*" "*/"
      :actions '(insert)
      :post-handlers '(+default-comment-spacing

--- a/modules/config/default/config.el
+++ b/modules/config/default/config.el
@@ -3,6 +3,10 @@
 (defvar +default-want-RET-continue-comments t
   "If non-nil, RET will continue commented lines.")
 
+(defvar +default-want-comment-end-on-new-line t
+  "If non-nil, RET will put */ on its own line.
+/* | */ RET -> /* \n * |\n*/.")
+
 (defvar +default-minibuffer-maps
   (append '(minibuffer-local-map
             minibuffer-local-ns-map
@@ -245,7 +249,8 @@ Continues comments if executed from a commented line. Consults
              (fboundp comment-line-break-function))
     (dotimes (_ (or arg 1))
       (funcall comment-line-break-function nil))
-    (when (and (derived-mode-p 'c-mode 'c++-mode 'objc-mode 'rust-mode
+    (when (and +default-want-comment-end-on-new-line
+               (derived-mode-p 'c-mode 'c++-mode 'objc-mode 'rust-mode
                                'java-mode 'javascript-mode 'js2-mode)
                (looking-at-p "[[:space:]]*\\*+/"))
       (save-excursion

--- a/modules/config/default/config.el
+++ b/modules/config/default/config.el
@@ -202,7 +202,7 @@ Useful in `smartparens' pairs."
      :post-handlers '(+default-comment-spacing
                       ("[d-2]* |" "*")
                       ("[d-2]! |" "!")
-                      ("||\n" "RET")))
+                      ("||\n[i]" "RET")))
 
     (after! smartparens-ml
       (sp-with-modes '(tuareg-mode fsharp-mode)


### PR DESCRIPTION
- `/*` = `/* | */`
- `/*[*!]` = `/*[*!] | */`
- `/* C-6 *` = 6 stars

Typing `/**/` now yields `/* | */`, saving the user a single space keypress.
Then typing * or ! puts them at the start of the comment, i.e. /\*! =
/**! | \*/, with /* | */ as intermediate step (somewhat like
`lispy-comment`).

Expand JavaDoc and Doxygen Qt-style comments (/** \*/ and /*\*! \*/
respectively) automatically if the user invokes `newline-and-indent`
within such a comment: /** | \*/ + RET -> /**\n * |\n */. This is only
done for JavaDoc comments that are not yet expanded, such comments being
defined as spanning not more than one line.

`+default--newline-and-indent` now respects the prefix argument: /* C-6
RET now correctly yields 6 stars. This also works with JavaDoc comment
expansion.

Drop the `smartparens` pairs for /** and /\*!, since they are now handled
by /*. Drop `+default-open-doc-comments-block`, since it is unused.


----

#