### PR TITLE
Add ranger documentation to dired README

### DIFF
--- a/modules/emacs/dired/README.org
+++ b/modules/emacs/dired/README.org
@@ -8,6 +8,7 @@
   - [[#module-flags][Module Flags]]
   - [[#plugins][Plugins]]
 - [[#prerequisites][Prerequisites]]
+- [[#ranger][Ranger]]
 - [[#keybindings][Keybindings]]
 
 * Description

--- a/modules/emacs/dired/README.org
+++ b/modules/emacs/dired/README.org
@@ -32,6 +32,11 @@ This module provides configuration for dired.
 This module has no prerequisites *except on BSDs* where =GNU ls= (~gls~) is
 needed for it to work properly (Doom doctor will notify you if it is missing).
 
+* Ranger
+If =+ranger= is enabled often a buffer will be opened in minimal ranger mode
+(deer-mode). In this case =z P= can be used to toggle between full ranger and
+deer-mode.
+
 * Keybindings
 | Keybind   | Description                  |
 |-----------+------------------------------|

--- a/modules/emacs/dired/README.org
+++ b/modules/emacs/dired/README.org
@@ -8,8 +8,8 @@
   - [[#module-flags][Module Flags]]
   - [[#plugins][Plugins]]
 - [[#prerequisites][Prerequisites]]
-- [[#ranger][Ranger]]
 - [[#keybindings][Keybindings]]
+  - [[#ranger][Ranger]]
 
 * Description
 This module provides configuration for dired.
@@ -33,11 +33,6 @@ This module provides configuration for dired.
 This module has no prerequisites *except on BSDs* where =GNU ls= (~gls~) is
 needed for it to work properly (Doom doctor will notify you if it is missing).
 
-* Ranger
-If =+ranger= is enabled often a buffer will be opened in minimal ranger mode
-(deer-mode). In this case =z P= can be used to toggle between full ranger and
-deer-mode.
-
 * Keybindings
 | Keybind   | Description                  |
 |-----------+------------------------------|
@@ -47,3 +42,8 @@ deer-mode.
 | =C-c C-e= | Rename entries with =wdired= |
 
 Other keybindings can be found on the official [[https://www.gnu.org/software/emacs/refcards/pdf/dired-ref.pdf][Dired reference card]].
+
+** Ranger
+If =+ranger= is enabled often a buffer will be opened in minimal ranger mode
+(deer-mode). In this case =z P= can be used to toggle between full ranger and
+deer-mode.


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] I've searched for similar pull requests and found nothing
  - [ ] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [ ] I've linked any relevant issues and PRs below
  - [ ] All my commit messages are descriptive and distinct

-->


I added a small ranger section to "/modules/emacs/dired/README.org". This section simply explains that if the +ranger flag for dired is set in init.el often a "deer-mode" or minimal ranger buffer will be opened, and that "Z p" can be used to toggle between this minimal mode and the full ranger mode. I added this because I think deer-mode looks deceptively similar to standard dired-mode and it may not be obvious what is occurring and how to switch to full ranger if the +ranger flag was set without reading the ranger.el docs.
