### PR TITLE
Add counsel-outline to :not ivy-prescient-sort-commands

### DIFF
--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -387,9 +387,9 @@ results buffer.")
   (setq ivy-prescient-sort-commands
         '(:not swiper swiper-isearch ivy-switch-buffer
           lsp-ivy-workspace-symbol ivy-resume ivy--restore-session
-          counsel-grep counsel-git-grep counsel-rg counsel-ag
-          counsel-ack counsel-fzf counsel-pt counsel-imenu
-          counsel-yank-pop counsel-recentf counsel-buffer-or-recentf)
+          counsel-grep counsel-git-grep counsel-rg counsel-ag counsel-ack
+          counsel-fzf counsel-pt counsel-imenu counsel-yank-pop counsel-recentf
+          counsel-buffer-or-recentf counsel-outline)
         ivy-prescient-retain-classic-highlighting t)
   (defun +ivy-prescient-non-fuzzy (str)
     (let ((prescient-filter-method '(literal regexp)))


### PR DESCRIPTION
It doesn't make sense to sort the outline, better to leave the order as-is.