### PR TITLE
ophints: Add hooks for lispyville

### DIFF
--- a/modules/ui/ophints/config.el
+++ b/modules/ui/ophints/config.el
@@ -23,7 +23,45 @@
             '(+eval:region
               :face evil-goggles-yank-face
               :switch evil-goggles-enable-yank
-              :advice evil-goggles--generic-async-advice)))
+              :advice evil-goggles--generic-async-advice))
+  (when (featurep! :editor lispy)
+    (pushnew! evil-goggles--commands
+              '(lispyville-delete
+                :face evil-goggles-delete-face
+                :switch evil-goggles-enable-delete
+                :advice evil-goggles--generic-blocking-advice)
+              '(lispyville-delete-line
+                :face evil-goggles-delete-face
+                :switch evil-goggles-enable-delete
+                :advice evil-goggles--delete-line-advice)
+              '(lispyville-yank
+                :face evil-goggles-yank-face
+                :switch evil-goggles-enable-yank
+                :advice evil-goggles--generic-async-advice)
+              '(lispyville-yank-line
+                :face evil-goggles-yank-face
+                :switch evil-goggles-enable-yank
+                :advice evil-goggles--generic-async-advice)
+              '(lispyville-change
+                :face evil-goggles-change-face
+                :switch evil-goggles-enable-change
+                :advice evil-goggles--generic-blocking-advice)
+              '(lispyville-change-line
+                :face evil-goggles-change-face
+                :switch evil-goggles-enable-change
+                :advice evil-goggles--generic-blocking-advice)
+              '(lispyville-change-whole-line
+                :face evil-goggles-change-face
+                :switch evil-goggles-enable-change
+                :advice evil-goggles--generic-blocking-advice)
+              '(lispyville-indent
+                :face evil-goggles-indent-face
+                :switch evil-goggles-enable-indent
+                :advice evil-goggles--generic-async-advice)
+              '(lispyville-join
+                :face evil-goggles-join-face
+                :switch evil-goggles-enable-join
+                :advice evil-goggles--join-advice))))
 
 
 (use-package! volatile-highlights


### PR DESCRIPTION
Because lispyville (depending on how you configure it) replaces some
evil-mode mappings with its own function, we lose the indication of our
deletions/yanks/etc. This change adds all lispyville functions to the
evil-goggles--commands list.