### PR TITLE
Feature-gate :tools lsp company-specific hooks

### DIFF
--- a/modules/tools/lsp/+lsp.el
+++ b/modules/tools/lsp/+lsp.el
@@ -81,13 +81,14 @@ about it (it will be logged to *Messages* however).")
           (lsp--info "Could not guess project root."))))
     #'+lsp-optimization-mode)
 
-  (add-hook! 'lsp-completion-mode-hook
-    (defun +lsp-init-company-backends-h ()
-      (when lsp-completion-mode
-        (set (make-local-variable 'company-backends)
-             (cons +lsp-company-backends
-                   (remove +lsp-company-backends
-                           (remq 'company-capf company-backends)))))))
+  (when (featurep! :completion company)
+    (add-hook! 'lsp-completion-mode-hook
+      (defun +lsp-init-company-backends-h ()
+        (when lsp-completion-mode
+          (set (make-local-variable 'company-backends)
+               (cons +lsp-company-backends
+                     (remove +lsp-company-backends
+                             (remq 'company-capf company-backends))))))))
 
   (defvar +lsp--deferred-shutdown-timer nil)
   (defadvice! +lsp-defer-server-shutdown-a (orig-fn &optional restart)


### PR DESCRIPTION
As I’m trying to use [corfu](https://github.com/minad/corfu) for a bit, I found out that this hook prevents lsp-mode from starting if company-mode isn’t used.