### PR TITLE
Update suggested clangd flags in lang/cc docs

### DIFF
--- a/modules/lang/cc/README.org
+++ b/modules/lang/cc/README.org
@@ -210,7 +210,8 @@ Search for your combination of =(LSP client package, LSP server)=. You are using
                                 "--background-index"
                                 "--clang-tidy"
                                 "--completion-style=detailed"
-                                "--header-insertion=never"))
+                                "--header-insertion=never"
+                                "--header-insertion-decorators=0"))
 (after! lsp-clangd (set-lsp-priority! 'clangd 2))
 #+END_SRC
 


### PR DESCRIPTION
This adds a missing clangd flag for LSP, needed to make it work correctly with company-mode.
It's from the default value of `lsp-clients-clangd-args`.
This is with `clangd version 11.1.0`.

If not set, I find C++ completion will produce a single space instead of showing up the list, in a case like `myVariable.`, triggering completion after the dot character.
