### PR TITLE
Fix #4736 - remap insert state bindings in minibuffer maps

### DIFF
--- a/modules/input/layout/+bepo.el
+++ b/modules/input/layout/+bepo.el
@@ -82,6 +82,14 @@
     (after! treemacs
       (doom-bepo-rotate-ts-bare-keymap '(evil-treemacs-state-map)))
     (after! (:or helm ivy selectrum icomplete)
+      (doom-bepo--evil-collection-hook
+        nil
+       '(minibuffer-local-map
+         minibuffer-local-ns-map
+         minibuffer-local-completion-map
+         minibuffer-local-must-match-map
+         minibuffer-local-isearch-map
+         read-expression-map))
       (doom-bepo-rotate-bare-keymap
        '(minibuffer-local-map
          minibuffer-local-ns-map
@@ -91,7 +99,10 @@
          read-expression-map)
        doom-bepo-cr-rotation-style))
     (after! ivy
-      (doom-bepo-rotate-bare-keymap '(ivy-minibuffer-map ivy-switch-buffer-map) doom-bepo-cr-rotation-style))
+      (doom-bepo-rotate-bare-keymap '(ivy-minibuffer-map ivy-switch-buffer-map) doom-bepo-cr-rotation-style)
+      (doom-bepo--evil-collection-hook nil '(ivy-minibuffer-map ivy-switch-buffer-map)))
+    (after! swiper
+      (map! :map swiper-map "C-s" nil))
     (after! helm
       (doom-bepo-rotate-bare-keymap '(helm-map) doom-bepo-cr-rotation-style))
     (after! helm-rg

--- a/modules/input/layout/+bepo.el
+++ b/modules/input/layout/+bepo.el
@@ -83,7 +83,7 @@
       (doom-bepo-rotate-ts-bare-keymap '(evil-treemacs-state-map)))
     (after! (:or helm ivy selectrum icomplete)
       (doom-bepo--evil-collection-hook
-        nil
+       nil
        '(minibuffer-local-map
          minibuffer-local-ns-map
          minibuffer-local-completion-map
@@ -225,5 +225,5 @@
     (after! evil-easymotion
       ;; instead of using gs as the evilem-map we use gé to avoid conflicts with org-mode
       ;; down the road
-      (map! :nvm "gé" evilem-map)
+      (evilem-default-keybindings "gé")
       (doom-bepo-rotate-bare-keymap '(evilem-map) doom-bepo-cr-rotation-style))))

--- a/modules/input/layout/+bepo.el
+++ b/modules/input/layout/+bepo.el
@@ -104,11 +104,17 @@
     (after! swiper
       (map! :map swiper-map "C-s" nil))
     (after! helm
-      (doom-bepo-rotate-bare-keymap '(helm-map) doom-bepo-cr-rotation-style))
+      (doom-bepo-rotate-bare-keymap '(helm-map) doom-bepo-cr-rotation-style)
+      (doom-bepo--evil-collection-hook nil '(helm-map)))
     (after! helm-rg
-      (doom-bepo-rotate-bare-keymap '(helm-rg-map) doom-bepo-cr-rotation-style))
+      (doom-bepo-rotate-bare-keymap '(helm-rg-map) doom-bepo-cr-rotation-style)
+      (doom-bepo--evil-collection-hook nil '(helm-rg-map)))
     (after! helm-files
-      (doom-bepo-rotate-bare-keymap '(helm-read-file-map) doom-bepo-cr-rotation-style))
+      (doom-bepo-rotate-bare-keymap '(helm-read-file-map) doom-bepo-cr-rotation-style)
+      (doom-bepo--evil-collection-hook nil '(helm-read-file-map)))
+    (after! selectrum
+      (doom-bepo-rotate-bare-keymap '(selectrum-minibuffer-map) doom-bepo-cr-rotation-style)
+      (doom-bepo--evil-collection-hook nil '(selectrum-minibuffer-map)))
     (after! company
       (doom-bepo-rotate-bare-keymap '(company-active-map company-search-map) doom-bepo-cr-rotation-style))
     (after! evil-snipe

--- a/modules/input/layout/README.org
+++ b/modules/input/layout/README.org
@@ -117,6 +117,10 @@ actually put all the =c= functions on the key that does not need a curl.
 
 * Troubleshooting
 # Common issues and their solution, or places to look for help.
+** Outstanding issues (contributions welcome)
+*** Bépo
+- in eshell, the key `c` is still bound to
+  `evil-collection-eshell-evil-change` in normal mode
 ** How to investigate an issue ?
 If a key is misbehaving, use =describe-key= (=C-h k= or =SPC h k= or =F1 k=) to
 see the functions bound to the key, and more importantly in which map it is


### PR DESCRIPTION
- Run `doom-bepo--evil-collection-hook` on all minibuffer maps. This
  allows all bindings in <insert-state> to be remapped in minibuffer
  contexts
- Unmap `swiper-C-s`