### PR TITLE
Fix Groovy REPL's command name

### DIFF
--- a/modules/lang/java/autoload/java.el
+++ b/modules/lang/java/autoload/java.el
@@ -73,7 +73,7 @@ root)."
       "ClassName"))
 
 ;;;###autoload
-(defun +java/groovy-open-repl ()
+(defun +java/open-groovy-repl ()
   "Open a Groovy REPL."
   (interactive)
   (call-interactively #'run-groovy)

--- a/modules/lang/java/config.el
+++ b/modules/lang/java/config.el
@@ -48,4 +48,4 @@ If the depth is 2, the first two directories are removed: net.lissner.game.")
   :config
   (set-docsets! 'groovy-mode "Groovy" "Groovy_JDK")
   (set-eval-handler! 'groovy-mode "groovy")
-  (set-repl-handler! 'groovy-mode #'+java/groovy-open-repl))
+  (set-repl-handler! 'groovy-mode #'+java/open-groovy-repl))


### PR DESCRIPTION
+java/groovy-open-repl -> +java/open-groovy-repl: the old name's format
can't be found via `+eval-open-repl`