### PR TITLE
Suppress highlight-indent-guides's auto errors

### DIFF
--- a/modules/ui/indent-guides/config.el
+++ b/modules/ui/indent-guides/config.el
@@ -3,7 +3,8 @@
 (use-package! highlight-indent-guides
   :hook ((prog-mode text-mode conf-mode) . highlight-indent-guides-mode)
   :init
-  (setq highlight-indent-guides-method 'character)
+  (setq highlight-indent-guides-method 'character
+        highlight-indent-guides-suppress-auto-error t)
   :config
   (defun +indent-guides-init-faces-h (&rest _)
     (when (display-graphic-p)


### PR DESCRIPTION
Otherwise it constantly spams the echo area in tty Emacs.