### PR TITLE
company: support `prescient`

### DIFF
--- a/modules/completion/company/README.org
+++ b/modules/completion/company/README.org
@@ -30,11 +30,14 @@ https://assets.doomemacs.org/completion/company/overlay.png
 + =+tng= Enables completion using only ~TAB~. Pressing ~TAB~ will select the
   next completion suggestion, while ~S-TAB~ will select the previous one. *This
   is incompatible with the =+childframe= flag*
++ =+prescient+= Enable completion candidate sorting based on previous
+  completions using =company-prescient=.
 
 ** Plugins
 + [[https://github.com/company-mode/company-mode][company-mode]]
 + [[https://github.com/hlissner/emacs-company-dict][company-dict]]
 + [[https://github.com/sebastiencs/company-box][company-box]]* (=+childframe=)
++ [[https://github.com/raxod502/prescient.el][company-prescient]]* (=+prescient=)
 
 * Prerequisites
 This module has no direct prerequisites.

--- a/modules/completion/company/config.el
+++ b/modules/completion/company/config.el
@@ -174,3 +174,7 @@
       (if (symbol-value mode)
           (add-to-list 'company-dict-minor-mode-list mode nil #'eq)
         (setq company-dict-minor-mode-list (delq mode company-dict-minor-mode-list))))))
+
+(use-package! company-prescient
+  :after company
+  :config (company-prescient-mode +1))

--- a/modules/completion/company/packages.el
+++ b/modules/completion/company/packages.el
@@ -5,3 +5,5 @@
 (package! company-dict :pin "cd7b8394f6014c57897f65d335d6b2bd65dab1f4")
 (when (featurep! +childframe)
   (package! company-box :pin "be37a9a30dc112ab172af21af694e2cb04a74f85"))
+(when (featurep! +prescient)
+  (package! company-prescient :pin "5d139e5b1fe03ccaddff8c250ab8e9d795071b95"))


### PR DESCRIPTION
As with the `ivy` module, `+prescient` enables `prescient`-based sorting for
`company` using `company-prescient`.


----

#