### PR TITLE
Enable lispy-mode during eval-expression.

### DIFF
--- a/modules/editor/lispy/config.el
+++ b/modules/editor/lispy/config.el
@@ -10,6 +10,15 @@
          (lfe-mode . lispy-mode)
          (dune-mode . lispy-mode)
          (clojure-mode . lispy-mode))
+  :init
+  (add-hook! 'eval-expression-minibuffer-setup-hook
+    (defun doom-init-lispy-in-eval-expression-h ()
+      "Enable `lispy-mode' in the minibuffer for `eval-expression'."
+      (lispy-mode)
+      ;; When `lispy-key-theme' has `parinfer', the TAB key doesn't do
+      ;; completion, neither (kbd "<tab>"/"TAB"/"C-i")/[tab]/"\C-i" works in
+      ;; terminal as tested so remapping is used as a workaround
+      (local-set-key (vector 'remap (lookup-key lispy-mode-map (kbd "TAB"))) #'completion-at-point)))
   :config
   (setq lispy-close-quotes-at-end-p t)
   (add-hook 'lispy-mode-hook #'turn-off-smartparens-mode))


### PR DESCRIPTION
`eval-expression` is basically Elisp, therefore it makes sense to enable `lispy`.