### PR TITLE
Fix ivy-resume with ivy-prescient

### DIFF
--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -393,6 +393,10 @@ results buffer.")
     (let ((prescient-filter-method '(literal regexp)))
       (ivy-prescient-re-builder str)))
 
+  ;; Fix `ivy-resume' when invoked with an argument
+  ;; see https://github.com/raxod502/prescient.el/issues/102
+  (add-to-list 'ivy-sort-functions-alist (list 'ivy-resume))
+
   ;; NOTE prescient config duplicated with `company'
   (setq prescient-save-file (concat doom-cache-dir "prescient-save.el")))
 


### PR DESCRIPTION
Hi M.Lissner

ivy-resume can be used with a argument to restore a previous ivy session.

This doesn't work with ivy-prescient installed.

Steps to reproduce :

    1. have ivy and ivy-prescient enabled.
    2. register an ivy session (eg: call M-x or wathever)
    3. C-u ivy-resume
    4. ivy-prescient-sort-function: Wrong type argument: sequencep, counsel-M-x

See https://github.com/raxod502/prescient.el/issues/102