### PR TITLE
fix #4901: suppress strange behavior involving org agenda commands

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -618,13 +618,11 @@ mutating hooks on exported output, like formatters."
 
   (defun +org--restart-mode-h ()
     "Restart `org-mode', but only once."
+    (quiet! (org-mode-restart))
+    (delq! (current-buffer) org-agenda-new-buffers)
     (remove-hook 'doom-switch-buffer-hook #'+org--restart-mode-h
                  'local)
-    (delq! (current-buffer) org-agenda-new-buffers)
-    (let ((file buffer-file-name)
-          (inhibit-redisplay t))
-      (kill-buffer)
-      (find-file file)))
+    (run-hooks 'find-file-hook))
 
   (add-hook! 'org-agenda-finalize-hook
     (defun +org-exclude-agenda-buffers-from-workspace-h ()


### PR DESCRIPTION
With current hacks involving `org-agenda-files`, one cannot use org agenda
commands like clock in or change the entry's state to done, etc.

Specifically, the mangled behavior observed at #4901. This commit fixes those
problems around `org-agenda` buffer specific commands.

For more details, please refer to https://github.com/hlissner/doom-emacs/issues/4759#issuecomment-822100632.