### PR TITLE
bump evil-nerd-commenter to 3.5.4

### DIFF
--- a/modules/editor/evil/packages.el
+++ b/modules/editor/evil/packages.el
@@ -11,7 +11,7 @@
 (package! evil-exchange :pin "3030e21ee16a42dfce7f7cf86147b778b3f5d8c1")
 (package! evil-indent-plus :pin "0c7501e6efed661242c3a20e0a6c79a6455c2c40")
 (package! evil-lion :pin "6b03593f5dd6e7c9ca02207f9a73615cf94c93ab")
-(package! evil-nerd-commenter :pin "2730820b9ccedf758c8a0428ee2c994c9fc415dd")
+(package! evil-nerd-commenter :pin "b8ac35fe019df5602c31912f65303a3d8ad0066c")
 (package! evil-numbers
   :recipe (:host github :repo "janpath/evil-numbers")
   :pin "006da406d175c05fedca4431cccd569e20bef92c")


### PR DESCRIPTION
This gives us `evilnc-yank-and-comment-operator`, which allows us to yank
a line while simultaneously commenting or uncommenting it.

This function was added just a little while ago at https://github.com/redguardtoo/evil-nerd-commenter/issues/120, and it's been tagged as 3.5.4, which is the same as the commit in this PR.

Not that Spacemacs should be a reference for authority, but I think it had used `g Y` as its prefix for similar functionality (it uses `evil-commentary`, which has had this feature for a while). Quick prodding around shows `g Y` to be free in the Doom ecosystem.

Such a mapping might be as simple as this?

``` lisp
(map!
  :n "g Y" #'evilnc-yank-and-comment-operator
  )
```
I'm happy to add it to the PR as well, if that seems reasonable/useful. But for now this is just a bump :)

I've done some quick testing with a local pin and 3.5.4 works reasonably well.

Thanks for maintaining Doom! :) 