### PR TITLE
Prevent electric-quotes in org src-blocks.

### DIFF
--- a/modules/emacs/electric/config.el
+++ b/modules/emacs/electric/config.el
@@ -15,4 +15,7 @@ current line.")
       (when (and (eolp) +electric-indent-words)
         (save-excursion
           (backward-word)
-          (looking-at-p (concat "\\<" (regexp-opt +electric-indent-words))))))))
+          (looking-at-p (concat "\\<" (regexp-opt +electric-indent-words)))))))
+
+;; Prevent electric-quotes in org src-blocks.
+  (add-hook 'electric-quote-inhibit-functions (lambda () (org-in-block-p '("src")))))


### PR DESCRIPTION
Fixes #5051

Added hook to prevent electric-quote-mode from converting quotes when point is inside an org src-block.

In the linked issue, I had tried using "org-in-src-block-p" as the inhibiting function. It worked, but only after rearranging the functions in post-self-insert-hook so the electric-quote function (electric-quote-post-self-insert-function) would run before the smartparens function (sp--post-self-insert-hook-handler).

Looking deeper into the problem, I found that "org-in-src-block-p" isn't always accurate, because it relies on the "src-block" property of the char at point. But that property is getting switched to nil by sp--post-self-insert-hook-handler (specifically, by the call to sp-insert-pair). 

I think this might be caused by the "src-block" text property getting inherited from the quote that smartparens inserts in front of our own typed quote mark. Not sure.

Unlike "org-in-src-block-p", "org-in-block-p" doesn't rely on an abstracted text property. It examines the text surrounding point to determine if it's within a src-block. So it should more reliably prevent electric-quotes from sullying our src-blocks. (I appreciate any suggestions you might have.)