### PR TITLE
Fix +debug/start for dap-based debuggers.

### DIFF
--- a/modules/tools/debugger/autoload/debugger.el
+++ b/modules/tools/debugger/autoload/debugger.el
@@ -50,21 +50,24 @@ infromation."
                           (+debugger-list-for-dap)
                           (+debugger-list-for-realgud)))
          (result (--map (cons (cadr it) it) configurations))
-         (completion (completing-read "Start debugger: " (-map 'car result) nil t ))
-         (configuration (cdr (assoc completion result))))
-    (if (eq (car configuration) 'dap)
-        (let* ((debug-args (-> (cdr configuration)
-                               cl-rest
-                               copy-tree
-                               dap-variables-expand-in-launch-configuration))
-               (launch-args (or (-some-> (plist-get debug-args :type)
-                                  (gethash dap--debug-providers)
-                                  (funcall debug-args))
-                                (user-error "Have you loaded the `%s' specific dap package?"
-                                            (or (plist-get debug-args :type)
-                                                (user-error "%s does not specify :type" debug-args))))))
-          (cons 'dap launch-args))
-      (cons 'realgud (intern (cadr configuration))))))
+         (completion (completing-read "Start debugger: " (-map 'car result) nil t)))
+    (if (eq completion "")
+        (user-error "No debugging configuration specified.")
+      (let ((configuration (cdr (assoc completion result))))
+        (if (eq (car configuration) 'dap)
+            ;; get dap debugging arguments
+            (let* ((debug-args (-> (cdr configuration)
+                                   cl-rest
+                                   copy-tree
+                                   dap-variables-expand-in-launch-configuration))
+                   (launch-args (or (-some-> (plist-get debug-args :type)
+                                      (gethash dap--debug-providers)
+                                      (funcall debug-args))
+                                    (user-error "Have you loaded the `%s' specific dap package?"
+                                                (or (plist-get debug-args :type)
+                                                    (user-error "%s does not specify :type" debug-args))))))
+              (cons 'dap launch-args))
+          (cons 'realgud (intern (cadr configuration))))))))
 
 ;;
 ;;; Interactive commands

--- a/modules/tools/debugger/autoload/debugger.el
+++ b/modules/tools/debugger/autoload/debugger.el
@@ -1,37 +1,39 @@
 ;;; tools/debugger/autoload/debugger.el -*- lexical-binding: t; -*-
 
-(defvar +debugger-last-configuration nil
+(defvar-local +debugger--last-config nil
   "Configuration of the last debugging session of buffer.")
-(make-variable-buffer-local '+debugger-last-configuration)
+(put '+debugger--last-config 'permanent-local t) ; don't kill on mode change
 
-(defun +debugger-get-configuration ()
+(defun +debugger--get-last-config ()
   "Get last debugging configuration.
 
 If in a project, returns the configuration of the last debugging session in the
 project, if any. Else, returns the last debugging configuration of the current
 buffer, if any."
-  (if (projectile-project-p)
-      (projectile-variable-get '+debugger-last-configuration)
-    +debugger-last-configuration))
+  (if (doom-project-p)
+      (doom-store-get (doom-project-root) "+debugger")
+    +debugger--last-config))
 
-(defun +debugger-set-configuration (configuration)
-  "Set the debugging configuration.
+(defun +debugger--set-config (config)
+  "Remember this debugging configuration for `+debugger/start-last'.
 
 If in a project, sets the project's debugging session configuration. Else, sets
 the debugging configuration of the current buffer."
-  (if (projectile-project-p)
-      (projectile-variable-put '+debugger-last-configuration configuration)
-    (setq-local +debugger-last-configuration configuration)))
+  (if (doom-project-p)
+      (doom-store-put (doom-project-root) config
+                      (lambda (key _cfg) (file-directory-p key))
+                      "+debugger")
+    (setq +debugger--last-config config)))
 
-(defun +debugger-list-for-dap ()
-  (when (and (bound-and-true-p lsp-mode)
-             (bound-and-true-p lsp--buffer-deferred)
-             (require 'dap-mode nil t)
-             dap-mode)
-    (mapcar (lambda (c) (cons 'dap c))
-            (apply 'append (mapcar #'funcall dap-launch-configuration-providers)))))
+(defun +debugger--list-for-dap ()
+  (and (or (bound-and-true-p lsp-mode)
+           (bound-and-true-p lsp--buffer-deferred))
+       (require 'dap-mode nil t)
+       dap-mode
+       (mapcar (lambda (c) (cons 'dap c))
+               (apply #'append (mapcar #'funcall dap-launch-configuration-providers)))))
 
-(defun +debugger-list-for-realgud ()
+(defun +debugger--list-for-realgud ()
   (mapcar (lambda (c) (cons 'realgud (list (symbol-name c))))
           (cl-loop for (sym . plist) in +debugger--realgud-alist
                    for sym-name = (symbol-name sym)
@@ -44,21 +46,19 @@ the debugging configuration of the current buffer."
   "Completing read for debug configuration.
 
 Presents both dap and realgud configurations, and returns a list of the form
-('dap ...) or ('realgud ...) containing the corresponding debug configuration
+\('dap ...) or ('realgud ...) containing the corresponding debug configuration
 infromation."
-  (let* ((configurations (append
-                          (+debugger-list-for-dap)
-                          (+debugger-list-for-realgud)))
-         (result (mapcar (lambda (c) (cons (cadr c) c)) configurations))
-         (completion (completing-read "Start debugger: " (mapcar 'car result) nil t)))
-    (if (or (null completion) (eq completion ""))
+  (let ((result (mapcar (lambda (c) (cons (cadr c) c))
+                        (append (+debugger--list-for-dap)
+                                (+debugger--list-for-realgud))))
+        (completion (completing-read "Start debugger: " (mapcar #'car result) nil t)))
+    (if (or (null completion) (string-empty-p completion))
         (user-error "No debugging configuration specified.")
       (let ((configuration (cdr (assoc completion result))))
         (if (eq (car configuration) 'dap)
             ;; get dap debugging arguments
-            (let* ((debug-args (dap-variables-expand-in-launch-configuration (copy-tree
-                                                                              (cl-rest
-                                                                               (cdr configuration)))))
+            (let* ((debug-args (dap-variables-expand-in-launch-configuration
+                                (copy-tree (cddr configuration))))
                    (launch-args (or (catch 'is-nil
                                       (funcall (or (gethash
                                                     (or (plist-get debug-args :type)
@@ -77,10 +77,10 @@ infromation."
 (defun +debugger/start-last ()
   "Relaunch the last debugger session."
   (interactive)
-  (let ((configuration (+debugger-get-configuration)))
+  (let ((configuration (+debugger--get-last-config)))
     (unless configuration
       (user-error "No last debugger%s to invoke"
-                  (if (projectile-project-p)
+                  (if (doom-project-p)
                       " of this project"
                     "")))
     (let ((launch-args (cdr configuration)))
@@ -99,8 +99,8 @@ infromation."
 Launches the last used debugger, if one exists. Otherwise, you will be prompted
 for what debugger to use. If the prefix ARG is set, prompt anyway."
   (interactive "P")
-  (if (or arg (null (+debugger-get-configuration)))
-      (+debugger-set-configuration (+debugger-completing-read)))
+  (when (or arg (null (+debugger--get-last-config)))
+    (+debugger--set-config (+debugger-completing-read)))
   (+debugger/start-last))
 
 ;;;###autoload

--- a/modules/tools/debugger/autoload/debugger.el
+++ b/modules/tools/debugger/autoload/debugger.el
@@ -107,7 +107,7 @@ for what debugger to use. If the prefix ARG is set, prompt anyway."
   "Quit the active debugger, if any."
   (interactive)
   (cond ((and (fboundp 'dap--cur-session) (dap--cur-session))
-         (dap-disconnect))
+         (dap-disconnect (dap--cur-session)))
         ((and (fboundp 'realgud-get-cmdbuf) (realgud-get-cmdbuf))
          (let ((buf (realgud-get-cmdbuf)))
            (ignore-errors

--- a/modules/tools/debugger/config.el
+++ b/modules/tools/debugger/config.el
@@ -38,6 +38,12 @@
 (setq gdb-show-main t
       gdb-many-windows t)
 
+(use-package! projectile-variable
+  :defer t
+  :commands (projectile-variable-put
+             projectile-variable-get
+             projectile-variable-alist
+             projectile-variable-plist))
 
 (use-package! realgud
   :defer t

--- a/modules/tools/debugger/packages.el
+++ b/modules/tools/debugger/packages.el
@@ -5,8 +5,6 @@
   (when (featurep! :lang javascript)
     (package! realgud-trepan-ni :pin "6e38cf838c7b47b5f1353d00901b939ffa36d707")))
 
-(package! projectile-variable :pin "8d348ac70bdd6dc320c13a12941b32b38140e264")
-
 (when (featurep! +lsp)
   (package! dap-mode :pin "aa15b9c49b7e09bb23f9a4ff7855122f0eb19976")
   (package! posframe :pin "3454a4cb9d218c38f9c5b88798dfb2f7f85ad936"))

--- a/modules/tools/debugger/packages.el
+++ b/modules/tools/debugger/packages.el
@@ -5,6 +5,8 @@
   (when (featurep! :lang javascript)
     (package! realgud-trepan-ni :pin "6e38cf838c7b47b5f1353d00901b939ffa36d707")))
 
+(package! projectile-variable :pin "8d348ac70bdd6dc320c13a12941b32b38140e264")
+
 (when (featurep! +lsp)
   (package! dap-mode :pin "aa15b9c49b7e09bb23f9a4ff7855122f0eb19976")
   (package! posframe :pin "3454a4cb9d218c38f9c5b88798dfb2f7f85ad936"))


### PR DESCRIPTION
Reworks the internals of how the debugger module stores the last-used configuration:
- car of the configuration indicates whether it is a realgud or a dap-based configuration.
- For dap-based debuggers, the entire dap configuration is stored, with code copied from `dab-debug`.
- When inside a project, don't store the configuration as a buffer-local variable, but instead as a project-local variable using `projectile-variable`.

Fixes #2367.