### PR TITLE
Fix void-variable error in rust module

### DIFF
--- a/modules/lang/rust/config.el
+++ b/modules/lang/rust/config.el
@@ -12,7 +12,8 @@
   :init
   (after! org-src
     (defalias 'org-babel-execute:rust #'org-babel-execute:rustic)
-    (add-to-list 'org-src-lang-modes '("rust" . rustic))
+    (add-to-list 'org-src-lang-modes '("rust" . rustic)))
+  (after! ob-tangle
     (add-to-list 'org-babel-tangle-lang-exts '("rustic" . "rs")))
   :config
   (setq rustic-indent-method-chain t)


### PR DESCRIPTION
org-babel-tangle-lang-exts is defined in ob-tangle and not autoloaded,
and does not seem to always be defined immediately after org-src is
loaded.

Add to it after loading ob-tangle instead.

Fixes #4970