### PR TITLE
notmuch: remove org-mime

### DIFF
--- a/modules/email/notmuch/README.org
+++ b/modules/email/notmuch/README.org
@@ -18,17 +18,19 @@
   - [[#downloading-your-email][Downloading your email]]
   - [[#customize-notmuch-hello-buffer][Customize =*notmuch-hello*= buffer]]
   - [[#changing-the-notmuch-landing-page][Changing the =notmuch= landing page]]
+  - [[#writing-html-emails][Writing HTML Emails]]
 - [[#troubleshooting][Troubleshooting]]
 
 * Description
 This module turns Emacs into email client using ~notmuch~.
 
 ** Module Flags
++ =+org= Enables org-mime for writing HTML emails using org-mode.
 + =+afew= Enables integration with =afew=.
 
 ** Plugins
 + [[https://notmuchmail.org/][notmuch]]
-+ [[https://github.com/org-mime/org-mime][org-mime]]
++ [[https://github.com/org-mime/org-mime][org-mime]]* (with =+org= flag)
 + [[https://github.com/fuxialexander/counsel-notmuch][counsel-notmuch]]*
 + [[https://github.com/emacs-helm/helm-notmuch][helm-notmuch]]*
 
@@ -159,5 +161,24 @@ a custom search as your landing page.
 #+BEGIN_SRC emacs-lisp
 (setq +notmuch-home-function (lambda () (notmuch-search "tag:inbox")))
 #+END_SRC
+** Writing HTML Emails
+The [[https://github.com/org-mime/org-mime][org-mime]] package provides functionality for composing emails in org-mode and transforming them to HTML. This feature is enabled using the =+org= flag.
+
+Example use cases:
+
+- To convert an email to an HTML email use ~M-x org-mime-htmlize~
+- To compose email using an org-mode editor buffer, use ~M-x org-mime-edit-mail-in-org-mode~
+
+If you'd like to make configuration changes to =org-mime=, you may do so normally. By default the output of =org-mime-htmlize= includes section numbers, a byline, and a table of contents. That's probably more formal than the emails you're used to sending, so here's some example configuration that turns those features off.
+
+/config.el/
+
+#+begin_src emacs-lisp
+(after! org-mime
+  (setq org-mime-export-options '(:section-numbers nil
+                                  :with-author nil
+                                  :with-toc nil)))
+#+end_src
+
 
 * TODO Troubleshooting

--- a/modules/email/notmuch/config.el
+++ b/modules/email/notmuch/config.el
@@ -88,6 +88,7 @@ OR a shell command string such as
 
 
 (use-package! org-mime
+  :when (featurep! +org)
   :after (org notmuch)
   :config (setq org-mime-library 'mml))
 

--- a/modules/email/notmuch/packages.el
+++ b/modules/email/notmuch/packages.el
@@ -2,7 +2,8 @@
 ;;; email/notmuch/packages.el
 
 (package! notmuch :pin "63413a5563450bdedee4c077f2f998578e75083a")
-(package! org-mime :pin "eb21c02ba8f97fe69c14dc657a7883b982664649")
+(when (featurep! +org)
+  (package! org-mime :pin "eb21c02ba8f97fe69c14dc657a7883b982664649"))
 (when (featurep! :completion ivy)
   (package! counsel-notmuch :pin "a4a1562935e4180c42524c51609d1283e9be0688"))
 (when (featurep! :completion helm)


### PR DESCRIPTION
Hi Henrik,

I'm not sure about this one. Feel free to decline.

This module is minimally configured and we're not providing anything extra on top with it. There may be many people that use this module and don't know `org-mime` is available to them. This PR removes `org-mime` and adds a section to the readme under a heading "Writing HTML Emails."

If you have ideas for why this module should stay, please share.

Best,
Will