### PR TITLE
Fix treemacs + lsp doctor check

### DIFF
--- a/modules/ui/treemacs/doctor.el
+++ b/modules/ui/treemacs/doctor.el
@@ -1,5 +1,5 @@
 ;;; ui/treemacs/doctor.el -*- lexical-binding: t; -*-
 
-(assert! (and (not (featurep! :tools lsp +eglot))
-              (featurep! +lsp))
+(assert! (not (and (featurep! +lsp)
+                   (featurep! :tools lsp +eglot)))
          "+lsp flag is not supported with eglot, only with lsp-mode.")


### PR DESCRIPTION
The previous check was incorrect when eglot and treemacs without lsp was
on.