### PR TITLE
:ui modeline: Fix missing arg to +modeline-format-icon function

### DIFF
--- a/modules/ui/modeline/+light.el
+++ b/modules/ui/modeline/+light.el
@@ -427,11 +427,11 @@ Requires `anzu', also `evil-anzu' if using `evil-mode' for compatibility with
                                                     error
                                                     warning
                                                     info))))
-               (+modeline-format-icon "check" "" 'success)))
-            (`running     (+modeline-format-icon'material "access_time" "*" 'mode-line-inactive "Running..."))
-            (`errored     (+modeline-format-icon'material "sim_card_alert" "!" 'error "Errored!"))
-            (`interrupted (+modeline-format-icon'material "pause" "!" 'mode-line-inactive "Interrupted"))
-            (`suspicious  (+modeline-format-icon'material "priority_high" "!" 'error "Suspicious"))))))
+               (+modeline-format-icon 'material "check" "" 'success)))
+            (`running     (+modeline-format-icon 'material "access_time" "*" 'mode-line-inactive "Running..."))
+            (`errored     (+modeline-format-icon 'material "sim_card_alert" "!" 'error "Errored!"))
+            (`interrupted (+modeline-format-icon 'material "pause" "!" 'mode-line-inactive "Interrupted"))
+            (`suspicious  (+modeline-format-icon 'material "priority_high" "!" 'error "Suspicious"))))))
 
 
 


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [X] It targets the develop branch
  - [X] I've searched for similar pull requests and found nothing
  - [X] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [X] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [X] I've linked any relevant issues and PRs below
  - [X] All my commit messages are descriptive and distinct

-->

Fix for #3307 

Because of a wrong conflict solve on #3307, I missed one function to add the new arg