### PR TITLE
Prevent okular from stealing focus

### DIFF
--- a/modules/lang/latex/+viewers.el
+++ b/modules/lang/latex/+viewers.el
@@ -26,7 +26,7 @@
      (when (executable-find "okular")
        ;; Configure Okular as viewer. Including a bug fix
        ;; (https://bugs.kde.org/show_bug.cgi?id=373855)
-       (add-to-list 'TeX-view-program-list '("Okular" ("okular --unique file:%o" (mode-io-correlate "#src:%n%a"))))
+       (add-to-list 'TeX-view-program-list '("Okular" ("okular --noraise --unique file:%o" (mode-io-correlate "#src:%n%a"))))
        (add-to-list 'TeX-view-program-selection '(output-pdf "Okular"))))
 
     (`zathura


### PR DESCRIPTION
Pass the "noraise" flag to okular if it is used as a Latex viewer. If an
okular instance is already displaying the Latex compilation result,
subsequent invocations won't make okular steal focus from Emacs.