### PR TITLE
fix regex in lsp-file-watch-ignored-directories in elixir module

### DIFF
--- a/modules/lang/elixir/config.el
+++ b/modules/lang/elixir/config.el
@@ -39,7 +39,7 @@
   (when (featurep! +lsp)
     (add-hook 'elixir-mode-local-vars-hook #'lsp!)
     (after! lsp-mode
-      (add-to-list 'lsp-file-watch-ignored-directories "[/\\\\]\\_build\\'")))
+      (add-to-list 'lsp-file-watch-ignored-directories "[/\\\\]_build\\'")))
 
   (after! highlight-numbers
     (puthash 'elixir-mode


### PR DESCRIPTION
The Elixir module adds this regex to the `lsp-file-watch-ignored-directories` variable: `"[/\\\\]\\_build\\'"`. This leads to this error message:

~~~
Lisp error: (invalid-regexp "Invalid regular expression")
  string-match("[/\\\\]\\_build\\'" "...")
  lsp--string-match-any(("[/\\\\]\\_build\\'" "[/\\\\]\\.git\\'" "[/\\\\]\\.hg\\'" "[/\\\\]\\.bzr\\'" "[/\\\\]_darcs\\'" "[/\\\\]\\.svn\\'" "[/\\\\]_FOSSIL_\\'" "[/\\\\]\\.idea\\'" "[/\\\\]\\.ensime_cache\\'" "[/\\\\]\\.eunit\\'" "[/\\\\]node_modules" "[/\\\\]\\.fslckout\\'" "[/\\\\]\\.tox\\'" "[/\\\\]dist\\'" "[/\\\\]dist-newstyle\\'" "[/\\\\]\\.stack-work\\'" "[/\\\\]\\.bloop\\'" "[/\\\\]\\.metals\\'" "[/\\\\]target\\'" "[/\\\\]\\.ccls-cache\\'" "[/\\\\]\\.vscode\\'" "[/\\\\]\\.deps\\'" "[/\\\\]build-aux\\'" "[/\\\\]autom4te.cache\\'" "[/\\\\]\\.reference\\'" "[/\\\\]\\.lsp\\'" "[/\\\\]\\.clj-kondo\\'" "[/\\\\]\\.cpcache\\'" "[/\\\\]bin/Debug\\'" "[/\\\\]obj\\'") "/Users/ckruse/Code/web/wwwtech/.build")
;; ...
~~~

The fix is to remove the backslashes before the `_` character.

