### PR TITLE
lang/rust: Binding for `cargo doc`

### DIFF
--- a/modules/lang/rust/config.el
+++ b/modules/lang/rust/config.el
@@ -45,16 +45,17 @@
   (map! :map rustic-mode-map
         :localleader
         (:prefix ("b" . "build")
-          :desc "cargo audit"    "a" #'+rust/cargo-audit
-          :desc "cargo build"    "b" #'rustic-cargo-build
-          :desc "cargo bench"    "B" #'rustic-cargo-bench
-          :desc "cargo check"    "c" #'rustic-cargo-check
-          :desc "cargo clippy"   "C" #'rustic-cargo-clippy
-          :desc "cargo doc"      "d" #'rustic-cargo-doc
-          :desc "cargo fmt"      "f" #'rustic-cargo-fmt
-          :desc "cargo new"      "n" #'rustic-cargo-new
-          :desc "cargo outdated" "o" #'rustic-cargo-outdated
-          :desc "cargo run"      "r" #'rustic-cargo-run)
+          :desc "cargo audit"      "a" #'+rust/cargo-audit
+          :desc "cargo build"      "b" #'rustic-cargo-build
+          :desc "cargo bench"      "B" #'rustic-cargo-bench
+          :desc "cargo check"      "c" #'rustic-cargo-check
+          :desc "cargo clippy"     "C" #'rustic-cargo-clippy
+          :desc "cargo doc"        "d" #'rustic-cargo-build-doc
+          :desc "cargo doc --open" "D" #'rustic-cargo-doc
+          :desc "cargo fmt"        "f" #'rustic-cargo-fmt
+          :desc "cargo new"        "n" #'rustic-cargo-new
+          :desc "cargo outdated"   "o" #'rustic-cargo-outdated
+          :desc "cargo run"        "r" #'rustic-cargo-run)
         (:prefix ("t" . "cargo test")
           :desc "all"          "a" #'rustic-cargo-test
           :desc "current test" "t" #'rustic-cargo-current-test))


### PR DESCRIPTION
- [x] It targets the develop branch
- [x] I've searched for similar pull requests and found nothing
- [x] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
- [x] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
- [x] I've linked any relevant issues and PRs below
- [x] All my commit messages are descriptive and distinct

`cargo doc --open` (the previous binding of `SPC m b d`) always opens a new
browser tab. For "doc-driven development" this isn't so nice, since we'd like to
stay in the same tab and just refresh its contents after editing. That's what
`cargo doc` (without `--open`) does, which is called by
`#'rustic-cargo-build-doc`.

This commit introduces a binding for the latter behaviour, but asigns it to the
old `SPC m b d`, with the "open" variant as `SPC m b D`. This matches Spacemacs
and follows the usual pattern of "the capital letter variant is the one you use
less often".

Of course if you'd rather not the existing binding be flipped, I'm perfectly willing to switch it.
