### PR TITLE
Refactor doom/help-packages

### DIFF
--- a/core/autoload/help.el
+++ b/core/autoload/help.el
@@ -513,11 +513,8 @@ If prefix arg is present, refresh the cache."
 
            (package--print-help-section "Build")
            (let ((default-directory (straight--repos-dir (symbol-name package))))
-             (if
-                 (file-exists-p default-directory)
-                 (insert
-                  (cdr
-                   (doom-call-process "git" "log" "-1" "--format=%D %h %ci")))
+             (if (file-exists-p default-directory)
+                 (insert (cdr (doom-call-process "git" "log" "-1" "--format=%D %h %ci")))
                (insert "n/a")))
            (insert "\n" indent)
 


### PR DESCRIPTION
Hey there! Here's my work on the doom/help-packages function and the helper for inserting buttons. It fixes a bunch of bugs and oddities in the buffer content, and hopefully doesn't introduce too many more. I've also tried to generally improve readability and formatting where I can. 

I'm sure there are plenty more ways to improve this still. One idea I had would be to pull some data out of the package-desc structs like describe-package does. Currently packages from [M]elpa don't have a summary or description like they do in describe-package.

I'm still pretty new to lisp, and this is my first big contribution to Doom, so please let me know what I can improve!