### PR TITLE
Add `:lang zig` module

### DIFF
--- a/docs/modules.org
+++ b/docs/modules.org
@@ -151,6 +151,7 @@ Modules that bring support for a language or group of languages to Emacs.
 + terra - TODO
 + web =+lsp= - HTML and CSS (SCSS/SASS/LESS/Stylus) support.
 + [[file:../modules/lang/yaml/README.org][yaml]] =+lsp= - TODO
++ [[file:../modules/lang/zig/README.org][zig]] =+lsp= - Zig support.
 
 
 * :os

--- a/init.example.el
+++ b/init.example.el
@@ -167,6 +167,7 @@
        ;;terra             ; Earth and Moon in alignment for performance.
        ;;web               ; the tubes
        ;;yaml              ; JSON, but readable
+       ;;zig               ; C, but simpler
 
        :email
        ;;(mu4e +gmail)

--- a/modules/lang/zig/README.org
+++ b/modules/lang/zig/README.org
@@ -58,10 +58,9 @@ This module supports LSP integration. For it to work you'll need:
 
 * Configuration
 ** Customize zls path
-To customize the path of the =zls= executable, modify
-~lsp-clients-zls-executable~.
+To customize the path of the =zls= executable, modify ~lsp-zig-zls-executable~.
 
 #+BEGIN_SRC elisp
 ;; in $DOOMDIR/config.el
-(setq lsp-clients-zls-executable "~/path/to/zls")
+(setq lsp-zig-zls-executable "~/path/to/zls")
 #+END_SRC

