### PR TITLE
term/vterm: yield the vterm buffer

### DIFF
--- a/modules/term/vterm/autoload.el
+++ b/modules/term/vterm/autoload.el
@@ -41,7 +41,9 @@ If prefix ARG is non-nil, recreate vterm buffer in the current project's root."
 (defun +vterm/here (arg)
   "Open a terminal buffer in the current window at project root.
 
-If prefix ARG is non-nil, cd into `default-directory' instead of project root."
+If prefix ARG is non-nil, cd into `default-directory' instead of project root.
+
+Return the created buffer."
   (interactive "P")
   (unless (fboundp 'module-load)
     (user-error "Your build of Emacs lacks dynamic modules support and cannot load vterm"))
@@ -56,8 +58,9 @@ If prefix ARG is non-nil, cd into `default-directory' instead of project root."
              project-root))
          display-buffer-alist)
     (setenv "PROOT" project-root)
-    (vterm vterm-buffer-name)
-    (+vterm--change-directory-if-remote)))
+    (let ((buffer (vterm vterm-buffer-name)))
+      (+vterm--change-directory-if-remote)
+      buffer)))
 
 (defun +vterm--change-directory-if-remote ()
   "When `default-directory` is remote, use the corresponding


### PR DESCRIPTION
- [x] It targets the develop branch
- [x] I've searched for similar pull requests and found nothing
- [x] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
- [x] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
- [x] I've linked any relevant issues and PRs below
- [x] All my commit messages are descriptive and distinct

This PR extends `+vterm/here` to return the vterm buffer that was created, so that downstream callers can manipulate it programmatically.
