### PR TITLE
Fix vterm popup rule

### DIFF
--- a/modules/term/vterm/config.el
+++ b/modules/term/vterm/config.el
@@ -6,7 +6,7 @@
   :hook (vterm-mode . doom-mark-buffer-as-real-h)
   :hook (vterm-mode . hide-mode-line-mode) ; modeline serves no purpose in vterm
   :config
-  (set-popup-rule! "^vterm" :size 0.25 :vslot -4 :select t :quit nil :ttl 0)
+  (set-popup-rule! "^\\*vterm" :size 0.25 :vslot -4 :select t :quit nil :ttl 0)
 
   ;; Once vterm is dead, the vterm buffer is useless. Why keep it around? We can
   ;; spawn another if want one.


### PR DESCRIPTION
akermu/emacs-libvterm@c2c2c8afb935c11778388721912250cd1103aaf9 changed
the default buffer name of vterm buffers, so Doom's popup-rule no longer
matches them. This causes functions like `+vterm/here` to use the entire
frame instead of creating a popup window.

Fix it by changing the popup rule to match the new naming scheme.