### PR TITLE
Fix +vterm-toggle not changing directory to project root

### DIFF
--- a/modules/term/vterm/autoload.el
+++ b/modules/term/vterm/autoload.el
@@ -30,12 +30,17 @@ If prefix ARG is non-nil, recreate vterm buffer in the current project's root."
             (evil-change-to-initial-state))
           (goto-char (point-max)))
       (setenv "PROOT" (or (doom-project-root) default-directory))
-      (let ((buffer (get-buffer-create buffer-name)))
+      (let* ((project-root (or (doom-project-root) default-directory))
+         (default-directory
+           (if arg
+               default-directory
+             project-root)))
+        (let ((buffer (get-buffer-create buffer-name)))
         (with-current-buffer buffer
           (unless (eq major-mode 'vterm-mode)
             (vterm-mode))
           (+vterm--change-directory-if-remote))
-        (pop-to-buffer buffer)))))
+        (pop-to-buffer buffer))))))
 
 ;;;###autoload
 (defun +vterm/here (arg)

--- a/modules/term/vterm/autoload.el
+++ b/modules/term/vterm/autoload.el
@@ -6,41 +6,36 @@
 
 If prefix ARG is non-nil, recreate vterm buffer in the current project's root."
   (interactive "P")
-  (unless (fboundp 'module-load)
-    (user-error "Your build of Emacs lacks dynamic modules support and cannot load vterm"))
-  (let ((buffer-name
-         (format "*doom:vterm-popup:%s*"
-                 (if (bound-and-true-p persp-mode)
-                     (safe-persp-name (get-current-persp))
-                   "main")))
-        confirm-kill-processes
-        current-prefix-arg)
-    (when arg
-      (let ((buffer (get-buffer buffer-name))
-            (window (get-buffer-window buffer-name)))
-        (when (buffer-live-p buffer)
-          (kill-buffer buffer))
-        (when (window-live-p window)
-          (delete-window window))))
-    (if-let (win (get-buffer-window buffer-name))
-        (if (eq (selected-window) win)
-            (delete-window win)
-          (select-window win)
-          (when (bound-and-true-p evil-local-mode)
-            (evil-change-to-initial-state))
-          (goto-char (point-max)))
-      (setenv "PROOT" (or (doom-project-root) default-directory))
-      (let* ((project-root (or (doom-project-root) default-directory))
-         (default-directory
-           (if arg
-               default-directory
-             project-root)))
-        (let ((buffer (get-buffer-create buffer-name)))
-        (with-current-buffer buffer
-          (unless (eq major-mode 'vterm-mode)
-            (vterm-mode))
-          (+vterm--change-directory-if-remote))
-        (pop-to-buffer buffer))))))
+  (+vterm--configure-project-root-and-display
+   arg
+   (lambda()
+     (let ((buffer-name
+            (format "*doom:vterm-popup:%s*"
+                    (if (bound-and-true-p persp-mode)
+                        (safe-persp-name (get-current-persp))
+                      "main")))
+           confirm-kill-processes
+           current-prefix-arg)
+       (when arg
+         (let ((buffer (get-buffer buffer-name))
+               (window (get-buffer-window buffer-name)))
+           (when (buffer-live-p buffer)
+             (kill-buffer buffer))
+           (when (window-live-p window)
+             (delete-window window))))
+       (if-let (win (get-buffer-window buffer-name))
+           (if (eq (selected-window) win)
+               (delete-window win)
+             (select-window win)
+             (when (bound-and-true-p evil-local-mode)
+               (evil-change-to-initial-state))
+             (goto-char (point-max)))
+         (let ((buffer (get-buffer-create buffer-name)))
+           (with-current-buffer buffer
+             (unless (eq major-mode 'vterm-mode)
+               (vterm-mode))
+             (+vterm--change-directory-if-remote))
+           (pop-to-buffer buffer)))))))
 
 ;;;###autoload
 (defun +vterm/here (arg)
@@ -48,20 +43,29 @@ If prefix ARG is non-nil, recreate vterm buffer in the current project's root."
 
 If prefix ARG is non-nil, cd into `default-directory' instead of project root."
   (interactive "P")
+  (+vterm--configure-project-root-and-display
+   arg
+   (lambda()
+     (require 'vterm)
+     ;; This hack forces vterm to redraw, fixing strange artefacting in the tty.
+     (save-window-excursion
+       (pop-to-buffer "*scratch*"))
+     (let (display-buffer-alist)
+       (vterm vterm-buffer-name)))))
+
+(defun +vterm--configure-project-root-and-display (arg display-fn)
+  "Sets the environment variable PROOT and displays a terminal using `display-fn`.
+
+If prefix ARG is non-nil, cd into `default-directory' instead of project root."
   (unless (fboundp 'module-load)
     (user-error "Your build of Emacs lacks dynamic modules support and cannot load vterm"))
-  (require 'vterm)
-  ;; This hack forces vterm to redraw, fixing strange artefacting in the tty.
-  (save-window-excursion
-    (pop-to-buffer "*scratch*"))
   (let* ((project-root (or (doom-project-root) default-directory))
          (default-directory
            (if arg
                default-directory
-             project-root))
-         display-buffer-alist)
+             project-root)))
     (setenv "PROOT" project-root)
-    (vterm vterm-buffer-name)
+    (funcall display-fn)
     (+vterm--change-directory-if-remote)))
 
 (defun +vterm--change-directory-if-remote ()


### PR DESCRIPTION
Fixes #4834 

Before this change, `+vterm/toggle` would toggle a vterm window and change directory to the directory of the current buffer.  Now it oppens the root of the current project when it does't get an universal argument.

The comments of the function indicate this should be the appropriate behavior.  `+vterm/here` behaves in a similar way.

Before:

![output](https://user-images.githubusercontent.com/5473302/117892129-c3c42580-b27d-11eb-9d79-c7d847231ce0.gif)

After:

![output2](https://user-images.githubusercontent.com/5473302/117892143-cb83ca00-b27d-11eb-85ca-02d1d406b23f.gif)

