### PR TITLE
fix a break change in vterm.el,  (+vterm/here) can't create new terminal any more without this pr

### DIFF
--- a/modules/term/vterm/autoload.el
+++ b/modules/term/vterm/autoload.el
@@ -56,7 +56,7 @@ If prefix ARG is non-nil, cd into `default-directory' instead of project root."
              project-root))
          display-buffer-alist)
     (setenv "PROOT" project-root)
-    (vterm)
+    (vterm vterm-buffer-name)
     (+vterm--change-directory-if-remote)))
 
 (defun +vterm--change-directory-if-remote ()


### PR DESCRIPTION
see https://github.com/akermu/emacs-libvterm/issues/505

I am not a doom user , maybe this is not a best fix, but it works .