### PR TITLE
:lang racket: Fix README typos 

### DIFF
--- a/modules/lang/racket/README.org
+++ b/modules/lang/racket/README.org
@@ -9,6 +9,7 @@
   - [[#module-flags][Module Flags]]
   - [[#plugins][Plugins]]
 - [[#prerequisites][Prerequisites]]
+  - [[#arch-linux][Arch Linux]]
 - [[#features][Features]]
 - [[#configuration][Configuration]]
   - [[#racket-smart-open-bracket-mode][racket-smart-open-bracket-mode]]
@@ -30,6 +31,18 @@ This module has no dedicated maintainers.
 * Prerequisites
 This module only requires ~racket~. Install it directly from the [[https://download.racket-lang.org/][racket website]],
 or check your package manger.
+
+** Arch Linux
+
+#+begin_src bash
+pacman -S racket
+#+end_src
+
+Or, for fewer dependencies:
+
+#+begin_src bash
+pacman -S racket-minimal
+#+end_src
 
 * TODO Features
 

--- a/modules/lang/racket/README.org
+++ b/modules/lang/racket/README.org
@@ -16,7 +16,7 @@
 - [[#troubleshooting][Troubleshooting]]
 
 * Description
-This module provide integration for [[https://github.com/greghendershott/racket-mode][racket-mode]].
+This module provides integration for [[https://github.com/greghendershott/racket-mode][racket-mode]].
 
 ** Maintainers
 This module has no dedicated maintainers.
@@ -28,7 +28,7 @@ This module has no dedicated maintainers.
 + [[https://github.com/greghendershott/racket-mode][racket-mode]]
 
 * Prerequisites
-This module only require `racket`. Install it directly from the [[https://download.racket-lang.org/][racket website]],
+This module only requires ~racket~. Install it directly from the [[https://download.racket-lang.org/][racket website]],
 or check your package manger.
 
 * TODO Features


### PR DESCRIPTION
> - [x] I've targeted the develop branch
> - [x] I've searched for similar pull requests and found nothing
> - [x] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
> - [x] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
> - [x] I've linked any relevant issues and PRs below
> - [x] All my commit messages are descriptive and distinct

This PR fixes some minor typos I noticed in the README of the Racket module, and also mentions the available Arch Linux packages for Racket.
