### PR TITLE
notmuch -- respect +afew feature flag, fix sync buffer kill

### DIFF
--- a/modules/email/notmuch/config.el
+++ b/modules/email/notmuch/config.el
@@ -66,7 +66,7 @@
   (map! :localleader
         :map (notmuch-hello-mode-map notmuch-search-mode-map notmuch-tree-mode-map notmuch-show-mode-map)
         :desc "Compose email"   "c" #'+notmuch/compose
-        :desc "Sync email" "u" #'+notmuch/update
+        :desc "Sync email"      "u" #'+notmuch/update
         :desc "Quit notmuch"    "q" #'+notmuch/quit
         :map notmuch-search-mode-map
         :desc "Mark as deleted" "d" #'+notmuch/search-delete

--- a/modules/email/notmuch/config.el
+++ b/modules/email/notmuch/config.el
@@ -64,9 +64,9 @@
              #'hide-mode-line-mode)
  
   (map! :localleader
-        :map (notmuch-search-mode-map notmuch-tree-mode-map notmuch-show-mode-map)
+        :map (notmuch-hello-mode-map notmuch-search-mode-map notmuch-tree-mode-map notmuch-show-mode-map)
         :desc "Compose email"   "c" #'+notmuch/compose
-        :desc "Fetch new email" "u" #'+notmuch/update
+        :desc "Sync email" "u" #'+notmuch/update
         :desc "Quit notmuch"    "q" #'+notmuch/quit
         :map notmuch-search-mode-map
         :desc "Mark as deleted" "d" #'+notmuch/search-delete


### PR DESCRIPTION
When #3933 was closed, part of it's documentation snuck in. The part about the `+afew` feature flag is in the docs, but it's not respected.

This change will make it be respected. It also edits the notmuch sync function to use `compile` in order to address the problems described in https://github.com/hlissner/doom-emacs/issues/3188

Please consider this for merge.