### PR TITLE
define-localleader-key's featurep -> featurep!

### DIFF
--- a/core/core-keybinds.el
+++ b/core/core-keybinds.el
@@ -167,7 +167,7 @@ interface.
 
 See `doom-localleader-key' and `doom-localleader-alt-key' to change the
 localleader prefix."
-  (if (featurep 'evil)
+  (if (featurep! :editor evil)
       ;; :non-normal-prefix doesn't apply to non-evil sessions (only evil's
       ;; emacs state)
       `(general-define-key


### PR DESCRIPTION
Replace the use of featurep with featurep! in `define-localleader-key!`

This stops a race condition where a module with `(map! :map a-map :localleader ....` is loaded
before `evil` has been activated, so the macro expands to use the `doom-local-leader-alt-key` prefix.