### PR TITLE
Fixing the gpl snippet template formatting

### DIFF
--- a/modules/editor/file-templates/templates/text-mode/__license-gpl3
+++ b/modules/editor/file-templates/templates/text-mode/__license-gpl3
@@ -659,11 +659,11 @@ Also add information on how to contact you by electronic and paper mail.
 notice like this when it starts in an interactive mode:
 
     ${3:<program>}  Copyright (C) ${1:`(format-time-string "%Y")`} ${2:`user-full-name`}
-    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This program comes with ABSOLUTELY NO WARRANTY; for details type \`show w'.
     This is free software, and you are welcome to redistribute it
-    under certain conditions; type `show c' for details.
+    under certain conditions; type \`show c' for details.
 
-The hypothetical commands `show w' and `show c' should show the appropriate
+The hypothetical commands \`show w' and \`show c' should show the appropriate
 parts of the General Public License.  Of course, your program's commands
 might be different; for a GUI interface, you would use an "about box".
 


### PR DESCRIPTION
Need to escape the backticks that should appear as literals in the GPLv3 license.