### PR TITLE
[doc: modules/lang/cc] Readability improvements

### DIFF
--- a/modules/lang/cc/README.org
+++ b/modules/lang/cc/README.org
@@ -95,13 +95,15 @@ After installing its dependencies (Clang and CMake), run ~M-x irony-install-serv
 *** macOS
 Due to linking issues, macOS users must compile irony-server manually:
 
-#+BEGIN_SRC sh
-$ brew install cmake
-$ brew install llvm
+~$ brew install cmake~ \\
+~$ brew install llvm~
 
-$ git clone https://github.com/Sarcasm/irony-mode irony-mode
-$ mkdir irony-mode/server/build
-$ pushd irony-mode/server/build
+#+BEGIN_SRC sh
+#!/bin/sh
+
+git clone https://github.com/Sarcasm/irony-mode irony-mode
+mkdir irony-mode/server/build
+pushd irony-mode/server/build
 
 DEST="$HOME/.emacs.d/.local/etc/irony-server/"
 cmake -DCMAKE_PREFIX_PATH=/usr/local/opt/llvm \
@@ -114,8 +116,8 @@ install_name_tool -change @rpath/libclang.dylib \
     "$DEST/bin/irony-server"
 
 # cleanup
-$ popd
-$ rm -rf irony-mode
+popd
+rm -rf irony-mode
 #+END_SRC
 
 ** rtags

--- a/modules/lang/cc/README.org
+++ b/modules/lang/cc/README.org
@@ -92,20 +92,19 @@ recommended.
 ** irony-server
 Irony powers the code completion, eldoc and syntax checking systems.
 
-After installing its dependencies (Clang and CMake), run ~M-x irony-install-server~ in Emacs.
+After installing its dependencies (Clang and CMake), run ~M-x
+irony-install-server~ in Emacs.
 
 *** macOS
 Due to linking issues, macOS users must compile irony-server manually:
 
-#+BEGIN_SRC sh :results output raw
+#+BEGIN_SRC sh
 brew install cmake
 brew install llvm
 git clone https://github.com/Sarcasm/irony-mode irony-mode
 #+END_SRC
 
-#+BEGIN_SRC bash :results output raw
-#!/bin/bash
-
+#+BEGIN_SRC bash
 mkdir irony-mode/server/build
 pushd irony-mode/server/build
 
