### PR TITLE
Change poetry-tracking-strategy for performance

### DIFF
--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -290,6 +290,7 @@
   :when (featurep! +poetry)
   :after python
   :init
+  (setq poetry-tracking-strategy 'switch-buffer)
   (add-hook 'python-mode-hook #'poetry-tracking-mode))
 
 


### PR DESCRIPTION
`poetry-tracking-strategy`'s docstring:
```
  - `post-command' (default): check after every command (can be quite slow but ensure
that the virtualenv is always the good one).
```
With `(python +poetry)` and a Python buffer opened, Emacs dedicates ~25% CPU time (measured by `(profiler-start 'cpu)`) when scrolling continuously with `next-line`, which violates Doom's performance goal.