### PR TITLE
Remove double underscore from c header templates

### DIFF
--- a/modules/editor/file-templates/templates/c++-mode/__hpp
+++ b/modules/editor/file-templates/templates/c++-mode/__hpp
@@ -2,7 +2,7 @@
 # group: file templates
 # contributor: Henrik Lissner
 # --
-#ifndef ${1:__`(upcase (file-name-base buffer-file-name))`_H_$(upcase yas-text)}
+#ifndef ${1:`(upcase (file-name-base buffer-file-name))`_H_$(upcase yas-text)}
 #define $1
 
 $0

--- a/modules/editor/file-templates/templates/c-mode/__h
+++ b/modules/editor/file-templates/templates/c-mode/__h
@@ -2,7 +2,7 @@
 # group: file templates
 # contributor: Henrik Lissner
 # --
-#ifndef ${1:__`(upcase (file-name-base buffer-file-name))`_H_$(upcase yas-text)}
+#ifndef ${1:`(upcase (file-name-base buffer-file-name))`_H_$(upcase yas-text)}
 #define $1
 
 $0


### PR DESCRIPTION
Using double underscore for an identifier in C/C++ invokes undefined
behavior.

From https://eel.is/c++draft/lex.name:

Each identifier that contains a double underscore __ or begins with an
underscore followed by an uppercase letter is reserved to the
implementation for any use.