### PR TITLE
[feature] Better CIDER debugging

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -86,6 +86,14 @@
            (with-current-buffer nrepl-server-buffer
              (buffer-string)))))))
 
+  ;; When in cider-debug-mode, override evil keys to not interfere with debug keys
+  (after! evil
+    (add-hook! cider--debug-mode
+      (defun +clojure--cider-setup-debug ()
+        "Setup cider debug to override evil keys cleanly"
+        (evil-make-overriding-map cider--debug-mode-map 'normal)
+        (evil-normalize-keymaps))))
+
   ;; The CIDER welcome message obscures error messages that the above code is
   ;; supposed to be make visible.
   (setq cider-repl-display-help-banner nil)
@@ -98,6 +106,8 @@
             "C"  #'cider-connect-cljs
             "m"  #'cider-macroexpand-1
             "M"  #'cider-macroexpand-all
+            (:prefix ("d" . "debug")
+             "d" #'cider-debug-defun-at-point)
             (:prefix ("e" . "eval")
               "b" #'cider-eval-buffer
               "d" #'cider-eval-defun-at-point


### PR DESCRIPTION
The CIDER debugging experience needs a little bit of improvement.
This PR fixes some issues, in particular:

* Maps cider-debug-at-point to "localleader d d" - so that you can easily drop into debug!
* Overrides evil keybindings to not interfere with the cider--debug-mode
  bindings during the debug session - this overrides keys like 'j' and 'n' to allow you to 'inject expression' or 'step over'.

Thanks for a great editor Henrik!