### PR TITLE
Add qt module documentation

### DIFF
--- a/modules/lang/qt/README.org
+++ b/modules/lang/qt/README.org
@@ -1,0 +1,31 @@
+#+TITLE:   lang/qt
+#+DATE:    May 22, 2021
+#+SINCE:   v2.0.9
+#+STARTUP: inlineimages nofold
+
+* Table of Contents :TOC_3:noexport:
+- [[#description][Description]]
+  - [[#maintainers][Maintainers]]
+  - [[#module-flags][Module Flags]]
+  - [[#plugins][Plugins]]
+- [[#prerequisites][Prerequisites]]
+
+* Description
+# A summary of what this module does.
+This module provides language functionality for [[https://qt.io][Qt]] specific files.
+
++ Syntax highlighting for [[https:://en.wikipedia.org/wiki/QML][qml]] files
++ Syntax highlighting for .pro and .pri files used by [[https://doc.qt.io/qt-5/qmake-project-files.html][qmake]]
+
+** Maintainers
+This module has no dedicated maintainers.
+
+** Module Flags
+This module provides no flags.
+
+** Plugins
++ [[https://github.com/coldnew/qml-mode/tree/master][qml-mode]]
++ [[https://github.com/EricCrosson/qt-pro-mode][qt-pro-mode]]
+
+* Prerequisites
+This module has no prerequisites.


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] I've searched for similar pull requests and found nothing
  - [ ] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [ ] I've linked any relevant issues and PRs below
  - [ ] All my commit messages are descriptive and distinct

-->

This is part of #1166, adding documentation for the `lang/qt` module.

I am not sure if I need to mention the `qml-beginning-of-defun` and `qml-end-of-defun` navigation commands provided by qml-mode or not?
