### PR TITLE
allow opt-out for automatic lsp/tide

### DIFF
--- a/modules/lang/javascript/README.org
+++ b/modules/lang/javascript/README.org
@@ -31,6 +31,8 @@ This module adds JavaScript and TypeScript support.
 + =+lsp= Enables LangServer support for this module. You must have =:tools lsp=
   enabled for this to work, as well as the langserver (e.g.
   typescript-language-server) installed on your system.
++ =-lsp-or-tide= Disables auto-starting LangServer. Useful if you are editing
+  many projects simultaneously
 
 ** Packages
 + [[https://github.com/defunkt/coffee-mode][coffee-mode]]

--- a/modules/lang/javascript/config.el
+++ b/modules/lang/javascript/config.el
@@ -144,34 +144,36 @@
 ;;
 ;;; Tools
 
-(add-hook! '(js2-mode-local-vars-hook
-             typescript-mode-local-vars-hook
-             typescript-tsx-mode-local-vars-hook
-             web-mode-local-vars-hook
-             rjsx-mode-local-vars-hook)
-  (defun +javascript-init-lsp-or-tide-maybe-h ()
-    "Start `lsp' or `tide' in the current buffer.
+(defun +javascript-init-lsp-or-tide-maybe-h ()
+  "Start `lsp' or `tide' in the current buffer.
 
 LSP will be used if the +lsp flag is enabled for :lang javascript AND if the
 current buffer represents a file in a project.
 
 If LSP fails to start (e.g. no available server or project), then we fall back
 to tide."
-    (let ((buffer-file-name (buffer-file-name (buffer-base-buffer))))
-      (when (derived-mode-p 'js-mode 'typescript-mode 'typescript-tsx-mode)
-        (if (not buffer-file-name)
-            ;; necessary because `tide-setup' and `lsp' will error if not a
-            ;; file-visiting buffer
-            (add-hook 'after-save-hook #'+javascript-init-lsp-or-tide-maybe-h nil 'local)
-          (or (and (featurep! +lsp) (lsp!))
-              ;; fall back to tide
-              (if (executable-find "node")
-                  (and (require 'tide nil t)
-                       (progn (tide-setup) tide-mode))
-                (ignore
-                 (doom-log "Couldn't start tide because 'node' is missing"))))
-          (remove-hook 'after-save-hook #'+javascript-init-lsp-or-tide-maybe-h 'local))))))
+  (let ((buffer-file-name (buffer-file-name (buffer-base-buffer))))
+    (when (derived-mode-p 'js-mode 'typescript-mode 'typescript-tsx-mode)
+      (if (not buffer-file-name)
+          ;; necessary because `tide-setup' and `lsp' will error if not a
+          ;; file-visiting buffer
+          (add-hook 'after-save-hook #'+javascript-init-lsp-or-tide-maybe-h nil 'local)
+        (or (and (featurep! +lsp) (lsp!))
+            ;; fall back to tide
+            (if (executable-find "node")
+                (and (require 'tide nil t)
+                     (progn (tide-setup) tide-mode))
+              (ignore
+               (doom-log "Couldn't start tide because 'node' is missing"))))
+        (remove-hook 'after-save-hook #'+javascript-init-lsp-or-tide-maybe-h 'local)))))
 
+(unless (featurep! -lsp-or-tide)
+  (add-hook! '(js2-mode-local-vars-hook
+             typescript-mode-local-vars-hook
+             typescript-tsx-mode-local-vars-hook
+             web-mode-local-vars-hook
+             rjsx-mode-local-vars-hook)
+             #'+javascript-init-lsp-or-tide-maybe-h))
 
 (use-package! tide
   :defer t


### PR DESCRIPTION
In the past, when editing many, many projects simultaneously, I've noticed that I've accumulated dozens of running tideserver processes, which were starting to consume nontrivial amounts of memory. Given that I don't often take advantage of tide, I prefer to start it only if I want it.

This change adds a `-lsp-or-tide` flag to disable automatically starting the langserver.

I noted that you didn't take #929. However, this version preserves the default behavior. It's opt-out, not opt-in.

Arguably `-lsp-or-tide` is a bad name. I just kinda copied the name from the hook I was changing. Possible better names include:

- `-auto-lsp-or-tide`
- `-auto-langserver`
