### PR TITLE
update org-mime

### DIFF
--- a/modules/email/notmuch/packages.el
+++ b/modules/email/notmuch/packages.el
@@ -2,7 +2,7 @@
 ;;; email/notmuch/packages.el
 
 (package! notmuch :pin "45193bab16c728ba892a5d45fc62ef59e2a6ef85")
-(package! org-mime :pin "9bb6351b25c62835c7881fc64096028eb8ef83ef")
+(package! org-mime :pin "eb21c02ba8f97fe69c14dc657a7883b982664649")
 (when (featurep! :completion ivy)
   (package! counsel-notmuch :pin "a4a1562935e4180c42524c51609d1283e9be0688"))
 (when (featurep! :completion helm)


### PR DESCRIPTION
Hey Sir,

The `org-mime` version we're using is lacking some useful new functions and fixes. I figured I'd update it. I also wanted to ask if you think `org-mime` should actually be included in this module? We don't provide any extra features or configuration for `org-mime` out of the box really, It's minimally configured and not documented or emphasized in our README. My thought is that most people who use doom and notmuch probably don't even know `org-mime` is available to them and installed. We could probably remove it, One less thing to keep updating or changing :)

I'm willing to change this PR to remove `org-mime` from the module and add a section of documentation about setting it in your own  "user space" configs. Let me know if you think that's a reasonable thing to do. Otherwise, please consider this version bump for merge.

Best,
Will