### PR TITLE
Active pyenv-mode only when pyenv exe is found

### DIFF
--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -243,8 +243,8 @@
   :when (featurep! +pyenv)
   :after python
   :config
-  (pyenv-mode +1)
   (when (executable-find "pyenv")
+    (pyenv-mode +1)
     (add-to-list 'exec-path (expand-file-name "shims" (or (getenv "PYENV_ROOT") "~/.pyenv"))))
   (add-hook 'python-mode-local-vars-hook #'+python-pyenv-mode-set-auto-h)
   (add-hook 'doom-switch-buffer-hook #'+python-pyenv-mode-set-auto-h))


### PR DESCRIPTION
When "pyenv"'s executable isn't found, `pyenv-mode` fails miserably, making`python-mode` unusable.
 "pyenv"'s executable is always searched for, so there's no additional performance penalty.

Use case: shared config among machines with and without pyenv installed.