### PR TITLE
Fix 'too many arguments' error on org-capture

### DIFF
--- a/bin/org-capture
+++ b/bin/org-capture
@@ -30,7 +30,7 @@ shift $((OPTIND-1))
 
 # use remaining args, else try stdin
 str="$*"
-if [ -z $str ]; then
+if [ -z "$str" ]; then
   str=$(cat)
 fi
 


### PR DESCRIPTION
org-capture foo bar baz

will fail with:

org/capture: line 33: [: too many arguments

Adding quotes to the expansion of $str will ensure that test -z has
only one argument.

Hope that it helps.
Cheers!