### PR TITLE
Add ielm-mode to lispy module

### DIFF
--- a/modules/editor/lispy/config.el
+++ b/modules/editor/lispy/config.el
@@ -3,6 +3,7 @@
 (use-package! lispy
   :hook ((lisp-mode . lispy-mode)
          (emacs-lisp-mode . lispy-mode)
+         (ielm-mode . lispy-mode)
          (scheme-mode . lispy-mode)
          (racket-mode . lispy-mode)
          (hy-mode . lispy-mode)


### PR DESCRIPTION
I think lispy module should have `ielm-mode` included in hooks

fix #4625 