### PR TITLE
Use correct `brew install --cask` command

### DIFF
--- a/modules/lang/latex/README.org
+++ b/modules/lang/latex/README.org
@@ -69,9 +69,9 @@ pacman -S texlive-core
 
 ** TODO macOS
 #+BEGIN_SRC sh
-brew cask install basictex
+brew install --cask basictex
 # If the above doesn't work, then
-brew cask install mactex  # WARNING: large 4gb download!
+brew install --cask mactex  # WARNING: large 4gb download!
 #+END_SRC
 
 #+begin_quote

--- a/modules/lang/org/README.org
+++ b/modules/lang/org/README.org
@@ -184,7 +184,7 @@ esoteric features:
 
 ** MacOS
 #+BEGIN_SRC sh
-brew cask install mactex
+brew install --cask mactex
 brew install gnuplot
 #+END_SRC
 


### PR DESCRIPTION
I've noticed that some docs are a bit outdated, as homebrew doesn't have
`brew cask` command now, all features regarding to casks were moved to
the option `--cask` instead.

This commit just introduce such changes to be up-to-date with homebrew instructions.