### PR TITLE
Bump treemacs pinned version to latest master

### DIFF
--- a/modules/ui/treemacs/packages.el
+++ b/modules/ui/treemacs/packages.el
@@ -1,7 +1,7 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; ui/treemacs/packages.el
 
-(package! treemacs :pin "a7e2e4388f3b588dff64536c811961b7f7945d13")
+(package! treemacs :pin "685781676acdca61b40f1932890230a741f2b82d")
 ;; These packages have no :pin because they're in the same repo
 (when (featurep! :editor evil +everywhere)
   (package! treemacs-evil))


### PR DESCRIPTION
Treemacs was broken for tramp in https://github.com/Alexander-Miller/treemacs/commit/6c431174dd933f87c32f283740ad2078e1c4fcb8. It is fixed in the pinned commit.