### PR TITLE
tools/lsp: revert to dumb-jump if find-definition fails

### DIFF
--- a/modules/tools/lsp/+lsp.el
+++ b/modules/tools/lsp/+lsp.el
@@ -10,6 +10,14 @@ Can be a list of backends; accepts any value `company-backends' accepts.")
 If set to `quiet', suppress the install prompt and don't visibly inform the user
 about it (it will be logged to *Messages* however).")
 
+(cl-defun +lsp-find-definition-or-dumb-jump ()
+  "Find definition using LSP, falling back to dumb-jump when necessary."
+  (interactive)
+  (let ((loc (lsp-request "textDocument/definition"
+                          (lsp--text-document-position-params))))
+    (if (seq-empty-p loc)
+        (dumb-jump-go) ;; todo: this is technically deprecated
+      (lsp-show-xrefs (lsp--locations-to-xref-items loc) nil nil))))
 
 ;;
 ;;; Packages
@@ -58,7 +66,7 @@ about it (it will be logged to *Messages* however).")
   (set-popup-rule! "^\\*lsp-help" :size 0.35 :quit t :select t)
   (set-lookup-handlers! 'lsp-mode :async t
     :documentation #'lsp-describe-thing-at-point
-    :definition #'lsp-find-definition
+    :definition #'lsp-find-definition-or-dumb-jump
     :implementations #'lsp-find-implementation
     :type-definition #'lsp-find-type-definition
     :references #'lsp-find-references)


### PR DESCRIPTION
Fixes #4662, more context is available in https://github.com/hlissner/doom-emacs/issues/4662#issuecomment-780911875.

This has worked decently for me for a couple of weeks, but I'm not working on a very diverse set of projects at the moment.

Edit: I need to account for people who don't have `lookup` enabled. Currently trying to figure out a development flow with `doom/sandbox` to test this across different configurations.