### PR TITLE
Set default eshell TERM

### DIFF
--- a/modules/term/eshell/README.org
+++ b/modules/term/eshell/README.org
@@ -12,6 +12,7 @@
 - [[#prerequisites][Prerequisites]]
 - [[#features][Features]]
 - [[#configuration][Configuration]]
+  - [[#term-name][TERM name]]
 - [[#troubleshooting][Troubleshooting]]
 
 * Description
@@ -54,8 +55,11 @@ found. If neither shell is found, completions may not be available.
 + [[https://github.com/rupa/z][=z=]]-like directory jumping
 + Command-not-found recommendations
 
-* TODO Configuration
-# How to configure this module, including common problems and how to address them.
+* Configuration
+** TERM name
+By default, =eshell= sets the =$TERM= variable to ="xterm-256color"=, which helps with
+rendering various colours. As eshell is /not/ a terminal emulator, these will not
+always work 100%. Modifying =eshell-term-name= to your liking may help.
 
 * TODO Troubleshooting
 # Common issues and their solution, or places to look for help.

--- a/modules/term/eshell/config.el
+++ b/modules/term/eshell/config.el
@@ -71,7 +71,9 @@ You should use `set-eshell-alias!' to change this.")
         eshell-prompt-function #'+eshell-default-prompt-fn
         ;; em-glob
         eshell-glob-case-insensitive t
-        eshell-error-if-no-glob t)
+        eshell-error-if-no-glob t
+        ;; Shell config
+        eshell-term-name "xterm-256color")
 
   ;; Consider eshell buffers real
   (add-hook 'eshell-mode-hook #'doom-mark-buffer-as-real-h)
@@ -90,7 +92,6 @@ You should use `set-eshell-alias!' to change this.")
 
   ;; UI enhancements
   (add-hook! 'eshell-mode-hook
-    (setenv "TERM" "xterm-256color")
     (defun +eshell-remove-fringes-h ()
       (set-window-fringes nil 0 0)
       (set-window-margins nil 1 nil))

--- a/modules/term/eshell/config.el
+++ b/modules/term/eshell/config.el
@@ -90,6 +90,7 @@ You should use `set-eshell-alias!' to change this.")
 
   ;; UI enhancements
   (add-hook! 'eshell-mode-hook
+    (setenv "TERM" "xterm-256color")
     (defun +eshell-remove-fringes-h ()
       (set-window-fringes nil 0 0)
       (set-window-margins nil 1 nil))


### PR DESCRIPTION
Makes eshell more ansi-friendly ootb. I'm not 100% tied to it being `xterm` if you think there's a better option.