### PR TITLE
Proper fix for "[BUG] org-tree-slide mode does not show headings"

### DIFF
--- a/modules/lang/org/contrib/present.el
+++ b/modules/lang/org/contrib/present.el
@@ -51,7 +51,6 @@
                      (when (org-before-first-heading-p)
                        (org-next-visible-heading 1))
                      (ignore-errors (org-up-heading-all 99))
-                     (forward-line 1)
                      (point))
                    (progn (org-end-of-subtree t t)
                           (when (and (org-at-heading-p) (not (eobp)))


### PR DESCRIPTION
https://github.com/hlissner/doom-emacs/issues/2182 still exist and the cause was not that explained in https://github.com/hlissner/doom-emacs/issues/2182#issuecomment-564899286.

The cause is from the line I'm removing in this PR, which actually skips the heading.