### PR TITLE
Makes fd-dired compatible with BSD xargs

### DIFF
--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -171,7 +171,10 @@ we have to clean it up ourselves."
   :defer t
   :init
   (global-set-key [remap find-dired] #'fd-dired)
-  (set-popup-rule! "^\\*F\\(?:d\\|ind\\)\\*$" :ignore t))
+  (set-popup-rule! "^\\*F\\(?:d\\|ind\\)\\*$" :ignore t)
+  :config
+  (when IS-BSD
+    (setq fd-dired-ls-option `(,(concat "| xargs -0 " insert-directory-program " -ld | uniq") . "-ld"))))
 
 (use-package! dired-aux
   :defer t


### PR DESCRIPTION
`Fd-dired` used the `--quoting-style=literal` option to `xargs`, which does not exist in BSD xargs. I've just removed this option.