### PR TITLE
Fix `+lookup/file` so that it can look up file in selection

### DIFF
--- a/modules/tools/lookup/autoload/lookup.el
+++ b/modules/tools/lookup/autoload/lookup.el
@@ -259,11 +259,16 @@ current buffer."
                     (<  pt end))))))))
 
 (defun +lookup-ffap-backend-fn (_identifier)
-  "Uses `find-file-at-point' to read file at point."
+  "Uses `find-file-at-point' to read file in region or at point."
   (require 'ffap)
-  (when (ffap-guesser)
-    (find-file-at-point)
-    t))
+  (or (and (region-active-p)
+           (let ((region (buffer-substring (region-beginning) (region-end))))
+             (when (file-exists-p region)
+               (find-file-at-point region)
+               t)))
+      (when (ffap-guesser)
+        (find-file-at-point)
+        t)))
 
 (defun +lookup-bug-reference-backend-fn (_identifier)
   "Searches for a bug reference in user/repo#123 or #123 format and opens it in


### PR DESCRIPTION
Previously, when we issue `gf` in visual mode, `+lookup/file` couldn't reflect
the region in interest.

With this commit, you can look up file based on the region activated.
I agree this can be achieved via tweaking `+lookup-file-functions`, but the end
user should have this facility by default.