### PR TITLE
Bump :lang swift (update lsp-sourcekit and add support for sourcekit-lsp bundled with Xcode)

### DIFF
--- a/modules/lang/swift/config.el
+++ b/modules/lang/swift/config.el
@@ -24,11 +24,10 @@
   :after swift-mode
   :init (add-hook 'swift-mode-local-vars-hook #'lsp!)
   :config
-  (unless (getenv "SOURCEKIT_TOOLCHAIN_PATH")
-    (setenv "SOURCEKIT_TOOLCHAIN_PATH" "/Library/Developer/Toolchains/swift-latest.xctoolchain"))
   (setq lsp-sourcekit-executable
         (cl-find-if #'executable-find
-                    (list lsp-sourcekit-executable ; 'sourcekit' by default
-                          "sourcekit-lsp"
-                          "/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin/sourcekit"
-                          "/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin/sourcekit-lsp"))))
+                    (list lsp-sourcekit-executable ; 'sourcekit-lsp' by default
+                          "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/sourcekit-lsp"
+                          "sourcekit"
+                          "/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin/sourcekit-lsp"
+                          "/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin/sourcekit"))))

--- a/modules/lang/swift/packages.el
+++ b/modules/lang/swift/packages.el
@@ -1,10 +1,10 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; lang/swift/packages.el
 
-(package! swift-mode :pin "95ff0041370660e839ed06aa92330694d8590d62")
+(package! swift-mode :pin "ad12a3025156873995318b6a0480cd2459063bf7")
 
 (if (featurep! +lsp)
-    (package! lsp-sourcekit :pin "ff204ed820df8c3035ebdc4b5a583640d52caeeb")
+    (package! lsp-sourcekit :pin "aafa9878a3df2f08e5a9c846d91fd53350ce3c99")
   (when (featurep! :completion company)
     (package! company-sourcekit :pin "abf9bc5a0102eb666d3aa6d6bf22f6efcc852781"))
   (when (featurep! :checkers syntax)


### PR DESCRIPTION
## Bump :lang swift along with lsp-sourcekit

Bump the version of :lang swift and lsp-sourcekit which is used in it:

swift-emacs/swift-mode@95ff004 -> swift-emacs/swift-mode@ad12a30
https://github.com/emacs-lsp/lsp-sourcekit/commit/ff204ed820df8c3035ebdc4b5a583640d52caeeb -> https://github.com/emacs-lsp/lsp-sourcekit/commit/aafa9878a3df2f08e5a9c846d91fd53350ce3c99

## Add support for sourcekit-lsp bundled with Xcode

Recent Xcode ships with the `sourcekit-lsp` server and the latest lsp-soucekit package [supports that bundled `sourcekit-lsp` as the default configuration](https://github.com/emacs-lsp/lsp-sourcekit/blob/aafa9878a3df2f08e5a9c846d91fd53350ce3c99/README.md#quickstart), so I have inserted the bundled `sourcekit-lsp` server path to the first place of the executable list.

Also, since the new version of lsp-sourcekit package changes the default executable from `sourcekit` to `soucekit-lsp`, I modified the executable list to fit to that.

Although lsp-sourcekit package [now has nicer executable lookup method](https://github.com/emacs-lsp/lsp-sourcekit/commit/aafa9878a3df2f08e5a9c846d91fd53350ce3c99), I leave the executable list for backward compatibility.

For these reasons, `SOURCEKIT_TOOLCHAIN_PATH` environment variable should be explicitly set by users, so that users can manage the path of executable flexibly.