### PR TITLE
Update vterm installation instructions for NixOS

### DIFF
--- a/modules/term/vterm/README.org
+++ b/modules/term/vterm/README.org
@@ -70,7 +70,7 @@ variable (=SPC h v system-configuration-options=).
   #+BEGIN_SRC nix
   programs.emacs = {
     enable = true;
-    extraPackages = epkgs: [ epkgs.emacs-libvterm ];
+    extraPackages = epkgs: [ epkgs.vterm ];
   };
   #+END_SRC
 


### PR DESCRIPTION
According to `home-manager`:
```
trace: Melpa attribute 'emacs-libvterm' is a legacy alias that will be removed in 21.03, use 'vterm' instead
```

:point_up: is just a warning. `home-manager` builds without errors either with `emacs-libvterm` or `vterm`.

FYI, my home-manager config is set to `home.stateVersion = "21.03";`. I wonder if we want to include instructions for previous versions as well.