### PR TITLE
Delete only 1 treemacs-mode in aw-ignored-buffers.

### DIFF
--- a/modules/ui/treemacs/config.el
+++ b/modules/ui/treemacs/config.el
@@ -28,7 +28,7 @@ This must be set before `treemacs' has loaded.")
   :config
   ;; Allow ace-window to target treemacs windows elsewhere
   (after! ace-window
-    (delq! 'treemacs-mode aw-ignored-buffers))
+    (setq aw-ignored-buffers (cl-remove 'treemacs-mode aw-ignored-buffers :count 1)))
   ;; ...but not from treemacs-visit-node-ace-* commands.
   (defadvice! +treemacs--ace-window-ignore-treemacs-buffer-a (orig-fn &rest args)
     :around '(treemacs-visit-node-ace

--- a/modules/ui/treemacs/config.el
+++ b/modules/ui/treemacs/config.el
@@ -26,7 +26,7 @@ This must be set before `treemacs' has loaded.")
         treemacs-persist-file (concat doom-cache-dir "treemacs-persist")
         treemacs-last-error-persist-file (concat doom-cache-dir "treemacs-last-error-persist"))
   :config
-  ;; Allow ace-window to target treemacs windows elsewhere
+  ;; Allow ace-window to target treemacs windows elsewhere, unless users want to ignore
   (after! ace-window
     (setq aw-ignored-buffers (cl-remove 'treemacs-mode aw-ignored-buffers :count 1)))
   ;; ...but not from treemacs-visit-node-ace-* commands.


### PR DESCRIPTION
---
name: Delete at most one occurrence of 'treemacs-mode in 'aw-ignored-buffers

about: Treemacs and Ace-window
---

So that users can easily add it back.

In vanilla treemacs, `'treemacs-mode` is in `aw-ignored-buffers`, but Doom removes that so `ace-window` can target `treemacs`.

But when an user tries to add it back, Doom overrides their attempt because `delq!` deletes all occurrences of `'treemacs` there, making it hard to perform without advises.

After applying this PR, Doom only removes the first `'treemacs` in `aw-ignored-buffers` which was added by `treemacs-compatibility.el`, makes room for users to add it back using `push`.

(Positive side effects: after applying this, `pushnew` and `add-to-list` work, too. Previously they don't.
Maybe because the order is application is: user's `config.el` -> `treemacs-compatibility.el` -> `ui/treemacs/config.el` and `treemacs` uses `push` internally, therefore there are still multiple `'treemacs-mode` in `aw-ignored-buffers` whether users use `pushnew` or `push`)

This doesn't change anything when users don't modify `aw-ignored-buffers`, `treemacs` windows are still targetable.