### PR TITLE
Enabling user config override for org-id-locations-file

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -67,7 +67,8 @@ Is relative to `org-directory', unless it is absolute. Is used in Doom's default
 (defun +org-init-org-directory-h ()
   (unless org-directory
     (setq-default org-directory "~/org"))
-  (setq org-id-locations-file (expand-file-name ".orgids" org-directory)))
+  (unless org-id-locations-file
+    (setq org-id-locations-file (expand-file-name ".orgids" org-directory))))
 
 
 (defun +org-init-agenda-h ()
@@ -1047,6 +1048,7 @@ compelling reason, so..."
   ;; Set to nil so we can detect user changes to them later (and fall back on
   ;; defaults otherwise).
   (defvar org-directory nil)
+  (defvar org-id-locations-file nil)
   (defvar org-attach-id-dir nil)
 
   (setq org-publish-timestamp-directory (concat doom-cache-dir "org-timestamps/")


### PR DESCRIPTION
The use case: if a user has their org directory stored in a synced
location (e.g. dropbox), this file is the same on all machines and is
almost always conflicted.

Given that it is just a cache on the org file locations for IDs, this enables users to move this file out of the directory.

This change enables users to override this in the :init section of their
config (or otherwise before org loading) and that the
+org-init-org-directory-h hook will detect an override.