### PR TITLE
Correctly gate on deft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ var/
 *.fas
 *.dat
 *.eld
+*.eln

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -142,7 +142,8 @@
 
        :desc "Toggle last org-clock"          "c" #'+org/toggle-last-clock
        :desc "Cancel current org-clock"       "C" #'org-clock-cancel
-       :desc "Open deft"                      "d" #'deft
+       (:when (featurep! :ui deft)
+        :desc "Open deft"                    "d" #'deft)
        (:when (featurep! :lang org +noter)
         :desc "Org noter"                    "e" #'org-noter)
 

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -488,7 +488,8 @@
 
        :desc "Toggle last org-clock"        "c" #'+org/toggle-last-clock
        :desc "Cancel current org-clock"     "C" #'org-clock-cancel
-       :desc "Open deft"                    "d" #'deft
+       (:when (featurep! :ui deft)
+        :desc "Open deft"                    "d" #'deft)
        (:when (featurep! :lang org +noter)
         :desc "Org noter"                  "e" #'org-noter)
 


### PR DESCRIPTION
Does not provide a key binding for deft when it is not installed. Also ignores .eln files. 