### PR TITLE
Advice lispyville-end-of-defun to go past defuns

### DIFF
--- a/modules/editor/lispy/config.el
+++ b/modules/editor/lispy/config.el
@@ -38,4 +38,14 @@
           additional
           additional-insert))
   :config
-  (lispyville-set-key-theme))
+  (lispyville-set-key-theme)
+;; REVIEW Delete this once https://github.com/noctuid/lispyville/pull/297 is merged
+  (defadvice! +lispy--fix-lispyville-end-of-defun-a (_)
+    "lispyville-end-of-defun doesn't go to the next defun when
+point is already at the end of a defun, whereas
+lispyville-beginning-of-defun does."
+    :before #'lispyville-end-of-defun
+    (when (<= (- (line-end-position)
+                 (point))
+              1)
+      (forward-line))))


### PR DESCRIPTION
-------

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] I've searched for similar pull requests and found nothing
  - [ ] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [ ] I've linked any relevant issues and PRs below
  - [ ] All my commit messages are descriptive and distinct

-->


I have sent a pull request to lispyville for making a keybinding more consistent (see https://github.com/noctuid/lispyville/pull/297). The maintainer does not seem to respond so until then I propose to advice the function in doom.

`lispyville-end-of-defun` doesn't go to the next defun when point is already at the end of a defun, whereas `lispyville-beginning-of-defun` does. This commit fixes this inconsistency by matching `lispyville-end-of-defun`'s behaviour with lispyville-beginning-of-defun.