### PR TITLE
ignore extension installed by lang/dart and recover behaviour of +vterm/here

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 \#*
 .\#*
 .local/
+.extension/
 *.cache*
 *.log
 /modules/private

--- a/modules/term/vterm/autoload.el
+++ b/modules/term/vterm/autoload.el
@@ -56,7 +56,7 @@ If prefix ARG is non-nil, cd into `default-directory' instead of project root."
              project-root))
          display-buffer-alist)
     (setenv "PROOT" project-root)
-    (vterm)
+    (vterm vterm-buffer-name)
     (+vterm--change-directory-if-remote)))
 
 (defun +vterm--change-directory-if-remote ()


### PR DESCRIPTION
1. lang/dart installs extension to ~/.emacs.d/.extension/vscode/Dart-Code.Dart-Code/.
2. emacs-libvterm makes +vterm/here not open new vterm buffer any more
   due to commit: https://github.com/akermu/emacs-libvterm/commit/c2c2c8afb935c11778388721912250cd1103aaf9