### PR TITLE
Fix the "Yank file path" non-evil bindings

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -78,7 +78,8 @@
        :desc "Recent project files"        "R"   #'projectile-recentf
        :desc "Sudo this file"              "u"   #'doom/sudo-this-file
        :desc "Sudo find file"              "U"   #'doom/sudo-find-file
-       :desc "Yank filename"               "y"   #'+default/yank-buffer-filename
+       :desc "Yank file path"              "y"   #'+default/yank-buffer-path
+       :desc "Yank file path from project" "Y"   #'+default/yank-buffer-path-relative-to-project
        :desc "Open scratch buffer"         "x"   #'doom/open-scratch-buffer
        :desc "Switch to scratch buffer"    "X"   #'doom/switch-to-scratch-buffer)
 


### PR DESCRIPTION
+default/yank-buffer-filename was replaced in
be9b3ff352f39f2f21812e13466bd6d2f26cd6e4 and +evil-bindings.el was
updated accordingly. This commit makes the corresponding updates in
+emacs-bindings.el.