### PR TITLE
config/default: Fix C-return binding in GUI Emacs

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -480,6 +480,7 @@
         [tab]        #'company-complete-common-or-cycle
         [backtab]    #'company-select-previous
         "C-RET"      #'counsel-company
+        "C-<return>" #'counsel-company
         :map company-search-map
         "C-n"        #'company-search-repeat-forward
         "C-p"        #'company-search-repeat-backward


### PR DESCRIPTION
The "C-RET" counsel-company binding does only seem to work when running Emacs in a
terminal. "C-<return>" makes it work when running the desktop version too.