### PR TITLE
`git-commit`: fix variable predicates

### DIFF
--- a/modules/emacs/vc/config.el
+++ b/modules/emacs/vc/config.el
@@ -9,8 +9,11 @@
   (setenv "GIT_ASKPASS" "git-gui--askpass"))
 
 ;; Don't complain when these variables are set in file/local vars
-(put 'git-commit-major-mode 'safe-local-variable 'symbolp)
-(put 'git-commit-summary-max-length 'safe-local-variable 'symbolp)
+(put 'git-commit-major-mode 'safe-local-variable
+     (lambda (x)
+       (memq x '(git-commit-elisp-text-mode
+                 text-mode fundamental-mode org-mode markdown-mode))))
+(put 'git-commit-summary-max-length 'safe-local-variable 'numberp)
 
 ;; In case the user is using `bug-reference-mode'
 (map! :when (fboundp 'bug-reference-mode)


### PR DESCRIPTION
`git-commit-summary-max-length` should be a number, not a symbol.

`git-commit-major-mode` should be checked more carefully, as otherwise
exploits are possible (e.g. if it is `erase-buffer` or some dangerous
function of the user's environment).


----

#