### PR TITLE
Don't set dash-docs-browser-func to eww.

### DIFF
--- a/modules/tools/lookup/config.el
+++ b/modules/tools/lookup/config.el
@@ -197,8 +197,7 @@ Dictionary.app behind the scenes to get definitions.")
   :config
   (setq dash-docs-enable-debugging doom-debug-p
         dash-docs-docsets-path (concat doom-etc-dir "docsets/")
-        dash-docs-min-length 2
-        dash-docs-browser-func #'eww)
+        dash-docs-min-length 2)
 
   (cond ((featurep! :completion helm)
          (require 'helm-dash nil t))


### PR DESCRIPTION
The only reference of `dash-docs-browser-func` is a lexical binding, which is `#'browse-url` by default anyway.

Setting it to `eww` doesn't make sense because plain `counsel/helm-dash` is hardly usable unless all of local `dash-docs-docset` are installed (which is set by `set-docsets!`).

Using a modern graphical browser is far easier on the eyes.