### PR TITLE
Bump :editor evil

### DIFF
--- a/modules/editor/evil/packages.el
+++ b/modules/editor/evil/packages.el
@@ -1,7 +1,7 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; editor/evil/packages.el
 
-(package! evil :pin "7eace67fc6d1f992e447f216baf9a8b7be634c1e")
+(package! evil :pin "d998a8195e404b01e2ea62a455c3dec74d0823c3")
 (package! evil-args :pin "758ad5ae54ad34202064fec192c88151c08cb387")
 (package! evil-easymotion :pin "f96c2ed38ddc07908db7c3c11bcd6285a3e8c2e9")
 (package! evil-embrace :pin "4379adea032b25e359d01a36301b4a5afdd0d1b7")
@@ -35,4 +35,4 @@
     (package! neotree)
     (autoload 'neotree-make-executor "neotree" nil nil 'macro))
 
-  (package! evil-collection :pin "b45ec5b3156d27a18a949e4bf55643107a21abc2"))
+  (package! evil-collection :pin "b6025cf9eaf7b4659db918548fd6d96ed17fddc6"))


### PR DESCRIPTION
emacs-evil/evil-collection@b45ec5b → emacs-evil/evil-collection@b6025cf
emacs-evil/evil@7eace67 -> emacs-evil/evil@d998a81

The register system has been rejigged in the last week, and some
packages in the Evil ecosystem are already making use of the new vars.

emacs-evil/evil@229ebb4
mamapanda/evil-owl#10