### PR TITLE
doctor: Check for missing `tidy`

### DIFF
--- a/modules/lang/web/doctor.el
+++ b/modules/lang/web/doctor.el
@@ -10,3 +10,5 @@
 (unless (executable-find "stylelint")
   (warn! "Couldn't find stylelint. Linting for CSS modes will not work."))
 
+(unless (executable-find "tidy")
+  (warn! "Couldn't find tidy. Code formatting in HTML modes will not work."))


### PR DESCRIPTION
  - [x] It targets the develop branch
  - [x] I've searched for similar pull requests and found nothing
  - [x] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [x] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [x] I've linked any relevant issues and PRs below
  - [x] All my commit messages are descriptive and distinct

This quick PR adds a check for the `tidy` executable in `doom doctor`. The new output looks like:

![tidy](https://user-images.githubusercontent.com/229679/119767696-23205900-be6c-11eb-9b9e-a4529372f6f3.png)
