### PR TITLE
Fix making doom-first-input-hook permanent-local

### DIFF
--- a/core/core.el
+++ b/core/core.el
@@ -127,7 +127,7 @@ users).")
 
 (defvar doom-first-input-hook nil
   "Transient hooks run before the first user input.")
-(put doom-first-input-hook 'permanent-local t)
+(put 'doom-first-input-hook 'permanent-local t)
 
 (defvar doom-first-file-hook nil
   "Transient hooks run before the first interactively opened file.")


### PR DESCRIPTION
We were making the value of doom-first-input-hook permanent-local
instead of doom-first-input-hook itself. That value is normally nil at
this point, which seems to be harmless. Reloading core.el from a script
(while doom-first-input-hook is not empty) results in an error.

Fix it by adding the missing quote present in the other calls.