### PR TITLE
Fix non-default REPL's format of command name.

### DIFF
--- a/modules/tools/eval/autoload/repl.el
+++ b/modules/tools/eval/autoload/repl.el
@@ -71,7 +71,7 @@
                (format "+%s/open-%srepl" module
                        (if (string= repl "default")
                            ""
-                         repl))))))
+                         (concat repl "-")))))))
     (let ((region (if (use-region-p)
                       (buffer-substring-no-properties (region-beginning)
                                                       (region-end)))))


### PR DESCRIPTION
Existing REPL commands has a dash ("-") before the "repl" suffix, but the function format to intern doesn't, currently I always get an error `"Couldn't find a valid REPL for %s"` whenever I open a non-default REPL.

For example, choosing "ipython" using `+eval/open-repl-other-window` with an `universal-argument` in `python-mode`.