### PR TITLE
Add support for parinfer-rust-mode

### DIFF
--- a/modules/editor/parinfer/README.org
+++ b/modules/editor/parinfer/README.org
@@ -17,7 +17,9 @@ https://raw.githubusercontent.com/DogLooksGood/parinfer-mode/a7c041454e05ec2b883
 More information can be found about it [[https://shaunlebron.github.io/parinfer/][in the project's documentation]].
 
 ** Module Flags
-This module provides no flags.
++ =+rust= Use [[github:justinbarclay/parinfer-rust-mode][parinfer-rust-mode]] instead of the now deprecated [[github:DogLooksGood/parinfer-mode][parinfer-mode]].
+  This depends on Emacs being compiled with the option `--with-modules`. The
+  pre-built library is only available for Linux, Windows and MacOS.
 
 ** Packages
 + [[https://github.com/DogLooksGood/parinfer-mode][parinfer]]

--- a/modules/editor/parinfer/config.el
+++ b/modules/editor/parinfer/config.el
@@ -33,17 +33,14 @@
           racket-mode
           hy-mode) . parinfer-rust-mode)
   :init
-  (setq! parinfer-rust-library
-         (concat user-emacs-directory
-                 ".local/etc/parinfer-rust/"
-                 (cond ((eq system-type 'darwin) "parinfer-rust-darwin.so")
-                       ((eq system-type 'gnu/linux) "parinfer-rust-linux.so")
-                       ((eq system-type 'windows-nt) "parinfer-rust-windows.dll")
-                       ((eq system-type 'berkeley-unix) "libparinfer_rust.so")))
-         parinfer-rust-auto-download
-         (if (eq system-type 'berkeley-unix)
-             nil
-           t))
+  (setq parinfer-rust-library
+        (concat user-emacs-directory
+                ".local/etc/parinfer-rust/"
+                (cond ((eq system-type 'darwin) "parinfer-rust-darwin.so")
+                      ((eq system-type 'gnu/linux) "parinfer-rust-linux.so")
+                      ((eq system-type 'windows-nt) "parinfer-rust-windows.dll")
+                      ((eq system-type 'berkeley-unix) "libparinfer_rust.so"))))
+  (setq parinfer-rust-auto-download (if (eq system-type 'berkeley-unix) nil t))
   :config
   (map! :map parinfer-rust-mode-map
         :localleader

--- a/modules/editor/parinfer/config.el
+++ b/modules/editor/parinfer/config.el
@@ -3,11 +3,11 @@
 (use-package! parinfer
   :unless (featurep! +rust)
   :hook ((emacs-lisp-mode
-            clojure-mode
-            scheme-mode
-            lisp-mode
-            racket-mode
-            hy-mode) . parinfer-mode)
+          clojure-mode
+          scheme-mode
+          lisp-mode
+          racket-mode
+          hy-mode) . parinfer-mode)
   :init
   (setq parinfer-extensions
         '(defaults

--- a/modules/editor/parinfer/config.el
+++ b/modules/editor/parinfer/config.el
@@ -1,24 +1,48 @@
 ;;; editor/parinfer/config.el -*- lexical-binding: t; -*-
 
-(use-package! parinfer
-  :hook ((emacs-lisp-mode
-          clojure-mode
-          scheme-mode
-          lisp-mode
-          racket-mode
-          hy-mode) . parinfer-mode)
-  :init
-  (setq parinfer-extensions
-        '(defaults
-          pretty-parens
-          smart-tab
-          smart-yank))
-  (when (featurep! :editor evil +everywhere)
-    (push 'evil parinfer-extensions))
-  :config
-  (map! :map parinfer-mode-map
-        "\"" nil  ; smartparens handles this
-        :i "<tab>"     #'parinfer-smart-tab:dwim-right-or-complete
-        :i "<backtab>" #'parinfer-smart-tab:dwim-left
-        :localleader
-        :desc "Toggle parinfer-mode" "m" #'parinfer-toggle-mode))
+(if (not (featurep! +rust))
+    (use-package! parinfer
+      :hook ((emacs-lisp-mode
+              clojure-mode
+              scheme-mode
+              lisp-mode
+              racket-mode
+              hy-mode) . parinfer-mode)
+      :init
+      (setq parinfer-extensions
+            '(defaults
+              pretty-parens
+              smart-tab
+              smart-yank))
+      (when (featurep! :editor evil +everywhere)
+        (push 'evil parinfer-extensions))
+      :config
+      (map! :map parinfer-mode-map
+            "\"" nil  ; smartparens handles this
+            :i "<tab>"     #'parinfer-smart-tab:dwim-right-or-complete
+            :i "<backtab>" #'parinfer-smart-tab:dwim-left
+            :localleader
+            :desc "Toggle parinfer-mode" "m" #'parinfer-toggle-mode))
+  (defvar parinfer-rust--doom-lib-name (cond ((eq system-type 'darwin)
+                                              "parinfer-rust-darwin.so")
+                                             ((eq system-type 'gnu/linux)
+                                              "parinfer-rust-linux.so")
+                                             ((eq system-type 'windows-nt)
+                                              "parinfer-rust-windows.dll")))
+  (use-package! parinfer-rust-mode
+    :hook ((emacs-lisp-mode
+            clojure-mode
+            scheme-mode
+            lisp-mode
+            racket-mode
+            hy-mode) . parinfer-rust-mode)
+    :init
+    (setq! parinfer-rust-library (concat user-emacs-directory
+                                         ".local/etc/parinfer-rust/"
+                                         parinfer-rust--doom-lib-name))
+    :config
+    (map! :map parinfer-rust-mode-map
+          :localleader
+          :desc "Switch parinfer-rust-mode" "m" #'parinfer-rust-switch-mode
+          :desc "Temporarily disable parinfer-rust-mode" "M"
+                #'parinfer-rust-switch-mode)))

--- a/modules/editor/parinfer/config.el
+++ b/modules/editor/parinfer/config.el
@@ -1,48 +1,51 @@
 ;;; editor/parinfer/config.el -*- lexical-binding: t; -*-
 
-(if (not (featurep! +rust))
-    (use-package! parinfer
-      :hook ((emacs-lisp-mode
-              clojure-mode
-              scheme-mode
-              lisp-mode
-              racket-mode
-              hy-mode) . parinfer-mode)
-      :init
-      (setq parinfer-extensions
-            '(defaults
-              pretty-parens
-              smart-tab
-              smart-yank))
-      (when (featurep! :editor evil +everywhere)
-        (push 'evil parinfer-extensions))
-      :config
-      (map! :map parinfer-mode-map
-            "\"" nil  ; smartparens handles this
-            :i "<tab>"     #'parinfer-smart-tab:dwim-right-or-complete
-            :i "<backtab>" #'parinfer-smart-tab:dwim-left
-            :localleader
-            :desc "Toggle parinfer-mode" "m" #'parinfer-toggle-mode))
-  (defvar parinfer-rust--doom-lib-name (cond ((eq system-type 'darwin)
-                                              "parinfer-rust-darwin.so")
-                                             ((eq system-type 'gnu/linux)
-                                              "parinfer-rust-linux.so")
-                                             ((eq system-type 'windows-nt)
-                                              "parinfer-rust-windows.dll")))
-  (use-package! parinfer-rust-mode
-    :hook ((emacs-lisp-mode
+(use-package! parinfer
+  :unless (featurep! +rust)
+  :hook ((emacs-lisp-mode
             clojure-mode
             scheme-mode
             lisp-mode
             racket-mode
-            hy-mode) . parinfer-rust-mode)
-    :init
-    (setq! parinfer-rust-library (concat user-emacs-directory
-                                         ".local/etc/parinfer-rust/"
-                                         parinfer-rust--doom-lib-name))
-    :config
-    (map! :map parinfer-rust-mode-map
-          :localleader
-          :desc "Switch parinfer-rust-mode" "m" #'parinfer-rust-switch-mode
-          :desc "Temporarily disable parinfer-rust-mode" "M"
-                #'parinfer-rust-switch-mode)))
+            hy-mode) . parinfer-mode)
+  :init
+  (setq parinfer-extensions
+        '(defaults
+          pretty-parens
+          smart-tab
+          smart-yank))
+  (when (featurep! :editor evil +everywhere)
+    (push 'evil parinfer-extensions))
+  :config
+  (map! :map parinfer-mode-map
+        "\"" nil  ; smartparens handles this
+        :i "<tab>"     #'parinfer-smart-tab:dwim-right-or-complete
+        :i "<backtab>" #'parinfer-smart-tab:dwim-left
+        :localleader
+        "m" #'parinfer-toggle-mode))
+(use-package! parinfer-rust-mode
+  :when (featurep! +rust)
+  :when (bound-and-true-p module-file-suffix)
+  :hook ((emacs-lisp-mode
+          clojure-mode
+          scheme-mode
+          lisp-mode
+          racket-mode
+          hy-mode) . parinfer-rust-mode)
+  :init
+  (setq! parinfer-rust-library
+         (concat user-emacs-directory
+                 ".local/etc/parinfer-rust/"
+                 (cond ((eq system-type 'darwin) "parinfer-rust-darwin.so")
+                       ((eq system-type 'gnu/linux) "parinfer-rust-linux.so")
+                       ((eq system-type 'windows-nt) "parinfer-rust-windows.dll")
+                       ((eq system-type 'berkeley-unix "libparinfer_rust.so"))))
+         parinfer-rust-auto-download
+         (if (eq system-type 'berkeley-unix)
+             nil
+           t))
+  :config
+  (map! :map parinfer-rust-mode-map
+        :localleader
+        "m" #'parinfer-rust-switch-mode
+        "M" #'parinfer-rust-toggle-disable))

--- a/modules/editor/parinfer/config.el
+++ b/modules/editor/parinfer/config.el
@@ -39,7 +39,7 @@
                  (cond ((eq system-type 'darwin) "parinfer-rust-darwin.so")
                        ((eq system-type 'gnu/linux) "parinfer-rust-linux.so")
                        ((eq system-type 'windows-nt) "parinfer-rust-windows.dll")
-                       ((eq system-type 'berkeley-unix "libparinfer_rust.so"))))
+                       ((eq system-type 'berkeley-unix) "libparinfer_rust.so")))
          parinfer-rust-auto-download
          (if (eq system-type 'berkeley-unix)
              nil

--- a/modules/editor/parinfer/doctor.el
+++ b/modules/editor/parinfer/doctor.el
@@ -4,8 +4,8 @@
   (unless (fboundp 'module-load)
     (warn! "Your emacs wasn't built with dynamic modules support. `parinfer-rust-mode' won't work"))
   (when (and (eq system-type 'berkeley-unix)
-             (not (file-readable-p
-                   (concat user-emacs-directory ".local/etc/parinfer-rust/libparinfer_rust.so"))))
+             (not (file-readable-p (concat user-emacs-directory
+                                           ".local/etc/parinfer-rust/libparinfer_rust.so"))))
     (warn! (concat "Could not read " user-emacs-directory
                    ".local/etc/parinfer-rust/libparinfer_rust.so. "
                    "`parinfer-rust-mode' won't work"))))

--- a/modules/editor/parinfer/doctor.el
+++ b/modules/editor/parinfer/doctor.el
@@ -1,0 +1,11 @@
+;;; editor/parinfer/doctor.el -*- lexical-binding: t; -*-
+
+(when (featurep! +rust)
+  (unless (fboundp 'module-load)
+    (warn! "Your emacs wasn't built with dynamic modules support. `parinfer-rust-mode' won't work"))
+  (when (and (eq system-type 'berkeley-unix)
+             (not (file-readable-p
+                   (concat user-emacs-directory ".local/etc/parinfer-rust/libparinfer_rust.so"))))
+    (warn! (concat "Could not read " user-emacs-directory
+                   ".local/etc/parinfer-rust/libparinfer_rust.so. "
+                   "`parinfer-rust-mode' won't work"))))

--- a/modules/editor/parinfer/packages.el
+++ b/modules/editor/parinfer/packages.el
@@ -1,7 +1,7 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; editor/parinfer/packages.el
 
-(when (featurep! :editor evil)
+(when (and (not (featurep! +rust)) (featurep! :editor evil))
   ;; Parinfer uses `evil-define-key' without loading evil, so if evil is
   ;; installed *after* parinfer, parinfer will throw up void-function errors.
   ;; because evil-define-key (a macro) wasn't expanded at compile-time. So we
@@ -11,4 +11,6 @@
   ;; separate session:
   (autoload 'evil-define-key "evil-core" nil nil 'macro))
 
-(package! parinfer :pin "8659c99a9475ee34af683fdf8f272728c6bebb3a")
+(if (featurep! +rust)
+    (package! parinfer-rust-mode :pin "c825606e6aca4a2ed18c0af321df5f36a3c8c774")
+  (package! parinfer :pin "8659c99a9475ee34af683fdf8f272728c6bebb3a"))

--- a/modules/editor/parinfer/packages.el
+++ b/modules/editor/parinfer/packages.el
@@ -13,4 +13,6 @@
 
 (if (featurep! +rust)
     (package! parinfer-rust-mode :pin "c825606e6aca4a2ed18c0af321df5f36a3c8c774")
-  (package! parinfer :pin "8659c99a9475ee34af683fdf8f272728c6bebb3a"))
+  (package! parinfer
+    :recipe (:host github :repo "emacsattic/parinfer")
+    :pin "8659c99a9475ee34af683fdf8f272728c6bebb3a"))


### PR DESCRIPTION
This commit adds support for the `parinfer` module flag `+rust`, which will use `parinfer-rust-mode`
instead of `parinfer-mode`. `parinfer-rust-mode` makes use of an external library named `parinfer-rust`
to do the heavy lifting. As such, `--with-modules` must be enabled.

Resolves #4635.