### PR TITLE
Fix typo

### DIFF
--- a/core/cli/packages.el
+++ b/core/cli/packages.el
@@ -356,7 +356,7 @@ declaration) or dependency thereof that hasn't already been."
                                       if (or (if want-byte-compile   (doom--elc-file-outdated-p file))
                                              (if want-native-compile (doom--eln-file-outdated-p file)))
                                       do (setq outdated t)
-                                         (when want-native
+                                         (when want-native-compile
                                            (push file doom--eln-output-expected))
                                       finally return outdated))
                          (puthash package t straight--packages-to-rebuild))))


### PR DESCRIPTION
`want-byte` and `want-native` was renamed `want-byte-compile` and `want-native-compile` in commit cfb8a866dc6181889b0c056abf4fdd3f34fb144b, but one `want-native` was not updated, leading to void-variable error while `doom sync`.