### PR TITLE
Change some `fboundp`'s and `doom-module-p`'s to `featurep!`'s

### DIFF
--- a/core/autoload/help.el
+++ b/core/autoload/help.el
@@ -200,9 +200,9 @@ selection of all minor-modes, active or not."
 (defun doom/help-search (&optional initial-input)
   "Preform a text search on all of Doom's documentation."
   (interactive)
-  (funcall (cond ((fboundp '+ivy-file-search)
+  (funcall (cond ((featurep! :completion ivy)
                   #'+ivy-file-search)
-                 ((fboundp '+helm-file-search)
+                 ((featurep! :completion helm)
                   #'+helm-file-search)
                  ((rgrep
                    (read-regexp

--- a/core/autoload/projects.el
+++ b/core/autoload/projects.el
@@ -128,11 +128,11 @@ If DIR is not a project, it will be indexed (but not cached)."
             (if (doom-module-p :completion 'ivy)
                 #'counsel-projectile-find-file
               #'projectile-find-file)))
-          ((fboundp 'counsel-file-jump) ; ivy only
+          ((featurep! :completion ivy)
            (call-interactively #'counsel-file-jump))
           ((project-current nil dir)
            (project-find-file-in nil nil dir))
-          ((fboundp 'helm-find-files)
+          ((featurep! :completion helm)
            (call-interactively #'helm-find-files))
           ((call-interactively #'find-file)))))
 

--- a/core/autoload/projects.el
+++ b/core/autoload/projects.el
@@ -125,7 +125,7 @@ If DIR is not a project, it will be indexed (but not cached)."
             ;; Intentionally avoid `helm-projectile-find-file', because it runs
             ;; asynchronously, and thus doesn't see the lexical
             ;; `default-directory'
-            (if (doom-module-p :completion 'ivy)
+            (if (featurep! :completion ivy)
                 #'counsel-projectile-find-file
               #'projectile-find-file)))
           ((featurep! :completion ivy)
@@ -141,9 +141,9 @@ If DIR is not a project, it will be indexed (but not cached)."
   "Traverse a file structure starting linearly from DIR."
   (let ((default-directory (file-truename (expand-file-name dir))))
     (call-interactively
-     (cond ((doom-module-p :completion 'ivy)
+     (cond ((featurep! :completion ivy)
             #'counsel-find-file)
-           ((doom-module-p :completion 'helm)
+           ((featurep! :completion helm)
             #'helm-find-files)
            (#'find-file)))))
 

--- a/modules/config/default/autoload/text.el
+++ b/modules/config/default/autoload/text.el
@@ -27,8 +27,8 @@
   "Interactively select what text to insert from the kill ring."
   (interactive)
   (call-interactively
-   (cond ((fboundp 'counsel-yank-pop)    #'counsel-yank-pop)
-         ((fboundp 'helm-show-kill-ring) #'helm-show-kill-ring)
+   (cond ((featurep! :completion ivy)  #'counsel-yank-pop)
+         ((featurep! :completion helm) #'helm-show-kill-ring)
          ((error "No kill-ring search backend available. Enable ivy or helm!")))))
 
 ;;;###autoload

--- a/modules/tools/lookup/autoload/online.el
+++ b/modules/tools/lookup/autoload/online.el
@@ -77,12 +77,13 @@ QUERY must be a string, and PROVIDER must be a key of
 ;;;###autoload
 (defun +lookup--online-backend-google (query)
   "Search Google, starting with QUERY, with live autocompletion."
-  (cond ((fboundp 'counsel-search)
+  (cond ((featurep! :completion ivy)
          (let ((ivy-initial-inputs-alist `((t . ,query)))
                (counsel-search-engine 'google))
            (call-interactively #'counsel-search)
            t))
-        ((require 'helm-net nil t)
+        ((featurep! :completion helm)
+         (require 'helm-net nil t)
          (helm :sources 'helm-source-google-suggest
                :buffer "*helm google*"
                :input query)
@@ -91,7 +92,7 @@ QUERY must be a string, and PROVIDER must be a key of
 ;;;###autoload
 (defun +lookup--online-backend-duckduckgo (query)
   "Search DuckDuckGo, starting with QUERY, with live autocompletion."
-  (cond ((fboundp 'counsel-search)
+  (cond ((featurep! :completion ivy)
          (let ((ivy-initial-inputs-alist `((t . ,query)))
                (counsel-search-engine 'ddg))
            (call-interactively #'counsel-search)


### PR DESCRIPTION
Makes the code more readable and searchable (say if we want to figure out all the places where turning on `ivy` effects the codebase), and from testing on my end doesn't seem to break anything.