### PR TITLE
Add Info-mode to list of ligature-excluded modes.

### DIFF
--- a/modules/ui/ligatures/config.el
+++ b/modules/ui/ligatures/config.el
@@ -87,7 +87,7 @@ string starting with the character contained in car.
 This variable is used only if you built Emacs with Harfbuzz on a version >= 28")
 
 (defvar +ligatures-in-modes
-  '(not special-mode comint-mode eshell-mode term-mode vterm-mode)
+  '(not special-mode comint-mode eshell-mode term-mode vterm-mode Info-mode)
   "List of major modes where ligatures should be enabled.
 
   If t, enable it everywhere (except `fundamental-mode').


### PR DESCRIPTION
This is my first pull-request (ever), and it relates to issue #4916.

The mangled links described there only show up when an Info-mode link is followed by a right-parenthesis.

So I simply added Info-mode to the list of modes where ligatures are disabled.