### PR TITLE
Better defaults for dired

### DIFF
--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -9,6 +9,8 @@
         ;; Always copy/delete recursively
         dired-recursive-copies  'always
         dired-recursive-deletes 'top
+        ;; Ask whether destination dirs should get created when copying/removing files.
+        dired-create-destination-dirs 'ask
         ;; Where to store image caches
         image-dired-dir (concat doom-cache-dir "image-dired/")
         image-dired-db-file (concat image-dired-dir "db.el")


### PR DESCRIPTION
This pr sets `dired-create-destination-dirs` per default to `'ask`, so that the behaviour is more consistent with the one of `find-file`.