### PR TITLE
Bind TeX-view in LaTeX-mode-map too

### DIFF
--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -100,7 +100,11 @@ If no viewers are found, `latex-preview-pane' is used.")
     (add-hook! '(tex-mode-local-vars-hook
                  latex-mode-local-vars-hook)
                #'lsp!))
-  (map! :map latex-mode-map
+  (map! :localleader
+        :map latex-mode-map
+        :desc "View" "v" #'TeX-view)
+  (map! :after latex
+        :map LaTeX-mode-map
         :localleader
         :desc "View" "v" #'TeX-view))
 


### PR DESCRIPTION
I know https://github.com/hlissner/doom-emacs/commit/0d6c32ff25292ecdef7ecdfd1542bb65807c4d9a was supposed to fix *something*, but I'm just unable to use any keybind on latex-mode-map.
Binding it on both is the safest bet I think.