### PR TITLE
Add haskell gitignore template

### DIFF
--- a/modules/editor/file-templates/templates/gitignore-mode/__
+++ b/modules/editor/file-templates/templates/gitignore-mode/__
@@ -3,7 +3,7 @@
 *.log
 tmp/
 
-`(let ((type-ignore (yas-choose-value '("(none)" "python" "ruby" "java" "js"))))
+`(let ((type-ignore (yas-choose-value '("(none)" "python" "ruby" "java" "js" "haskell"))))
     (string-join
        (cond ((string= type-ignore "python")
               '("*.py[cod]"
@@ -27,5 +27,29 @@ tmp/
                "yarn-error.log*"
                "*.tsbuildinfo"
                ".npm"
-               ".eslintcache")))
+               ".eslintcache"))
+             ((string= type-ignore "haskell")
+             '("dist"
+               "dist-*"
+               "cabal-dev"
+               "*.o"
+               "*.hi"
+               "*.hie"
+               "*.chi"
+               "*.chs.h"
+               "*.dyn_o"
+               "*.dyn_hi"
+               ".hpc"
+               ".hsenv"
+               ".cabal-sandbox/"
+               "cabal.sandbox.config"
+               "*.prof"
+               "*.aux"
+               "*.hp"
+               "*.eventlog"
+               ".stack-work/"
+               "cabal.project.local"
+               "cabal.project.local~"
+               ".HTF/"
+               ".ghc.environment.*")))
        "\n"))`


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [x] I've searched for similar pull requests and found nothing
  - [x] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [ ] I've linked any relevant issues and PRs below
  - [x] All my commit messages are descriptive and distinct

-->

Adds "haskell" to the `yas-choose-value` list when creating a new `.gitignore` file. The actual contents of the template are taken from https://www.toptal.com/developers/gitignore/api/haskell.
