### PR TITLE
bump adaptive-wrap

### DIFF
--- a/modules/editor/word-wrap/packages.el
+++ b/modules/editor/word-wrap/packages.el
@@ -1,4 +1,4 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; editor/word-wrap/packages.el
 
-(package! adaptive-wrap :pin "8f60ee70d6eadb0ddae206a0310505195e7ba0d8")
+(package! adaptive-wrap :pin "91e939b48a8129f696f45a7a3963fe09cbfa3a2d")

--- a/modules/lang/latex/packages.el
+++ b/modules/lang/latex/packages.el
@@ -2,7 +2,7 @@
 ;;; lang/latex/packages.el
 
 (package! auctex :pin "fb062a364fbc7d791707ff574b0f0a7f4c7a7269")
-(package! adaptive-wrap :pin "8f60ee70d6eadb0ddae206a0310505195e7ba0d8")
+(package! adaptive-wrap :pin "91e939b48a8129f696f45a7a3963fe09cbfa3a2d")
 (package! latex-preview-pane :pin "5297668a89996b50b2b62f99cba01cc544dbed2e")
 (when (featurep! :editor evil +everywhere)
   (package! evil-tex :pin "ac313efb22d621c093d8d30233bd7dc8b4cc54b4"))


### PR DESCRIPTION
Handle non-symbol values of `face` property and don't require `easymenu`