### PR TITLE
Fix #4770: New window is focused after split

### DIFF
--- a/modules/editor/evil/autoload/evil.el
+++ b/modules/editor/evil/autoload/evil.el
@@ -95,17 +95,17 @@ the only window, use evil-window-move-* (e.g. `evil-window-move-far-left')."
 ;;;###autoload
 (defun +evil/window-split-and-follow ()
   "Split current window horizontally, then focus new window.
-If `evil-vsplit-window-right' is non-nil, the new window isn't focused."
+If `evil-split-window-below' is non-nil, the new window isn't focused."
   (interactive)
-  (let ((evil-vsplit-window-right (not evil-vsplit-window-right)))
+  (let ((evil-split-window-below (not evil-split-window-below)))
     (call-interactively #'evil-window-split)))
 
 ;;;###autoload
 (defun +evil/window-vsplit-and-follow ()
   "Split current window vertically, then focus new window.
-If `evil-split-window-below' is non-nil, the new window isn't focused."
+If `evil-vsplit-window-right' is non-nil, the new window isn't focused."
   (interactive)
-  (let ((evil-split-window-below (not evil-split-window-below)))
+  (let ((evil-vsplit-window-right (not evil-vsplit-window-right)))
     (call-interactively #'evil-window-vsplit)))
 
 ;;;###autoload (autoload '+evil:apply-macro "editor/evil/autoload/evil" nil t)


### PR DESCRIPTION
According to the documentation of `evil-window-split` the variable
`evil-split-window-below` needs to be non-nil for the new window to be
created below; and for `evil-window-vsplit` it is the variable
`evil-vsplit-window-right` that needs to be non-nil for the window to be
created on the right.