### PR TITLE
rss: +org flag control installation of elfeed-org

### DIFF
--- a/modules/app/rss/packages.el
+++ b/modules/app/rss/packages.el
@@ -2,4 +2,5 @@
 ;;; app/rss/packages.el
 
 (package! elfeed :pin "e29c8b91450bd42d90041231f769c4e5fe5070da")
-(package! elfeed-org :pin "77b6bbf222487809813de260447d31c4c59902c9")
+(when (featurep! +org)
+  (package! elfeed-org :pin "77b6bbf222487809813de260447d31c4c59902c9"))


### PR DESCRIPTION
Hey there,

In the default `~/.doom.d/init.el` this module is commented but listed with the +org flag `(rss +org)`.

I happened to try using it without `+org` and it still installs https://github.com/remyhonig/elfeed-org even though it's not needed. This PR makes it so you only need to install elfeed-org if you use +org flag