### PR TITLE
+scala/open-repl don't kill non-existant sbt buffer

### DIFF
--- a/modules/lang/scala/autoload.el
+++ b/modules/lang/scala/autoload.el
@@ -41,7 +41,7 @@ Meant to be used for `scala-mode's `comment-line-break-function'."
   (if (and (require 'sbt-mode nil t)
            (sbt:find-root))
       (let ((buffer-name (sbt:buffer-name)))
-        (unless (comint-check-proc buffer-name)
+        (when (and (get-buffer buffer-name) (not (comint-check-proc buffer-name)))
           (kill-buffer buffer-name))
         (run-scala)
         (get-buffer buffer-name))


### PR DESCRIPTION
## Why
On current develop trying to open a scala repl in an sbt project via `SPC o r` or calling the `+scala/open-repl` method would fail with
```
if: No buffer named *sbt*<~/project/path>
```
This change updates the check so that we don't attempt to kill an sbt buffer that doesn't exist

## What
- the original method used only `comint-check-proc` before attempting to kill the buffer
  - this method doesn't distinguish between a dead buffer process and a buffer that doesn't actually exist
- update to check that buffer exists and is dead before calling `kill-buffer`

## Questions
1. I don't ever use scala without sbt so I didn't make the same change to line 50 (I'm not sure if its even broken for non-sbt users?). Should I update the logic in both places though? 