### PR TITLE
rss - podcast tagging and youtube feeds

### DIFF
--- a/modules/app/rss/README.org
+++ b/modules/app/rss/README.org
@@ -17,6 +17,7 @@
   - [[#keybindings][Keybindings]]
   - [[#news-filtering][News filtering]]
   - [[#automatically-updating-feed-when-opening-elfeed][Automatically updating feed when opening elfeed]]
+  - [[#youtube-videos][YouTube Videos]]
 - [[#troubleshooting][Troubleshooting]]
 
 * Description
@@ -27,12 +28,15 @@ This module has no dedicated maintainers.
 
 ** Module Flags
 + =+org= to enable ~elfeed-org~ to use ~org-directory/elfeed.org~
++ =+media= to enable using ~youtube-dl~
 
 ** Plugins
 + [[https://github.com/skeeto/elfeed][elfeed]]
 + [[https://github.com/algernon/elfeed-goodies][elfeed-goodies]] 
 + =+org=
   + [[https://github.com/remyhonig/elfeed-org][elfeed-org]]
++ =+media=
+  - [[https://github.com/skeeto/youtube-dl-emacs][youtube-dl-emacs]]
 
 ** Hacks
 + By default ~elfeed-search-filter~ is set to ~@2-weeks-ago~ and makes the last 2 weeks of entries visible. This needs to be set after elfeed has loaded like so in your ~config.el~
@@ -54,6 +58,16 @@ When you don't want to use org mode to manage your elfeed feeds you can put your
 (setq elfeed-feeds
       '("https://this-week-in-rust.org/rss.xml"
         "http://feeds.bbci.co.uk/news/rss.xml"))
+#+END_SRC
+
+You can also use the =+rss-elfeed-config=. If you're using the =+media= tag you should use this macro because it will allow you to enter youtube channel ids, user ids, and playlist ids without defining full urls as long as they are tagged with the ~youtube~ tag. You can use this macro without the =+media= flag too if you want.
+
+#+BEGIN_SRC elisp
+(+rss-elfeed-config!
+    ("https://this-week-in-rust.org/rss.xml" rust)
+    ("http://feeds.bbci.co.uk/news/rss.xml" news bbc)
+    ;; Systemcrafters - Learning Emacs Lisp Playlist
+    ("PLEoMzSkcN8oPQtn7FQEF3D7sroZbXuPZ7" youtube system-crafters emacs))
 #+END_SRC
 
 ** With +org
@@ -110,5 +124,14 @@ Hook ~elfeed-update~ to ~elfeed-search-mode-hook~
 #+BEGIN_SRC elisp
 (add-hook! 'elfeed-search-mode-hook 'elfeed-update)
 #+END_SRC
+
+** YouTube Videos
+
+When using the =+media= tag, you can download items in your feed originating from youtube.
+
+| Key | Mode                                 | Description                                            |
+|-----+--------------------------------------+--------------------------------------------------------|
+| =y= | Elfeed-show-mode, Elfeed-search-mode | Download youtube media and open youtube-dl-list buffer |
+| =L= | Elfeed-search-mode                   | Open youtube-dl-list buffer                            |
 
 * TODO Troubleshooting

--- a/modules/app/rss/README.org
+++ b/modules/app/rss/README.org
@@ -60,14 +60,14 @@ When you don't want to use org mode to manage your elfeed feeds you can put your
         "http://feeds.bbci.co.uk/news/rss.xml"))
 #+END_SRC
 
-You can also use the =+rss-elfeed-config=. If you're using the =+media= tag you should use this macro because it will allow you to enter youtube channel ids, user ids, and playlist ids without defining full urls as long as they are tagged with the ~youtube~ tag. You can use this macro without the =+media= flag too if you want.
+You can also use the =+rss-set-elfeed= function to configure your feeds. If you're using the =+media= tag you should use it to enter youtube channel ids, user ids, and playlist ids without defining full urls. These feed entries must be tagged with the ~youtube~ tag. You can use this function to set your feeds without the =+media= flag too if you'd like.
 
 #+BEGIN_SRC elisp
-(+rss-elfeed-config!
-    ("https://this-week-in-rust.org/rss.xml" rust)
-    ("http://feeds.bbci.co.uk/news/rss.xml" news bbc)
+(+rss-set-elfeed!
+    '("https://this-week-in-rust.org/rss.xml" rust)
+    '("http://feeds.bbci.co.uk/news/rss.xml" news bbc)
     ;; Systemcrafters - Learning Emacs Lisp Playlist
-    ("PLEoMzSkcN8oPQtn7FQEF3D7sroZbXuPZ7" youtube system-crafters emacs))
+    '("PLEoMzSkcN8oPQtn7FQEF3D7sroZbXuPZ7" youtube system-crafters emacs))
 #+END_SRC
 
 ** With +org

--- a/modules/app/rss/autoload.el
+++ b/modules/app/rss/autoload.el
@@ -1,13 +1,6 @@
 ;;; app/rss/autoload.el -*- lexical-binding: t; -*-
 
-(require 'cl-lib)
-
 (defvar +rss--wconf nil)
-
-(defvar +rss-youtube-feed-format
-  '(("^UC" . "https://www.youtube.com/feeds/videos.xml?channel_id=%s")
-    ("^PL" . "https://www.youtube.com/feeds/videos.xml?playlist_id=%s")
-    (""    . "https://www.youtube.com/feeds/videos.xml?user=%s")))
 
 ;;;###autoload
 (defun =rss ()
@@ -188,7 +181,6 @@
      (listing))))
 
 ;;;###autoload
-(defmacro +rss-elfeed-config! (&rest feeds)
-  "Minimizes FEEDS listings."
-  (declare (indent 0))
-  `(setf elfeed-feeds (mapcar #'+rss--elfeed-expand ',feeds)))
+(defun +rss-set-elfeed! (&rest feeds)
+  "Helper for setting multiple elfeed FEEDS."
+  (setq elfeed-feeds (mapcar #'+rss--elfeed-expand feeds)))

--- a/modules/app/rss/config.el
+++ b/modules/app/rss/config.el
@@ -89,5 +89,19 @@ easier to scroll through.")
   :config
   (elfeed-goodies/setup))
 
+(defvar +rss-youtube-feed-format
+  '(("^UC" . "https://www.youtube.com/feeds/videos.xml?channel_id=%s")
+    ("^PL" . "https://www.youtube.com/feeds/videos.xml?playlist_id=%s")
+    (""    . "https://www.youtube.com/feeds/videos.xml?user=%s")))
+
 (use-package! youtube-dl
-  :when (featurep! +media))
+  :when (featurep! +media)
+  :after elfeed
+  :config
+  (map! :when (and (featurep! +media)
+                   (featurep! :editor evil +everywhere))
+        (:map elfeed-show-mode-map
+              :n "y" #'+rss/show-youtube-dl)
+        (:map elfeed-search-mode-map
+              :n "y" #'+rss/search-youtube-dl
+              :n "L" #'youtube-dl-list)))

--- a/modules/app/rss/config.el
+++ b/modules/app/rss/config.el
@@ -49,6 +49,9 @@ easier to scroll through.")
       shr-put-image-function #'+rss-put-sliced-image-fn
       shr-external-rendering-functions '((img . +rss-render-image-tag-without-underline-fn))))
 
+  (when (featurep! +media)
+    (add-hook! 'elfeed-new-entry-hook #'+rss-podcast-tagger))
+
   ;; Keybindings
   (after! elfeed-show
     (define-key! elfeed-show-mode-map
@@ -85,3 +88,6 @@ easier to scroll through.")
   :after elfeed
   :config
   (elfeed-goodies/setup))
+
+(use-package! youtube-dl
+  :when (featurep! +media))

--- a/modules/app/rss/packages.el
+++ b/modules/app/rss/packages.el
@@ -6,4 +6,4 @@
 (when (featurep! +org)
   (package! elfeed-org :pin "268efdd0121fa61f63b722c30e0951c5d31224a4"))
 (when (featurep! +media)
-  (package! youtube-dl))
+  (package! youtube-dl :pin "af877b5bc4f01c04fccfa7d47a2c328926f20ef4"))

--- a/modules/app/rss/packages.el
+++ b/modules/app/rss/packages.el
@@ -5,3 +5,5 @@
 (package! elfeed-goodies :pin "95b4ea632fbd5960927952ec8f3394eb88da4752")
 (when (featurep! +org)
   (package! elfeed-org :pin "268efdd0121fa61f63b722c30e0951c5d31224a4"))
+(when (featurep! +media)
+  (package! youtube-dl))


### PR DESCRIPTION
Adds functionality to help users be able to manage downloads from
youtube channels, users, and playlists through youtube-dl.

This is based on the functionality that @skeeto uses in his own configs [here](https://github.com/skeeto/.emacs.d/blob/master/etc/feed-setup.el). I learned of this approach on [a reddit post](https://www.reddit.com/r/emacs/comments/7usz5q/youtube_subscriptions_using_elfeed_mpv_no_browser/dtntty8/?utm_source=reddit&utm_medium=web2x&context=3) by skeeto too. If you want to know more check it out. This change should also play nice with `emms` if you make the `youtube-dl-directory` the same as the `emms-directory`.

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [x] I've searched for similar pull requests and found nothing
  - [x] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [x] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [x] I've linked any relevant issues and PRs below
  - [x] All my commit messages are descriptive and distinct

-->