### PR TITLE
Fix for "Discover projects in folder"

### DIFF
--- a/modules/config/default/autoload/files.el
+++ b/modules/config/default/autoload/files.el
@@ -50,11 +50,11 @@ If prefix ARG is non-nil, prompt for the search path."
       (letf! (defun projectile-add-known-project (project-root)
                (unless (projectile-ignored-project-p project-root)
                  (funcall projectile-add-known-project project-root)
-                 (message "Added %S to known project roots")))
+                 (message "Added %S to known project roots" project-root)))
         (dolist (dir projectile-project-search-path)
           (if (not (file-accessible-directory-p dir))
-              (message "%S was inaccessible and couldn't searched")
-            (projectile-discover-projects-in-directory projectile-project-search-path)))))))
+              (message "%S was inaccessible and couldn't searched" dir)
+            (projectile-discover-projects-in-directory dir)))))))
 
 ;;;###autoload
 (defun +default/dired (arg)


### PR DESCRIPTION
Given the following config:
`(setq projectile-project-search-path '("~/src/"))`

I ran into a few errors when attempting to discover projects. This is my first contribution, and my Lisp skills are not strong so if there's something I'm missing please let me know. 