### PR TITLE
Finish custom-*-faces conversion to functions

### DIFF
--- a/core/autoload/themes.el
+++ b/core/autoload/themes.el
@@ -23,17 +23,16 @@
 
 THEME can be a single symbol or list thereof. If nil, apply these settings to
 all themes. It will apply to all themes once they are loaded."
-  (declare (indent defun))
   (let ((fn (gensym "doom--customize-themes-h-")))
     (fset
      fn (lambda ()
           (let (custom--inhibit-theme-enable)
-            (dolist (theme (doom-enlist (or ,theme 'doom)))
+            (dolist (theme (doom-enlist (or theme 'doom)))
               (when (or (memq theme '(user doom))
                         (custom-theme-enabled-p theme))
                 (apply #'custom-theme-set-faces theme
                        (mapcan #'doom--custom-theme-set-face
-                               (list ,@specs))))))))
+                               specs)))))))
     ;; Apply the changes immediately if the user is using the default theme or
     ;; the theme has already loaded. This allows you to evaluate these macros on
     ;; the fly and customize your faces iteratively.
@@ -51,7 +50,6 @@ all themes. It will apply to all themes once they are loaded."
 This is a convenience macro alternative to `custom-set-face' which allows for a
 simplified face format, and takes care of load order issues, so you can use
 doom-themes' API without worry."
-  (declare (indent defun))
   (apply #'custom-theme-set-faces! 'doom specs))
 
 ;;;###autoload


### PR DESCRIPTION
Fixes #5015

Note: Before the change from macro to function, when one of my fonts wasn't found ( `(setq doom-variable-pitch-font ...)` not found because of Guix shenanigans), nothing special happened except a nag message on start. Now an actual uncaught error is thrown somehow and it breaks Doom loading mid-way. Unsure if that's a regression or something I should just be wary of.