### PR TITLE
Fix bin/doom compile error introduced by e2a11d24fd4ea

### DIFF
--- a/core/cli/byte-compile.el
+++ b/core/cli/byte-compile.el
@@ -101,7 +101,8 @@ If RECOMPILE-P is non-nil, only recompile out-of-date files."
             (noninteractive t)
             doom-interactive-p)
         (doom-initialize 'force)
-        (quiet! (doom-initialize-packages))))
+        (quiet! (doom-initialize-packages))
+        (quiet! (doom-initialize-modules))))
 
     (if (null targets)
         (print! (info "No targets to %scompile" (if recompile-p "re" "")))


### PR DESCRIPTION
-------

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [X] It targets the develop branch
  - [X] I've searched for similar pull requests and found nothing
  - [X] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [X] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [X] I've linked any relevant issues and PRs below
  - [X] All my commit messages are descriptive and distinct

-->

With a commit of e2a11d24fd4ea20fb198493b3dd12742c4fad6b0, when it comes to
`doom compile`, modules aren't loaded anymore, which corrupts the compiling process.

What I did is just adding the necessity parts for the doom's byte compiler.