### PR TITLE
Fix deletion in minibuffer under cua-mode

### DIFF
--- a/core/core-ui.el
+++ b/core/core-ui.el
@@ -746,7 +746,7 @@ disable it to fix all that visual noise."
          (ignore-errors (call-interactively ',command)))
        (define-key minibuffer-local-map (kbd ,key) #',key-command))))
 (doom-silence-motion-key backward-delete-char "<backspace>")
-(doom-silence-motion-key delete-char "<delete>")
+(doom-silence-motion-key delete-forward-char "<delete>")
 
 (provide 'core-ui)
 ;;; core-ui.el ends here


### PR DESCRIPTION
With `cua-mode` globally enabled, deleting a text selection in the minibuffer using the `<delete>` key does not work as expected.
Instead, only the character under the cursor is deleted.
By editing the key override for minibuffer as indicated, this problem is resolved.