### PR TITLE
Fix doom-{after,before}-reload-hook doc strings

### DIFF
--- a/core/core.el
+++ b/core/core.el
@@ -135,10 +135,10 @@ users).")
   "Transient hooks run before the first interactively opened buffer.")
 
 (defvar doom-after-reload-hook nil
-  "A list of hooks to run before `doom/reload' has reloaded Doom.")
+  "A list of hooks to run after `doom/reload' has reloaded Doom.")
 
 (defvar doom-before-reload-hook nil
-  "A list of hooks to run after `doom/reload' has reloaded Doom.")
+  "A list of hooks to run before `doom/reload' has reloaded Doom.")
 
 
 ;;


### PR DESCRIPTION
The doc strings for these hooks had "after" and "before" swapped:
- `doom-after-reload-hook`
- `doom-before-reload-hook`