### PR TITLE
unicode-chars-list-chars -> insert-char

### DIFF
--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -204,7 +204,7 @@ results buffer.")
     [remap recentf-open-files]       #'counsel-recentf
     [remap set-variable]             #'counsel-set-variable
     [remap swiper]                   #'counsel-grep-or-swiper
-    [remap unicode-chars-list-chars] #'counsel-unicode-char
+    [remap insert-char]              #'counsel-unicode-char
     [remap yank-pop]                 #'counsel-yank-pop)
   :config
   (set-popup-rule! "^\\*ivy-occur" :size 0.35 :ttl 0 :quit nil)

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -137,7 +137,7 @@
        :desc "Current file name"             "f"   #'+default/insert-file-path
        :desc "Current file path"             "F"   (cmd!! #'+default/insert-file-path t)
        :desc "Snippet"                       "s"   #'yas-insert-snippet
-       :desc "Unicode"                       "u"   #'unicode-chars-list-chars
+       :desc "Unicode"                       "u"   #'insert-char
        :desc "From clipboard"                "y"   #'+default/yank-pop)
 
       ;;; <leader> n --- notes

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -489,7 +489,7 @@
        :desc "Evil ex path"                  "p"   (cmd! (evil-ex "R!echo "))
        :desc "From evil register"            "r"   #'evil-ex-registers
        :desc "Snippet"                       "s"   #'yas-insert-snippet
-       :desc "Unicode"                       "u"   #'unicode-chars-list-chars
+       :desc "Unicode"                       "u"   #'insert-char
        :desc "From clipboard"                "y"   #'+default/yank-pop)
 
       ;;; <leader> n --- notes


### PR DESCRIPTION
- [x] It targets the develop branch
- [X] I've searched for similar pull requests and found nothing
- [X] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
- [X] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
- [X] I've linked any relevant issues and PRs below
- [X] All my commit messages are descriptive and distinct

`unicode-chars-list-chars` doesn't seem to be an actual function (not
defined in emacs or found online), and `insert-char` seems like what one
would want here.

Issue #3556 seems to have been about this but has been deleted.