### PR TITLE
Extract program name from inferior-lisp-program

### DIFF
--- a/modules/lang/common-lisp/doctor.el
+++ b/modules/lang/common-lisp/doctor.el
@@ -1,6 +1,7 @@
 ;;; lang/common-lisp/doctor.el -*- lexical-binding: t; -*-
 
 (when (require 'sly nil t)
-  (unless (executable-find inferior-lisp-program)
-    (warn! "Couldn't find your `inferior-lisp-program' (%s). Is it installed?"
-           inferior-lisp-program)))
+  (let ((prog-name (car (split-string inferior-lisp-program))))
+    (unless (executable-find prog-name)
+      (warn! "Couldn't find your `inferior-lisp-program' (%s). Is it installed?"
+             inferior-lisp-program))))


### PR DESCRIPTION
Many users of sly also use roswell and set the inferior-lisp-program to
values like "ros run" or "ros -Q run". This is not detected correctly by
executable-find. Hence we try to extract the first part of the program
name.