### PR TITLE
tools/lsp: mark lookup handlers for lsp-mode as async

### DIFF
--- a/modules/tools/lsp/+lsp.el
+++ b/modules/tools/lsp/+lsp.el
@@ -55,11 +55,11 @@ about it (it will be logged to *Messages* however).")
         lsp-groovy-server-file (expand-file-name "groovy-language-server-all.jar" lsp-server-install-dir))
 
   (set-popup-rule! "^\\*lsp-help" :size 0.35 :quit t :select t)
-  (set-lookup-handlers! 'lsp-mode
+  (set-lookup-handlers! 'lsp-mode :async t
     :definition #'+lsp-lookup-definition-handler
     :references #'+lsp-lookup-references-handler
-    :documentation '(lsp-describe-thing-at-point :async t)
-    :implementations '(lsp-find-implementation :async t)
+    :documentation #'lsp-describe-thing-at-point
+    :implementations #'lsp-find-implementation
     :type-definition #'lsp-find-type-definition)
 
   (defadvice! +lsp--respect-user-defined-checkers-a (orig-fn &rest args)


### PR DESCRIPTION
- otherwise, +lsp-lookup-definition-handler and +lsp-lookup-references-handler
  would fail when the definition/reference is in another file
- related:
  + https://github.com/hlissner/doom-emacs/pull/4875
  + https://github.com/hlissner/doom-emacs/issues/4771