### PR TITLE
use setq-default for notmuch-search-oldest-first

### DIFF
--- a/modules/email/notmuch/config.el
+++ b/modules/email/notmuch/config.el
@@ -43,7 +43,6 @@ OR a shell command string such as
   (setq notmuch-fcc-dirs nil
         message-kill-buffer-on-exit t
         message-send-mail-function 'message-send-mail-with-sendmail
-        notmuch-search-oldest-first nil
         send-mail-function 'sendmail-send-it
         ;; sendmail-program "/usr/local/bin/msmtp"
         notmuch-search-result-format
@@ -60,6 +59,7 @@ OR a shell command string such as
           (:name "sent"    :query "tag:sent"                :key "s")
           (:name "drafts"  :query "tag:draft"               :key "d"))
         notmuch-archive-tags '("-inbox" "-unread"))
+  (setq-default notmuch-search-oldest-first nil)
 
   ;; only unfold unread messages in thread by default
   (add-hook 'notmuch-show-hook #'+notmuch-show-expand-only-unread-h)


### PR DESCRIPTION
It was made buffer-local upstream [1] and included in the latest version
bump [2].

[1]: https://git.notmuchmail.org/git?p=notmuch;a=commit;h=42d32713be9a23346de09b84983e1dd3b44b3400
[2]: https://github.com/hlissner/doom-emacs/commit/ed4b1ef8879d20868504805d838fd04a45011e84