### PR TITLE
org-capture: accept text arg non-interactively

### DIFF
--- a/bin/org-capture
+++ b/bin/org-capture
@@ -28,7 +28,11 @@ while getopts "hk:" opt; do
 done
 shift $((OPTIND-1))
 
-[ -t 0 ] && str="$*" || str=$(cat)
+# use remaining args, else try stdin
+str="$*"
+if [ -z $str ]; then
+  str=$(cat)
+fi
 
 # Fix incompatible terminals that cause odd 'not a valid terminal' errors
 [ "$TERM" = "alacritty" ] && export TERM=xterm-256color


### PR DESCRIPTION
Change org-capture to get text from positional args if present,
otherwise stdin.

Currently it gets text from positional args if interactive, and from
stdin otherwise, which lead to me scratching my head wondering why the script was eating
the passed texted when called from qutebrowser:

    :spawn org-capture "[[{url}][{title}]]"

In its present form the script doesn't support this usage.