### PR TITLE
`doom-file-set-extension`

### DIFF
--- a/core/autoload/files.el
+++ b/core/autoload/files.el
@@ -55,7 +55,7 @@ Ignores `nil' elements in SEGMENTS."
 ;;;###autoload
 (defun doom-glob (&rest segments)
   "Construct a path from SEGMENTS and expand glob patterns.
-Returns nil if the path doesn't exist.
+Returns `nil' if the path doesn't exist.
 Ignores `nil' elements in SEGMENTS."
   (let (case-fold-search)
     (file-expand-wildcards (apply #'doom-path segments) t)))
@@ -67,6 +67,22 @@ See `doom-path'.
 Ignores `nil' elements in SEGMENTS."
   (when-let (path (doom-path segments))
     (directory-file-name path)))
+
+;;;###autoload
+(defun doom-file-set-extension (file extension)
+  "Change the extension of a FILE to EXTENSION.
+
+Sanitizes the input to consolidate leading/trailing dots.
+
+Returns `nil' if either of the file or extension are `nil' before
+sanitizing, or empty afterwards."
+  (when (and file extension)
+    (let* ((patt "[ \\t\\n\\r.]+") ; Borrowed from `string-trim'.
+           (file (string-trim-right file patt))
+           (extension (string-trim-left extension patt)))
+      (unless (or (string-empty-p file)
+                  (string-empty-p extension))
+        (concat (file-name-sans-extension file) "." extension)))))
 
 ;;;###autoload
 (cl-defun doom-files-in

--- a/modules/lang/emacs-lisp/demos.org
+++ b/modules/lang/emacs-lisp/demos.org
@@ -34,6 +34,7 @@ usage from their documentation (e.g. =SPC h f add-hook\!=).
   - [[#setq-hook][setq-hook!]]
   - [[#unsetq-hook][unsetq-hook!]]
   - [[#use-package][use-package!]]
+  - [[#doom-file-set-extension][doom-file-set-extension]]
 
 * core-lib
 ** add-hook!
@@ -531,3 +532,27 @@ These are side-by-side comparisons, showing how to bind keys with and without
 (use-package! abc
   :defer-incrementally t)
 #+END_SRC
+
+** doom-file-set-extension
+#+begin_src elisp
+(doom-file-set-extension "jack.scss" "css")
+#+end_src
+
+#+RESULTS:
+: "jack.css"
+
+#+begin_src elisp
+;; Works even if the extension started with a dot already.
+(doom-file-set-extension "jack.scss" ".css")
+#+end_src
+
+#+RESULTS:
+: "jack.css"
+
+#+begin_src elisp
+;; Just don't get any funny ideas.
+(doom-file-set-extension "jack.scss" "..........")
+#+end_src
+
+#+RESULTS:
+: nil


### PR DESCRIPTION
- [x] It targets the develop branch
- [x] I've searched for similar pull requests and found nothing
- [x] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
- [x] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
- [x] I've linked any relevant issues and PRs below
- [x] All my commit messages are descriptive and distinct

This PR adds the function `doom-file-set-extension` to its set of other path-related convenience functions.
