### PR TITLE
Update brew install emacs-mac instructions

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -242,7 +242,7 @@ to least recommended for Doom (based on compatibility).
   with macOS, native emojis and better childframe support. 
   #+BEGIN_SRC bash
   brew tap railwaycat/emacsmacport
-  brew install emacs-mac --with-modules
+  brew install railwaycat/emacsmacport/emacs-mac --with-modules
   ln -s /usr/local/opt/emacs-mac/Emacs.app /Applications/Emacs.app
   #+END_SRC
 


### PR DESCRIPTION
When installing emacs-mac today with the command `brew install emacs-mac --with-modules` I got `Warning: Treating emacs-mac as a formula. For the cask, use railwaycat/emacsmacport/emacs-mac`. I'm not aware of any significant difference between formula vs cask, but most users are going to copy and paste the commands, see the warning, and be concerned that they messed up something. If the user has a reason to treat emacs-mac as a formula, they are probably savvy enough to use the other command.