--- a/modules/lang/zig/README.org
+++ b/modules/lang/zig/README.org
@@ -1,0 +1,67 @@
+#+TITLE:   lang/zig
+#+DATE:    March 18, 2021
+#+SINCE:   v2.0.9
+#+STARTUP: inlineimages nofold
+
+* Table of Contents :TOC_3:noexport:
+- [[#description][Description]]
+  - [[#maintainers][Maintainers]]
+  - [[#module-flags][Module Flags]]
+  - [[#plugins][Plugins]]
+- [[#prerequisites][Prerequisites]]
+- [[#features][Features]]
+  - [[#lsp-support][LSP support]]
+  - [[#keybinds][Keybinds]]
+- [[#configuration][Configuration]]
+  - [[#customize-zls-path][Customize zls path]]
+
+* Description
+This module adds [[https://ziglang.org/][Zig]] support, with optional (but recommended) LSP support via
+[[https://github.com/zigtools/zls][zls]].
+
++ Syntax highlighting
++ Syntax-checking (~flycheck~)
++ Code completion and LSP integration (~zls~)
+
+** Maintainers
++ [[https://github.com/bnjmnt4n][@bnjmnt4n]] (Author)
+
+** Module Flags
++ =+lsp= Enables integration for the zls LSP server. It is highly recommended
+  you use this.
+
+** Plugins
++ [[https://github.com/ziglang/zig-mode][zig-mode]]
+
+* Prerequisites
+To get started with Zig, you need the ~zig~ tool. Pre-built binaries for most
+systems are available for download from [[https://ziglang.org/download/]] or from
+[[https://github.com/ziglang/zig/wiki/Install-Zig-from-a-Package-Manager][system package managers]].
+
+zls is a language server for Zig, which provides code completion,
+
+* Features
+** LSP support
+This module supports LSP integration. For it to work you'll need:
+
+1. zls installed.
+2. The =:tools lsp= module enabled. Only =lsp-mode= is supported for now.
+3. The ~+lsp~ flag on this module enabled.
+
+** Keybinds
+| Binding           | Description         |
+|-------------------+---------------------|
+| ~<localleader> b~ | ~zig-compile~       |
+| ~<localleader> f~ | ~zig-format-buffer~ |
+| ~<localleader> r~ | ~zig-run~           |
+| ~<localleader> t~ | ~zig-test-buffer~   |
+
+* Configuration
+** Customize zls path
+To customize the path of the =zls= executable, modify
+~lsp-clients-zls-executable~.
+
+#+BEGIN_SRC elisp
+;; in $DOOMDIR/config.el
+(setq lsp-clients-zls-executable "~/path/to/zls")
+#+END_SRC

--- a/modules/lang/zig/config.el
+++ b/modules/lang/zig/config.el
@@ -12,14 +12,15 @@
   :config
   ;; Disable zig-mode's default format on save behaviour.
   (setq zig-format-on-save nil)
-  (when (featurep! +lsp)
-    (add-hook 'zig-mode-local-vars-hook #'lsp!))
   (map! :localleader
         :map zig-mode-map
         "b" #'zig-compile
         "f" #'zig-format-buffer
         "r" #'zig-run
         "t" #'zig-test-buffer))
+
+(when (featurep! +lsp)
+  (add-hook 'zig-mode-local-vars-hook #'lsp!))
 
 (when (featurep! :checkers syntax)
   (flycheck-define-checker zig

--- a/modules/lang/zig/config.el
+++ b/modules/lang/zig/config.el
@@ -1,32 +1,32 @@
 ;;; lang/zig/config.el -*- lexical-binding: t; -*-
 
 (after! projectile
-  (pushnew! projectile-project-root-files "build.zig"))
+  (add-to-list 'projectile-project-root-files "build.zig"))
 
 
 ;;
-;; zig-mode
+;;; Packages
 
 (use-package! zig-mode
   :hook (zig-mode . rainbow-delimiters-mode)
   :config
-  ;; Disable zig-mode's default format on save behaviour.
-  (setq zig-format-on-save nil)
+  (setq zig-format-on-save (featurep! :editor format +onsave))
+
+  (when (featurep! +lsp)
+    (add-hook 'zig-mode-local-vars-hook #'lsp!))
+
+  (when (featurep! :checkers syntax)
+    (flycheck-define-checker zig
+      "A zig syntax checker using the zig-fmt interpreter."
+      :command ("zig" "fmt" (eval (buffer-file-name)))
+      :error-patterns
+      ((error line-start (file-name) ":" line ":" column ": error: " (message) line-end))
+      :modes zig-mode)
+    (add-to-list 'flycheck-checkers 'zig))
+              
   (map! :localleader
         :map zig-mode-map
         "b" #'zig-compile
         "f" #'zig-format-buffer
         "r" #'zig-run
         "t" #'zig-test-buffer))
-
-(when (featurep! +lsp)
-  (add-hook 'zig-mode-local-vars-hook #'lsp!))
-
-(when (featurep! :checkers syntax)
-  (flycheck-define-checker zig
-    "A zig syntax checker using the zig-fmt interpreter."
-    :command ("zig" "fmt" (eval (buffer-file-name)))
-    :error-patterns
-    ((error line-start (file-name) ":" line ":" column ": error: " (message) line-end))
-    :modes zig-mode)
-  (add-to-list 'flycheck-checkers 'zig))

--- a/modules/lang/zig/config.el
+++ b/modules/lang/zig/config.el
@@ -1,0 +1,34 @@
+;;; lang/zig/config.el -*- lexical-binding: t; -*-
+
+(after! projectile
+  (pushnew! projectile-project-root-files "build.zig"))
+
+
+;;
+;; zig-mode
+
+(use-package! zig-mode
+  :mode "\\.zig$"
+  :hook (zig-mode . rainbow-delimiters-mode)
+  :config
+  ;; Disable zig-mode's default format on save behaviour.
+  (setq zig-format-on-save nil)
+  (when (featurep! +lsp)
+    (add-hook 'zig-mode-local-vars-hook #'lsp!)))
+
+(map! :localleader
+      (:after zig-mode
+        :map zig-mode-map
+        "b" #'zig-compile
+        "f" #'zig-format-buffer
+        "r" #'zig-run
+        "t" #'zig-test-buffer))
+
+(when (featurep! :checkers syntax)
+  (flycheck-define-checker zig
+    "A zig syntax checker using the zig-fmt interpreter."
+    :command ("zig" "fmt" (eval (buffer-file-name)))
+    :error-patterns
+    ((error line-start (file-name) ":" line ":" column ": error: " (message) line-end))
+    :modes zig-mode)
+  (add-to-list 'flycheck-checkers 'zig))

--- a/modules/lang/zig/config.el
+++ b/modules/lang/zig/config.el
@@ -8,7 +8,6 @@
 ;; zig-mode
 
 (use-package! zig-mode
-  :mode "\\.zig$"
   :hook (zig-mode . rainbow-delimiters-mode)
   :config
   ;; Disable zig-mode's default format on save behaviour.

--- a/modules/lang/zig/config.el
+++ b/modules/lang/zig/config.el
@@ -14,10 +14,8 @@
   ;; Disable zig-mode's default format on save behaviour.
   (setq zig-format-on-save nil)
   (when (featurep! +lsp)
-    (add-hook 'zig-mode-local-vars-hook #'lsp!)))
-
-(map! :localleader
-      (:after zig-mode
+    (add-hook 'zig-mode-local-vars-hook #'lsp!))
+  (map! :localleader
         :map zig-mode-map
         "b" #'zig-compile
         "f" #'zig-format-buffer

--- a/modules/lang/zig/doctor.el
+++ b/modules/lang/zig/doctor.el
@@ -1,0 +1,13 @@
+;; -*- lexical-binding: t; no-byte-compile: t; -*-
+;;; lang/zig/doctor.el
+
+(assert! (or (not (featurep! +lsp))
+             (featurep! :tools lsp))
+         "This module requires (:tools lsp)")
+
+(unless (executable-find "zig")
+  (warn! "Couldn't find zig binary"))
+
+(when (featurep! +lsp)
+  (unless (executable-find "zls")
+    (warn! "Couldn't find zls binary")))

--- a/modules/lang/zig/packages.el
+++ b/modules/lang/zig/packages.el
@@ -1,0 +1,4 @@
+;; -*- no-byte-compile: t; -*-
+;;; lang/zig/packages.el
+
+(package! zig-mode :pin "6f10653cc17b9c74150ac2f6833eaaaf55488398")

--- a/modules/lang/zig/packages.el
+++ b/modules/lang/zig/packages.el
@@ -1,4 +1,4 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; lang/zig/packages.el
 
-(package! zig-mode :pin "6f10653cc17b9c74150ac2f6833eaaaf55488398")
+(package! zig-mode :pin "2d0eb23e6b5c12b946f12c23803157605c90f02f")

--- a/modules/tools/lsp/README.org
+++ b/modules/tools/lsp/README.org
@@ -56,6 +56,7 @@ As of this writing, this is the state of LSP support in Doom Emacs:
 | [[../../lang/swift/README.org][:lang swift]]      | swift-mode                                              | sourcekit                                                     |
 | [[../../lang/web/README.org][:lang web]]        | web-mode, css-mode, scss-mode, sass-mode, less-css-mode | vscode-css-languageserver-bin, vscode-html-languageserver-bin |
 | [[../../lang/purescript/README.org][:lang purescript]] | purescript-mode                                         | purescript-language-server                                    |
+| [[../../lang/zig/README.org][:lang zig]]        | zig-mode                                                | zls                                                           |
 
 ** Module Flags
 + =+peek= Use =lsp-ui-peek= when looking up definitions and references with


### PR DESCRIPTION
This PR adds a language module for Zig. It turns out that there's less configuration than I expected, especially following updates to lsp-mode (https://github.com/emacs-lsp/lsp-mode/pull/2723), so let me know if you'd rather not add this as a module. Otherwise, I can write up the documentation for the module as well.

Ref. #4656.