### PR TITLE
Update clojure-mode to latest commit.

### DIFF
--- a/modules/lang/clojure/packages.el
+++ b/modules/lang/clojure/packages.el
@@ -1,7 +1,7 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; lang/clojure/packages.el
 
-(package! clojure-mode :pin "f26379bc18b089e794d4c3c3a2756c8c9ec0882f")
+(package! clojure-mode :pin "b5c913af12ab3f55723fa3f57d373a4984655e8a ")
 (package! cider :pin "815204f65db8b28524e8eab6421e6d8813a87e89")
 (package! clj-refactor :pin "b24ce76acefe792975f00147c94b4dd784e65b80")
 


### PR DESCRIPTION
Changes to pcase in Emacs master break clojure-mode indentation. A fix in clojure-mode was added in the latest commit.

https://github.com/clojure-emacs/clojure-mode/issues/584