### PR TITLE
Fix doom-module-mplist-map obsolete module warning

### DIFF
--- a/core/core-modules.el
+++ b/core/core-modules.el
@@ -288,7 +288,7 @@ those directories. The first returned path is always `doom-private-dir'."
                  (when-let (new (assq module obsolete))
                    (let ((newkeys (cdr new)))
                      (if (null newkeys)
-                         (message "WARNING %s module was removed" key)
+                         (message "WARNING %s module was removed" (list category module))
                        (if (cdr newkeys)
                            (message "WARNING %s module was removed and split into the %s modules"
                                     (list category module) (mapconcat #'prin1-to-string newkeys ", "))


### PR DESCRIPTION
Inside `doom-module-mplist-map`, one of the code paths handling obsolete module warnings references a `key` variable, which appears to be unbound.
```elisp
(message "WARNING %s module was removed" key)
```
I changed `key` to `(list category module)`, which appears to be what was intended and is consistent with neighboring code paths.

__Note__: Untested. I don't have doom installed, but I noticed this while reading through the code.