### PR TITLE
Fix smartparens pairing ' and ` in the minibuffer.

### DIFF
--- a/core/core-editor.el
+++ b/core/core-editor.el
@@ -550,8 +550,8 @@ on."
 
   ;; You're likely writing lisp in the minibuffer, therefore, disable these
   ;; quote pairs, which lisps doesn't use for strings:
-  (sp-local-pair 'minibuffer-inactive-mode "'" nil :actions nil)
-  (sp-local-pair 'minibuffer-inactive-mode "`" nil :actions nil)
+  (sp-local-pair '(minibuffer-mode minibuffer-inactive-mode) "'" nil :actions nil)
+  (sp-local-pair '(minibuffer-mode minibuffer-inactive-mode) "`" nil :actions nil)
 
   ;; Smartparens breaks evil-mode's replace state
   (defvar doom-buffer-smartparens-mode nil)


### PR DESCRIPTION
The current fix only specifies `minibuffer-inactive-mode`, which does nothing for me (Emacs 28 at https://github.com/emacs-mirror/emacs/commit/d55d5358b27dee15ebbd998131d22b221f5f4964). This PR adds `minibuffer-mode` to the mode lists, which fixes the issue for me.