### PR TITLE
Add feature to ocaml module to allow using prettifying-symbols while bypassing tuareg's symbol alist

### DIFF
--- a/modules/lang/ocaml/README.org
+++ b/modules/lang/ocaml/README.org
@@ -26,7 +26,11 @@ This module adds [[https://ocaml.org/][OCaml]] support to Doom Emacs, powered by
 + Dune file format ([[http://dune.build/][dune]])
 
 ** Module Flags
-This module provides no flags.
++ ~-pretty~ Disable =tuareg-mode='s default ligature configuration. This is
+  useful when you would prefer to use the ligature support provided by a font
+  like =iosevka= or =fira= via the [[file:~/.emacs.d/modules/ui/ligatures/README.org][=ligatures=]] module, instead of tuareg
+  prettify symbol list. Otherwise, tuareg's symbol list will override the font
+  ligatures.
 
 ** Plugins
 + [[https://github.com/ocaml/tuareg][tuareg]]
@@ -87,7 +91,7 @@ tools.
   | =utop-eval-region=           | =SPC c e=         | evaluate selected region in =utop=                        |
 
 ** Hacks
-+ =set-ligatures!= is called with the full tuareg prettify symbol list, this
-  can cause columns to change as certain keywords are shortened (e.g. =fun=
-  becomes \lambda.
++ Unless the feature =-pretty= is set, =set-ligatures!= is called with the full
+  tuareg prettify symbol list, this can cause columns to change as certain
+  keywords are shortened (e.g. =fun= becomes \lambda.
 + =tuareg-opam-update-env= is called the first time =tuareg= is loaded

--- a/modules/lang/ocaml/config.el
+++ b/modules/lang/ocaml/config.el
@@ -9,12 +9,14 @@
 
 
 (after! tuareg
-  ;; tuareg-mode has the prettify symbols itself
-  (set-ligatures! 'tuareg-mode :alist
-    (append tuareg-prettify-symbols-basic-alist
-            tuareg-prettify-symbols-extra-alist))
-  ;; harmless if `prettify-symbols-mode' isn't active
-  (setq tuareg-prettify-symbols-full t)
+
+  (unless (featurep! -pretty)
+    ;; Use tuareg-mode's own prettify symbols set
+    (set-ligatures! 'tuareg-mode :alist
+      (append tuareg-prettify-symbols-basic-alist
+              tuareg-prettify-symbols-extra-alist))
+    ;; harmless if `prettify-symbols-mode' isn't active
+    (setq tuareg-prettify-symbols-full t))
 
   ;; Use opam to set environment
   (setq tuareg-opam-insinuate t)


### PR DESCRIPTION
The current configuration of the `ocaml` module seems to override the support for ligatures coming from Fira code (and Iosevka) via `prettify-symbols-mode`. The current work-around I've found is to add a feature to disable the "hack" (according to [the documentation](https://github.com/hlissner/doom-emacs/blob/develop/modules/lang/ocaml/README.org#hacks)) of using `set-ligatures!` on the tuareg prettify symbols alist. Which this disabled, I am then free to add what I want in my personal config to get the kind of prettification I want[1].

In general, I think some users of the `ocaml` module will appreciate the ability to use a different symbols for prettifying than that supplied by tuareg, since tuareg's do not maintain character width, and the set is relatively limited. 

I don't think the solution here is the **correct** way, but just an illustration of the effect I am after. I expect that the reviewer will be able to instruct me on the preferred way of achieving the desired outcome which staying consistent with the excellent design philosophy and conventions of the doom project.

I have implemented the bypass currently as a "negative" feature, for the sake of maintaining backwards compatibility with current users. Should I just switch this into a "postive" feature? Should I came at this from a very different angle?

---

[1] Currently, this means adding 

```emacs-lisp
(add-hook! prog-mode
  ;; Enable fira-code ligatures
  (fira-code-mode)
  (prettify-symbols-mode-set-explicitly))
``` 

not nice, but it's working.