### PR TITLE
Add :not counsel-org-goto to ivy-prescient-sort-commands

### DIFF
--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -388,11 +388,11 @@ results buffer.")
   ;; REVIEW Remove when raxod502/prescient.el#102 is resolved
   (add-to-list 'ivy-sort-functions-alist '(ivy-resume))
   (setq ivy-prescient-sort-commands
-        '(:not swiper swiper-isearch ivy-switch-buffer
-          lsp-ivy-workspace-symbol ivy-resume ivy--restore-session
-          counsel-grep counsel-git-grep counsel-rg counsel-ag counsel-ack
-          counsel-fzf counsel-pt counsel-imenu counsel-yank-pop counsel-recentf
-          counsel-buffer-or-recentf counsel-outline counsel-jq)
+        '(:not swiper swiper-isearch ivy-switch-buffer lsp-ivy-workspace-symbol
+          ivy-resume ivy--restore-session counsel-grep counsel-git-grep
+          counsel-rg counsel-ag counsel-ack counsel-fzf counsel-pt counsel-imenu
+          counsel-yank-pop counsel-recentf counsel-buffer-or-recentf
+          counsel-outline counsel-org-goto counsel-jq)
         ivy-prescient-retain-classic-highlighting t)
   (defun +ivy-prescient-non-fuzzy (str)
     (let ((prescient-filter-method '(literal regexp)))


### PR DESCRIPTION
Although `counsel-org-goto` is an alias of `counsel-outline`, while the latter is already in the list, the former's output is still sorted.

Github's "Files changed" is too noisy, here is Magit's more friendly diff:
![image](https://user-images.githubusercontent.com/32123754/119641238-a4afc100-be43-11eb-941b-1ee02b5802f0.png)