### PR TITLE
Enable highlight of current line in org agenda

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -73,6 +73,7 @@ Is relative to `org-directory', unless it is absolute. Is used in Doom's default
 (defun +org-init-agenda-h ()
   (unless org-agenda-files
     (setq-default org-agenda-files (list org-directory)))
+  (pushnew! global-hl-line-modes 'org-agenda-mode)
   (setq-default
    ;; Different colors for different priority levels
    org-agenda-deadline-faces


### PR DESCRIPTION
This did not work previously since `org-agenda-mode` does not derive from any of the mode in  `global-hl-line-modes`.