### PR TITLE
Syntax highlight .sface files as html

### DIFF
--- a/modules/lang/web/+html.el
+++ b/modules/lang/web/+html.el
@@ -5,6 +5,7 @@
   :mode "\\.\\(?:tpl\\|blade\\)\\(?:\\.php\\)?\\'"
   :mode "\\.erb\\'"
   :mode "\\.l?eex\\'"
+  :mode "\\.sface\\'"
   :mode "\\.jsp\\'"
   :mode "\\.as[cp]x\\'"
   :mode "\\.hbs\\'"


### PR DESCRIPTION
[Phoenix.LiveView](https://hexdocs.pm/phoenix_live_view) has a project called [Surface](https://surface-ui.org/) that adds a `.sface` extension to files. These should be syntax highlighted as html.

First PR!