### PR TITLE
Prioritize company-capf over company-yasnippet

### DIFF
--- a/modules/tools/lsp/+lsp.el
+++ b/modules/tools/lsp/+lsp.el
@@ -1,7 +1,7 @@
 ;;; tools/lsp/+lsp.el -*- lexical-binding: t; -*-
 
 (defvar +lsp-company-backends (if (featurep! :editor snippets)
-                                  '(:separate company-yasnippet company-capf)
+                                  '(:separate company-capf company-yasnippet)
                                 'company-capf)
   "The backends to prepend to `company-backends' in `lsp-mode' buffers.
 Can be a list of backends; accepts any value `company-backends' accepts.")


### PR DESCRIPTION
I noticed after updating that I was seeing a lot of irrelevant results for certain completion scenarios and tracked it down to this commit. Swapping the order does the trick. This ensures that when doing things like completing on `this.` inside classes, the class fields and methods are shown before the yasnippet snippets.

Before: 

![image](https://user-images.githubusercontent.com/441474/110321818-7ecc0a80-8012-11eb-8612-3cb9cf34330c.png)

After:

![image](https://user-images.githubusercontent.com/441474/110321883-93100780-8012-11eb-8339-17266be40577.png)
