### PR TITLE
Java: Jshell REPL integration

### DIFF
--- a/modules/lang/java/autoload/repl.el
+++ b/modules/lang/java/autoload/repl.el
@@ -1,0 +1,46 @@
+;;; lang/java/autoload/repl.el -*- lexical-binding: t; -*-
+
+(defvar +java/inferior-java-program "jshell"
+  "Default Java interactive shell command.")
+
+(defvar +java/inferior-java-buffer-name-sans* +java/inferior-java-program
+  "Default Java REPL buffer name, sans \"*\".")
+
+(defvar +java/java-buffer nil)
+
+;;;###autoload
+(defun +java/run-java (cmd)
+  "Run an inferior Java process.
+
+With argument, allows you to edit the command line (default is
+value of `+java/inferior-java-program')."
+  (interactive
+   (list (if current-prefix-arg
+             (read-shell-command "Run java: " +java/inferior-java-program)
+           +java/inferior-java-program)))
+  (let ((buffer (make-comint +java/inferior-java-buffer-name-sans*
+                             (or cmd +java/inferior-java-program))))
+    (with-current-buffer buffer
+      (+java/inferior-java-mode)
+      (setq +java/java-buffer (buffer-name)))
+    (pop-to-buffer buffer)))
+
+;;;###autoload
+(defun +java/open-repl ()
+  "Open a Java REPL."
+  (interactive)
+  (call-interactively #'+java/run-java)
+  (get-buffer +java/java-buffer))
+
+(define-derived-mode +java/inferior-java-mode comint-mode "Inferior Java"
+  "Major mode for interacting with an inferior Java process.
+Runs a Java interpreter as a subprocess of Emacs, with Java I/O
+through an Emacs buffer. Variable `+java/inferior-java-program'
+controls which Java interpreter is run.
+
+The following commands are available:
+\\{+java/inferior-java-mode-map}."
+  (compilation-shell-minor-mode 1))
+
+(set-popup-rule! (concat "^\\*" +java/inferior-java-buffer-name-sans* "\\*$"))
+(set-repl-handler! 'java-mode #'+java/open-repl)

--- a/modules/lang/java/autoload/repl.el
+++ b/modules/lang/java/autoload/repl.el
@@ -1,11 +1,5 @@
 ;;; lang/java/autoload/repl.el -*- lexical-binding: t; -*-
 
-(defvar +java/inferior-java-program "jshell"
-  "Default Java interactive shell command.")
-
-(defvar +java/inferior-java-buffer-name-sans* +java/inferior-java-program
-  "Default Java REPL buffer name, sans \"*\".")
-
 (defvar +java/java-buffer nil)
 
 ;;;###autoload
@@ -15,15 +9,20 @@
 With argument, allows you to edit the command line (default is
 value of `+java/inferior-java-program')."
   (interactive
-   (list (if current-prefix-arg
-             (read-shell-command "Run java: " +java/inferior-java-program)
-           +java/inferior-java-program)))
-  (let ((buffer (make-comint +java/inferior-java-buffer-name-sans*
-                             (or cmd +java/inferior-java-program))))
+   (list
+    (if current-prefix-arg
+        (read-shell-command "Run java: " +java/inferior-java-program)
+      +java/inferior-java-program)))
+  (let ((buffer
+         (if (comint-check-proc +java/java-buffer)
+             +java/java-buffer
+           (make-comint +java/inferior-java-buffer-name-sans*
+                        (or cmd +java/inferior-java-program)))))
     (with-current-buffer buffer
       (+java/inferior-java-mode)
       (setq +java/java-buffer (buffer-name)))
-    (pop-to-buffer buffer)))
+    (pop-to-buffer buffer)
+    (get-buffer-process buffer)))
 
 ;;;###autoload
 (defun +java/open-repl ()
@@ -41,6 +40,3 @@ controls which Java interpreter is run.
 The following commands are available:
 \\{+java/inferior-java-mode-map}."
   (compilation-shell-minor-mode 1))
-
-(set-popup-rule! (concat "^\\*" +java/inferior-java-buffer-name-sans* "\\*$"))
-(set-repl-handler! 'java-mode #'+java/open-repl)

--- a/modules/lang/java/config.el
+++ b/modules/lang/java/config.el
@@ -30,6 +30,13 @@ If the depth is 2, the first two directories are removed: net.lissner.game.")
       ((featurep! :tools lsp +eglot))
       ((featurep! +lsp)       (load! "+lsp")))
 
+(defvar +java/inferior-java-program "jshell"
+  "Default Java interactive shell command.")
+(defvar +java/inferior-java-buffer-name-sans* +java/inferior-java-program
+  "Default Java REPL buffer name, sans \"*\".")
+(after! cc-mode
+  (set-popup-rule! (concat "^\\*" +java/inferior-java-buffer-name-sans* "\\*$"))
+  (set-repl-handler! 'java-mode #'+java/open-repl))
 
 ;;
 ;;; Common packages


### PR DESCRIPTION
New commands: `+java/run-java` (which utilizes `jshell` under the hood), `+java/open-repl` (which calls the former).

Make `+java/open-repl` `java-mode`'s default REPL.

Syntax highlighting is still unavailable.

(Edit: grammar)