### PR TITLE
Emacs lisp: fix variable value display in eldoc

### DIFF
--- a/modules/lang/emacs-lisp/config.el
+++ b/modules/lang/emacs-lisp/config.el
@@ -99,7 +99,7 @@ employed so that flycheck still does *some* helpful linting.")
     "Display variable value next to documentation in eldoc."
     :around #'elisp-get-var-docstring
     (when-let (ret (funcall orig-fn sym))
-      (if (fboundp sym)
+      (if (boundp sym)
           (concat ret " "
                   (let* ((truncated " [...]")
                          (print-escape-newlines t)


### PR DESCRIPTION
`fboundp` does not check if a variable is bound, but rather a function.
Use `boundp`.

I think this was a mistake introduced in one of my bug-fixing PRs...

----

#