### PR TITLE
Enable disabling of magit-gitflow

### DIFF
--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -233,7 +233,10 @@ ensure it is built when we actually use Forge."
     (evil-define-key* evil-collection-magit-state git-rebase-mode-map
       "gj" #'git-rebase-move-line-down
       "gk" #'git-rebase-move-line-up))
-  (transient-replace-suffix 'magit-dispatch 'magit-worktree
-    '("%" "Gitflow" magit-gitflow-popup))
+
+  (after! magit-gitflow
+    (transient-replace-suffix 'magit-dispatch 'magit-worktree
+      '("%" "Gitflow" magit-gitflow-popup)))
+
   (transient-append-suffix 'magit-dispatch '(0 -1 -1)
     '("*" "Worktree" magit-worktree)))


### PR DESCRIPTION
Disabling magit-gitflow breaks magit-dispatch due to the unconditional application of `transient-replace-suffix`.

With this change it is possible to disable magit-gitflow by adding the following to your private Doom configuration:

    (package! magit-gitflow :disable t)