### PR TITLE
Fix interactive doom/retab.

### DIFF
--- a/core/autoload/text.el
+++ b/core/autoload/text.el
@@ -251,7 +251,7 @@ the value of `indent-tab-mode'.
 
 If ARG (universal argument) is non-nil, retab the current buffer using the
 opposite indentation style."
-  (interactive "Pr")
+  (interactive "P\nr")
   (unless (and beg end)
     (setq beg (point-min)
           end (point-max)))

--- a/modules/editor/evil/autoload/evil.el
+++ b/modules/editor/evil/autoload/evil.el
@@ -123,7 +123,7 @@ the only window, use evil-window-move-* (e.g. `evil-window-move-far-left')."
   "Wrapper around `doom/retab'."
   :motion nil :move-point nil :type line
   (interactive "<r>")
-  (doom/retab beg end))
+  (doom/retab nil beg end))
 
 ;;;###autoload (autoload '+evil:narrow-buffer "editor/evil/autoload/evil" nil t)
 (evil-define-operator +evil:narrow-buffer (beg end &optional bang)


### PR DESCRIPTION
Both `+evil:retab` and `doom/retab` are currently broken when used interactively. This PR fixes these issues and makes both commands behave like intended.