### PR TITLE
native-comp: Add magit/git-commit/orgit to blackl.

### DIFF
--- a/core/core.el
+++ b/core/core.el
@@ -161,6 +161,9 @@ users).")
           (list (concat "\\`" (regexp-quote doom-autoloads-file) "\\'")
                 (concat local-dir-re ".*/evil-collection-vterm\\.el\\'")
                 (concat local-dir-re ".*/with-editor\\.el\\'")
+                (concat local-dir-re ".*/magit.*\\.el\\'")
+                (concat local-dir-re ".*/git-commit\\.el\\'")
+                (concat local-dir-re ".*/orgit\\.el\\'")
                 ;; https://github.com/nnicandro/emacs-jupyter/issues/297
                 (concat local-dir-re ".*/jupyter-channel\\.el\\'"))))
   ;; Default to using all cores, rather than half of them, since we compile


### PR DESCRIPTION
In their current state, the following packages result in a stuck doom
build "Waiting for N async jobs..." situation when using the `feature/native-comp` emacs branch:

- magit
- git-commit
- orgit

This PR adds those packages to the native-comp blacklist until the issues are
resolved.

Signed-off-by: Steven Lang <steven.lang.mz@gmail.com>
Resolves #4644, Resolves #4517, Resolves #4590