@@ -131,7 +130,7 @@ available through your OS's package manager.
 This module will auto-start ~rdm~ when you open C/C++ buffers (so long as one
 isn't already running). If you prefer to run it yourself:
 
-#+BEGIN_SRC sh :results output raw
+#+BEGIN_SRC sh
 rdm &
 rc -J $PROJECT_ROOT  # loads PROJECT_ROOT's compile_commands.json
 #+END_SRC
@@ -146,12 +145,12 @@ For a more universal solution: both LSP servers and irony will recognize a
 [[https://sarcasm.github.io/notes/dev/compilation-database.html#ninja][compilation database]] (a ~compile_commands.json~ file). There are [[https://sarcasm.github.io/notes/dev/compilation-database.html][many ways to
 generate one]]. Here is an example using [[http://www.cmake.org/][CMake]] and [[https://github.com/rizsotto/Bear][bear]]:
 
-#+BEGIN_SRC sh :results output raw
+#+BEGIN_SRC sh
 # For CMake projects
 cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .
 #+END_SRC
 
-#+BEGIN_SRC sh :results output raw
+#+BEGIN_SRC sh
 # For non-CMake projects
 make clean
 bear make
@@ -186,11 +185,11 @@ environment variables.
 A workaround might be to install ~make~ via Homebrew which puts ~gmake~
 under ~/usr/local/~.
 
-#+BEGIN_SRC sh :results output raw
+#+BEGIN_SRC sh
 brew install make
 #+END_SRC
 
-#+BEGIN_SRC sh :results output raw
+#+BEGIN_SRC sh
 make clean
 bear gmake
 #+END_SRC

--- a/modules/lang/cc/README.org
+++ b/modules/lang/cc/README.org
@@ -78,12 +78,12 @@ recommended.
   - Linux:
     - Debian 11 & Ubuntu 20.10: ~# apt-get install clangd-11~
       - 20.04 LTS: [[https://pkgs.org/search/?q=clangd][clangd-10]]
-    - Fedora & CentOS/RHEL >=8: ~# dnf install clang-tools-extra~
+    - Fedora & CentOS/RHEL 8+: ~# dnf install clang-tools-extra~
     - openSUSE: ~# zypper install clang~
     - Arch: ~# pacman -S clang~
   - BSDs:
     - NetBSD & OpenBSD: ~# pkg_add clang-tools-extra~
-  - macOS: ~$ brew install llvm~ // 1gb+ installation! May take a while!
+  - macOS: ~$ brew install llvm~ // 1GB+ installation! May take a while!
   - Windows: use the win64 installer from [[https://releases.llvm.org/download.html][LLVM's GitHub release page]].
 + ccls :: Available in many OS' package managers as =ccls=. Otherwise, there are
   alternative install methods listed [[https://github.com/MaskRay/ccls/wiki/Install][in the project's wiki]].
@@ -97,13 +97,13 @@ After installing its dependencies (Clang and CMake), run ~M-x irony-install-serv
 *** macOS
 Due to linking issues, macOS users must compile irony-server manually:
 
-#+BEGIN_SRC sh
+#+BEGIN_SRC sh :results output raw
 brew install cmake
 brew install llvm
 git clone https://github.com/Sarcasm/irony-mode irony-mode
 #+END_SRC
 
-#+BEGIN_SRC bash
+#+BEGIN_SRC bash :results output raw
 #!/bin/bash
 
 mkdir irony-mode/server/build
@@ -131,7 +131,7 @@ available through your OS's package manager.
 This module will auto-start ~rdm~ when you open C/C++ buffers (so long as one
 isn't already running). If you prefer to run it yourself:
 
-#+BEGIN_SRC sh
+#+BEGIN_SRC sh :results output raw
 rdm &
 rc -J $PROJECT_ROOT  # loads PROJECT_ROOT's compile_commands.json
 #+END_SRC
@@ -146,10 +146,12 @@ For a more universal solution: both LSP servers and irony will recognize a
 [[https://sarcasm.github.io/notes/dev/compilation-database.html#ninja][compilation database]] (a ~compile_commands.json~ file). There are [[https://sarcasm.github.io/notes/dev/compilation-database.html][many ways to
 generate one]]. Here is an example using [[http://www.cmake.org/][CMake]] and [[https://github.com/rizsotto/Bear][bear]]:
 
-#+BEGIN_SRC sh
+#+BEGIN_SRC sh :results output raw
 # For CMake projects
 cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .
+#+END_SRC
 
+#+BEGIN_SRC sh :results output raw
 # For non-CMake projects
 make clean
 bear make
@@ -184,11 +186,11 @@ environment variables.
 A workaround might be to install ~make~ via Homebrew which puts ~gmake~
 under ~/usr/local/~.
 
-#+BEGIN_SRC sh
+#+BEGIN_SRC sh :results output raw
 brew install make
 #+END_SRC
 
-#+BEGIN_SRC sh
+#+BEGIN_SRC sh :results output raw
 make clean
 bear gmake
 #+END_SRC

--- a/modules/lang/cc/README.org
+++ b/modules/lang/cc/README.org
@@ -99,7 +99,7 @@ Due to linking issues, macOS users must compile irony-server manually:
 ~$ brew install llvm~
 
 #+BEGIN_SRC sh
-#!/bin/sh
+#!/bin/bash
 
 git clone https://github.com/Sarcasm/irony-mode irony-mode
 mkdir irony-mode/server/build

--- a/modules/lang/cc/README.org
+++ b/modules/lang/cc/README.org
@@ -95,13 +95,15 @@ After installing its dependencies (Clang and CMake), run ~M-x irony-install-serv
 *** macOS
 Due to linking issues, macOS users must compile irony-server manually:
 
-~$ brew install cmake~ \\
-~$ brew install llvm~
-
 #+BEGIN_SRC sh
+$ brew install cmake
+$ brew install llvm
+$ git clone https://github.com/Sarcasm/irony-mode irony-mode
+#+END_SRC
+
+#+BEGIN_SRC bash
 #!/bin/bash
 
-git clone https://github.com/Sarcasm/irony-mode irony-mode
 mkdir irony-mode/server/build
 pushd irony-mode/server/build
 

--- a/modules/lang/cc/README.org
+++ b/modules/lang/cc/README.org
@@ -11,8 +11,6 @@
   - [[#lsp-servers][LSP servers]]
   - [[#irony-server][irony-server]]
     - [[#macos][macOS]]
-    - [[#arch-linux][Arch Linux]]
-    - [[#opensuse][openSUSE]]
   - [[#rtags][rtags]]
 - [[#configure][Configure]]
   - [[#project-compile-settings][Project compile settings]]
@@ -75,13 +73,16 @@ This module's requirements change depending on how you use it.
 =lsp-mode= and =eglot= support a few LSP servers, but =clangd= and =ccls= are
 recommended.
 
-+ clangd (must be v9 or newer) :: Clangd is included with =llvm= which should be
++ clangd (must be v9 or newer) :: clangd is included with =llvm= which should be
   available through your OS' package manager.
-  - Debian/Ubuntu: ~sudo apt-get install clangd-9~
-  - macOS: ~brew install llvm~
-  - Windows: install from [[https://releases.llvm.org/download.html][LLVM download page]]
+  - Debian/Ubuntu: ~# apt-get install clangd-11~
+  - Fedora: ~# dnf install clang-tools-extra~
+  - openSUSE: ~# zypper install clang~
+  - Arch: ~# pacman -S clang~
   - clangd is available on some Linux distros from a =clang-tools= package, if
     you'd like to avoid the full =llvm=.
+  - macOS: ~$ brew install llvm~ // 1gb+ installation! May take a while!
+  - Windows: use the win64 installer from [[https://releases.llvm.org/download.html][LLVM's GitHub release page]].
 + ccls :: Available in many OS' package managers as =ccls=. Otherwise, there are
   alternative install methods listed [[https://github.com/MaskRay/ccls/wiki/Install][in the project's wiki]].
 + cmake-language-server :: available through ~pip~ on most distributions
@@ -89,18 +90,18 @@ recommended.
 ** irony-server
 Irony powers the code completion, eldoc and syntax checking systems.
 
-After installing its dependencies, run ~M-x irony-install-server~ in Emacs.
+After installing its dependencies (Clang and CMake), run ~M-x irony-install-server~ in Emacs.
 
 *** macOS
 Due to linking issues, macOS users must compile irony-server manually:
 
 #+BEGIN_SRC sh
-brew install cmake
-brew install llvm  # 1gb+ installation! May take a while!
+$ brew install cmake
+$ brew install llvm
 
-git clone https://github.com/Sarcasm/irony-mode irony-mode
-mkdir irony-mode/server/build
-pushd irony-mode/server/build
+$ git clone https://github.com/Sarcasm/irony-mode irony-mode
+$ mkdir irony-mode/server/build
+$ pushd irony-mode/server/build
 
 DEST="$HOME/.emacs.d/.local/etc/irony-server/"
 cmake -DCMAKE_PREFIX_PATH=/usr/local/opt/llvm \
@@ -113,18 +114,8 @@ install_name_tool -change @rpath/libclang.dylib \
     "$DEST/bin/irony-server"
 
 # cleanup
-popd
-rm -rf irony-mode
-#+END_SRC
-
-*** Arch Linux
-#+BEGIN_SRC sh
-pacman -S clang cmake
-#+END_SRC
-
-*** openSUSE
-#+BEGIN_SRC sh :dir /sudo::
-sudo zypper install clang cmake
+$ popd
+$ rm -rf irony-mode
 #+END_SRC
 
 ** rtags
@@ -151,11 +142,11 @@ generate one]]. Here is an example using [[http://www.cmake.org/][CMake]] and [[
 
 #+BEGIN_SRC sh
 # For CMake projects
-cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .
+$ cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .
 
 # For non-CMake projects
-make clean
-bear make
+$ make clean
+$ bear make
 #+END_SRC
 
 Use ~M-x +cc/reload-compile-db~ to reload your compile db in an already-open
@@ -188,12 +179,12 @@ A workaround might be to install ~make~ via Homebrew which puts ~gmake~
 under ~/usr/local/~.
 
 #+BEGIN_SRC sh
-brew install make
+$ brew install make
 #+END_SRC
 
 #+BEGIN_SRC sh
-make clean
-bear gmake
+$ make clean
+$ bear gmake
 #+END_SRC
 
 Additional info:

--- a/modules/lang/cc/README.org
+++ b/modules/lang/cc/README.org
@@ -98,9 +98,9 @@ After installing its dependencies (Clang and CMake), run ~M-x irony-install-serv
 Due to linking issues, macOS users must compile irony-server manually:
 
 #+BEGIN_SRC sh
-$ brew install cmake
-$ brew install llvm
-$ git clone https://github.com/Sarcasm/irony-mode irony-mode
+brew install cmake
+brew install llvm
+git clone https://github.com/Sarcasm/irony-mode irony-mode
 #+END_SRC
 
 #+BEGIN_SRC bash
@@ -119,7 +119,7 @@ install_name_tool -change @rpath/libclang.dylib \
     /usr/local/opt/llvm/lib/libclang.dylib \
     "$DEST/bin/irony-server"
 
-# cleanup
+# Cleanup
 popd
 rm -rf irony-mode
 #+END_SRC
@@ -148,11 +148,11 @@ generate one]]. Here is an example using [[http://www.cmake.org/][CMake]] and [[
 
 #+BEGIN_SRC sh
 # For CMake projects
-$ cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .
+cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .
 
 # For non-CMake projects
-$ make clean
-$ bear make
+make clean
+bear make
 #+END_SRC
 
 Use ~M-x +cc/reload-compile-db~ to reload your compile db in an already-open
@@ -185,12 +185,12 @@ A workaround might be to install ~make~ via Homebrew which puts ~gmake~
 under ~/usr/local/~.
 
 #+BEGIN_SRC sh
-$ brew install make
+brew install make
 #+END_SRC
 
 #+BEGIN_SRC sh
-$ make clean
-$ bear gmake
+make clean
+bear gmake
 #+END_SRC
 
 Additional info:

--- a/modules/lang/cc/README.org
+++ b/modules/lang/cc/README.org
@@ -75,12 +75,14 @@ recommended.
 
 + clangd (must be v9 or newer) :: clangd is included with =llvm= which should be
   available through your OS' package manager.
-  - Debian/Ubuntu: ~# apt-get install clangd-11~
-  - Fedora: ~# dnf install clang-tools-extra~
-  - openSUSE: ~# zypper install clang~
-  - Arch: ~# pacman -S clang~
-  - clangd is available on some Linux distros from a =clang-tools= package, if
-    you'd like to avoid the full =llvm=.
+  - Linux:
+    - Debian 11 & Ubuntu 20.10: ~# apt-get install clangd-11~
+      - 20.04 LTS: [[https://pkgs.org/search/?q=clangd][clangd-10]]
+    - Fedora & CentOS/RHEL >=8: ~# dnf install clang-tools-extra~
+    - openSUSE: ~# zypper install clang~
+    - Arch: ~# pacman -S clang~
+  - BSDs:
+    - NetBSD & OpenBSD: ~# pkg_add clang-tools-extra~
   - macOS: ~$ brew install llvm~ // 1gb+ installation! May take a while!
   - Windows: use the win64 installer from [[https://releases.llvm.org/download.html][LLVM's GitHub release page]].
 + ccls :: Available in many OS' package managers as =ccls=. Otherwise, there are


### PR DESCRIPTION
- _sudo_ should not be assumed, as _[doas](https://github.com/Duncaen/OpenDoas)_ is an optimal and more secure alternative for workstation use cases (sudo is suited for servers, where automation is important).
- ~~It's easier to tell if a line is a command by having $ (non-escalated) or # (escalated/root) before the command, as Arch Linux's wiki does by default.~~
This causes problems if you want to execute the command(s) directly in Emacs, see: \
http://howardism.org/Technical/Emacs/literate-devops.html (visual examples) \
https://orgmode.org/manual/Working-with-Source-Code.html