### PR TITLE
Bump inflections to get extra argument to define-obsolete-function-alias

### DIFF
--- a/modules/lang/ruby/README.org
+++ b/modules/lang/ruby/README.org
@@ -45,7 +45,7 @@ This module add Ruby and optional Ruby on Rails support to Emacs.
 + [[https://github.com/pezra/rspec-mode][rspec-mode]]
 + [[https://github.com/arthurnn/minitest-emacs][minitest]]
 + [[https://github.com/asok/projectile-rails][projectile-rails]] (=+rails=)
-+ [[https://github.com/eschulte/jump.el/tree/e4f1372cf22e811faca52fc86bdd5d817498a4d8][inflections]]
++ [[https://github.com/eschulte/jump.el/tree/55caa66a7cc6e0b1a76143fd40eff38416928941][inflections]]
 + [[https://github.com/plexus/chruby.el][chruby]] (=+chruby=)
 
 ** Hacks

--- a/modules/lang/ruby/packages.el
+++ b/modules/lang/ruby/packages.el
@@ -33,4 +33,4 @@
 ;; Rails
 (when (featurep! +rails)
   (package! projectile-rails :pin "7a256b1b1444fe0001f97095d99252e946dd9777")
-  (package! inflections :pin "e4f1372cf22e811faca52fc86bdd5d817498a4d8"))
+  (package! inflections :pin "55caa66a7cc6e0b1a76143fd40eff38416928941"))


### PR DESCRIPTION
Similar to https://github.com/hlissner/doom-emacs/issues/4534. I could build doom with the current Emacs 28.0.50 native-comp branch after this without problems. 