### PR TITLE
Remap `describe-symbol` to `counsel-describe-symbol` .

### DIFF
--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -225,8 +225,7 @@ results buffer.")
 
   ;; Integrate with `helpful'
   (setq counsel-describe-function-function #'helpful-callable
-        counsel-describe-variable-function #'helpful-variable
-        counsel-describe-symbol-function #'helpful-symbol)
+        counsel-describe-variable-function #'helpful-variable)
 
   ;; Decorate `doom/help-custom-variable' results the same way as
   ;; `counsel-describe-variable' (adds value and docstring columns).

--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -184,6 +184,7 @@ results buffer.")
     [remap describe-face]            #'counsel-faces
     [remap describe-function]        #'counsel-describe-function
     [remap describe-variable]        #'counsel-describe-variable
+    [remap describe-symbol]          #'counsel-describe-symbol
     [remap evil-ex-registers]        #'counsel-evil-registers
     [remap evil-show-marks]          #'counsel-mark-ring
     [remap execute-extended-command] #'counsel-M-x
@@ -224,7 +225,8 @@ results buffer.")
 
   ;; Integrate with `helpful'
   (setq counsel-describe-function-function #'helpful-callable
-        counsel-describe-variable-function #'helpful-variable)
+        counsel-describe-variable-function #'helpful-variable
+        counsel-describe-symbol-function #'helpful-symbol)
 
   ;; Decorate `doom/help-custom-variable' results the same way as
   ;; `counsel-describe-variable' (adds value and docstring columns).


### PR DESCRIPTION
"SPC h o" now uses `counsel-describe-symbol` instead of plain `helpful-symbol` (maybe with completion) to get input.

This allows us to fully take the advantage of ivy's superior completion system:

- `[I]: info` and `[d]: definition` hydra heads in `ivy-dispatching-done`

- Quickly describe symbols with "C-M-n/p" (`ivy-next(or previous)-line-and-call` or with the `calling` hydra head on

Additionally the counsel one is prettier when icons are enabled.

Users who have the `+icons` flag with ivy are expected to notice the change visually when invoking "o" in help-map as icons now appear there. But it's an arguably good change anyway since originally "f1 f" and "f1 v" have icons but "f1 o" doesn't.