### PR TITLE
lang/org: cleanup `+pretty` feature, mostly just adding `if` cookie

### DIFF
--- a/modules/lang/org/contrib/pretty.el
+++ b/modules/lang/org/contrib/pretty.el
@@ -1,12 +1,11 @@
 ;;; lang/org/contrib/pretty.el -*- lexical-binding: t; -*-
-
+;;;###if (featurep! +pretty)
 (after! org
   (setq org-highlight-latex-and-related '(native script entities)))
 
 
 (use-package! org-superstar ; "prettier" bullets
   :hook (org-mode . org-superstar-mode)
-  :init
   :config
   ;; Make leading stars truly invisible, by rendering them as spaces!
   (setq org-superstar-leading-bullet ?\s


### PR DESCRIPTION
Add `if` cookie so that it doesn't get compiled by `doom compile`.

I know that you discourage to byte compile doom modules; nonetheless, it definitely speed up quite a lot. I felt it is annoying `pretty.el` file getting compiled with `doom compile`, so I added it to be consistent with other featured `.el` files.