### PR TITLE
`git-commit`: use upstream `magit` predicates

### DIFF
--- a/modules/emacs/vc/config.el
+++ b/modules/emacs/vc/config.el
@@ -8,10 +8,6 @@
 (when IS-WINDOWS
   (setenv "GIT_ASKPASS" "git-gui--askpass"))
 
-;; Don't complain when these variables are set in file/local vars
-(put 'git-commit-major-mode 'safe-local-variable 'symbolp)
-(put 'git-commit-summary-max-length 'safe-local-variable 'symbolp)
-
 ;; In case the user is using `bug-reference-mode'
 (map! :when (fboundp 'bug-reference-mode)
       :map bug-reference-map

--- a/modules/tools/magit/packages.el
+++ b/modules/tools/magit/packages.el
@@ -1,7 +1,7 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; tools/magit/packages.el
 
-(when (package! magit :pin "1c60edc86512c53b15e753d6dca319a5e01f83a3")
+(when (package! magit :pin "2277752a176f0b649fd72424d3427bf28184802e")
   (when (featurep! +forge)
     (package! forge :pin "fa80a8789cb15c1b1c5fc7a9e328283202c75135"))
   (package! magit-gitflow :pin "cc41b561ec6eea947fe9a176349fb4f771ed865b")


### PR DESCRIPTION
The same predicates are now specified in upstream magit, so there is no need to
override `safe-local-variable`.


----

#