### PR TITLE
Fix major mode for jupyter-R src block

### DIFF
--- a/modules/lang/org/contrib/jupyter.el
+++ b/modules/lang/org/contrib/jupyter.el
@@ -11,9 +11,10 @@
               "jupyter-R"))
 
   (after! org-src
-    (dolist (lang '(python julia R))
+    (dolist (lang '(python julia))
       (cl-pushnew (cons (format "jupyter-%s" lang) lang)
-                  org-src-lang-modes :key #'car)))
+                  org-src-lang-modes :key #'car))
+    (cl-pushnew '("jupyter-R" . ess-r) org-src-lang-modes :key #'car))
 
   (add-hook! '+org-babel-load-functions
     (defun +org-babel-load-jupyter-h (lang)


### PR DESCRIPTION
## Summary

`R-mode` -> `ess-r-mode`

Actually `R-mode` is a function alias for `ess-r-mode`, but with `R-mode`, `SPC c f` wouldn't work.