### PR TITLE
Indicate that lsp-describe-thing-at-point is async

### DIFF
--- a/modules/tools/lsp/+lsp.el
+++ b/modules/tools/lsp/+lsp.el
@@ -59,7 +59,7 @@ about it (it will be logged to *Messages* however).")
     :definition #'+lsp-lookup-definition-handler
     :references #'+lsp-lookup-references-handler
     :documentation '(lsp-describe-thing-at-point :async t)
-    :implementations #'lsp-find-implementation
+    :implementations '(lsp-find-implementation :async t)
     :type-definition #'lsp-find-type-definition)
 
   (defadvice! +lsp--respect-user-defined-checkers-a (orig-fn &rest args)

--- a/modules/tools/lsp/+lsp.el
+++ b/modules/tools/lsp/+lsp.el
@@ -58,7 +58,7 @@ about it (it will be logged to *Messages* however).")
   (set-lookup-handlers! 'lsp-mode
     :definition #'+lsp-lookup-definition-handler
     :references #'+lsp-lookup-references-handler
-    :documentation #'lsp-describe-thing-at-point
+    :documentation '(lsp-describe-thing-at-point :async t)
     :implementations #'lsp-find-implementation
     :type-definition #'lsp-find-type-definition)
 


### PR DESCRIPTION
- otherwise, `+lookup-online-backend-fn` would be called as well
- lsp-describe-thing-at-point was marked as not async in
  https://github.com/hlissner/doom-emacs/commit/d4eb7e31ac25107a35f9de567a497d9100fcc1ff
- but `lsp-describe-thing-at-point` calls `lsp--make-request`
  internally (which is async I assume):
  https://github.com/emacs-lsp/lsp-mode/blob/eda51c21662253fd05b4f3f20ad7b029d9c2aff7/lsp-mode.el#L4677