### PR TITLE
lang/latex: Remove the -g background flag on Skim.app to foreground the viewer

### DIFF
--- a/modules/lang/latex/+viewers.el
+++ b/modules/lang/latex/+viewers.el
@@ -14,7 +14,7 @@
                                    "~/Applications/Skim.app"))))
        (add-to-list 'TeX-view-program-selection '(output-pdf "Skim"))
        (add-to-list 'TeX-view-program-list
-                    (list "Skim" (format "%s/Contents/SharedSupport/displayline -b -g %%n %%o %%b"
+                    (list "Skim" (format "%s/Contents/SharedSupport/displayline -b %%n %%o %%b"
                                          app-path)))))
 
     (`sumatrapdf


### PR DESCRIPTION
The Skim.app `displayline` command takes the flag `-g` which is "Do not bring Skim to the foreground"

when viewing the pdf results of the latex build, bringing skim to the foreground saves an `Alt+Tab` to open the app that I was intending to lauch by the auctex View command.