### PR TITLE
Update docs for nonstandard homebrew installation prefix.

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -240,18 +240,20 @@ to least recommended for Doom (based on compatibility).
 
 - [[https://github.com/d12frosted/homebrew-emacs-plus][emacs-plus]]:
   #+BEGIN_SRC bash
+  HOMEBREW_PREFIX=$(brew config | grep '^HOMEBREW_PREFIX:' | cut -f 2 -d' ')
   brew tap d12frosted/emacs-plus
   brew install emacs-plus
-  ln -s /usr/local/opt/emacs-plus/Emacs.app /Applications/Emacs.app
+  ln -s "$HOMEBREW_PREFIX/opt/Emacs.app" /Applications/Emacs.app
   #+END_SRC
 
 - [[https://bitbucket.org/mituharu/emacs-mac/overview][emacs-mac]] is another acceptable option. It offers slightly better integration
   with macOS, native emojis and better childframe support. However, at the time
   of writing, it [[https://github.com/railwaycat/homebrew-emacsmacport/issues/52][lacks multi-tty support]] (which impacts daemon usage):
   #+BEGIN_SRC bash
+  HOMEBREW_PREFIX=$(brew config | grep '^HOMEBREW_PREFIX:' | cut -f 2 -d' ')
   brew tap railwaycat/emacsmacport
   brew install emacs-mac --with-modules
-  ln -s /usr/local/opt/emacs-mac/Emacs.app /Applications/Emacs.app
+  ln -s "$HOMEBREW_PREFIX/opt/emacs-mac/Emacs.app" /Applications/Emacs.app
   #+END_SRC
 
 - [[https://formulae.brew.sh/formula/emacs][emacs]] is another acceptable option, **but does not provide a Emacs.app**:

--- a/modules/lang/cc/README.org
+++ b/modules/lang/cc/README.org
@@ -102,14 +102,15 @@ git clone https://github.com/Sarcasm/irony-mode irony-mode
 mkdir irony-mode/server/build
 pushd irony-mode/server/build
 
+HOMEBREW_PREFIX=$(brew config | grep '^HOMEBREW_PREFIX:' | cut -f 2 -d' ')
 DEST="$HOME/.emacs.d/.local/etc/irony-server/"
-cmake -DCMAKE_PREFIX_PATH=/usr/local/opt/llvm \
+cmake -DCMAKE_PREFIX_PATH="$HOMEBREW_PREFIX"/opt/llvm \
       -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON \
       -DCMAKE_INSTALL_PREFIX="$DEST" ../
 cmake --build . --use-stderr --config Release --target install
 
 install_name_tool -change @rpath/libclang.dylib \
-    /usr/local/opt/llvm/lib/libclang.dylib \
+    "$HOMEBREW_PREFIX"/opt/llvm/lib/libclang.dylib \
     "$DEST/bin/irony-server"
 
 # cleanup
@@ -185,7 +186,7 @@ environment variables.
 #+end_quote
 
 A workaround might be to install ~make~ via Homebrew which puts ~gmake~
-under ~/usr/local/~.
+under ~/usr/local/~ by default.
 
 #+BEGIN_SRC sh
 brew install make

--- a/modules/tools/lookup/README.org
+++ b/modules/tools/lookup/README.org
@@ -74,9 +74,10 @@ brew install ripgrep wordnet
 # An older version of sqlite is included in MacOS. If it causes you problems (and
 # folks have reported it will), install it through homebrew:
 brew install sqlite
-# Note that it's keg-only, meaning it isn't symlinked to /usr/local/bin. You'll
+# Note that it's keg-only, meaning it isn't symlinked to $HOMEBREW_PREFIX/bin. You'll
 # have to add it to PATH yourself (or symlink it into your PATH somewhere). e.g.
-export PATH="/usr/local/opt/sqlite/bin:$PATH"
+HOMEBREW_PREFIX=$(brew config | grep '^HOMEBREW_PREFIX:' | cut -f 2 -d' ')
+export PATH="$HOMEBREW_PREFIX/opt/sqlite/bin:$PATH"
 #+END_SRC
 
 ** Arch Linux


### PR DESCRIPTION
If one assumes the user has set up their .profile with a definition of
HOMEBREW_PREFIX per the homebrew instructions then we don't
need the initial command to get it from brew config.  
@hlissner I'd be glad of your input on how to proceed with this

Still TODO: update emacs-lisp that assumes standard homebrew installation prefix.

