### PR TITLE
Noting the lsp-peek handlers as :async

### DIFF
--- a/modules/tools/lsp/+lsp.el
+++ b/modules/tools/lsp/+lsp.el
@@ -170,7 +170,8 @@ instead is more sensible."
     (set-lookup-handlers! 'lsp-ui-mode
       :definition 'lsp-ui-peek-find-definitions
       :implementations 'lsp-ui-peek-find-implementation
-      :references 'lsp-ui-peek-find-references))
+      :references 'lsp-ui-peek-find-references
+      :async t))
 
   (setq lsp-ui-peek-enable (featurep! +peek)
         lsp-ui-doc-max-height 8


### PR DESCRIPTION
I changed the lsp-peek handlers to be registered as :async.
This causes them to be considered successful by the lookup.el calls.

Without this, subsequent handlers registered (e.g. those from other
completion frameworks) will also pop up in addition to the peek UI.
This creates UI lock-up and is generally undesired.

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] I've searched for similar pull requests and found nothing
  - [ ] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [ ] I've linked any relevant issues and PRs below
  - [ ] All my commit messages are descriptive and distinct

-->



Although I haven't tested it with php, it probably fixes #5069 . The symptoms are identical to what I saw in C++.
