### PR TITLE
Fix `+debugger/start` not working

### DIFF
--- a/modules/tools/debugger/autoload/debugger.el
+++ b/modules/tools/debugger/autoload/debugger.el
@@ -48,7 +48,7 @@ the debugging configuration of the current buffer."
 Presents both dap and realgud configurations, and returns a list of the form
 \('dap ...) or ('realgud ...) containing the corresponding debug configuration
 infromation."
-  (let ((result (mapcar (lambda (c) (cons (cadr c) c))
+  (let* ((result (mapcar (lambda (c) (cons (cadr c) c))
                         (append (+debugger--list-for-dap)
                                 (+debugger--list-for-realgud))))
         (completion (completing-read "Start debugger: " (mapcar #'car result) nil t)))

--- a/modules/tools/debugger/autoload/debugger.el
+++ b/modules/tools/debugger/autoload/debugger.el
@@ -49,9 +49,9 @@ Presents both dap and realgud configurations, and returns a list of the form
 \('dap ...) or ('realgud ...) containing the corresponding debug configuration
 infromation."
   (let* ((result (mapcar (lambda (c) (cons (cadr c) c))
-                        (append (+debugger--list-for-dap)
-                                (+debugger--list-for-realgud))))
-        (completion (completing-read "Start debugger: " (mapcar #'car result) nil t)))
+                         (append (+debugger--list-for-dap)
+                                 (+debugger--list-for-realgud))))
+         (completion (completing-read "Start debugger: " (mapcar #'car result) nil t)))
     (if (or (null completion) (string-empty-p completion))
         (user-error "No debugging configuration specified.")
       (let ((configuration (cdr (assoc completion result))))


### PR DESCRIPTION
Use `let*` instead of `let`, otherwise we get this error `completing-read: Symbol’s value as variable is void: result`.