### PR TITLE
Add evil-keybindings for various sharper commands

### DIFF
--- a/modules/lang/csharp/config.el
+++ b/modules/lang/csharp/config.el
@@ -97,7 +97,19 @@ or terminating simple string."
 
 (use-package! sharper
   :when (featurep! +dotnet)
-  :general ("C-c d" #'sharper-main-transient))
+  :general ("C-c d" #'sharper-main-transient)
+  :config
+  (map! (:map sharper--solution-management-mode-map
+         :nv "RET" #'sharper-transient-solution
+         :nv "gr" #'sharper--solution-management-refresh)
+        (:map sharper--project-references-mode-map
+         :nv "RET" #'sharper-transient-project-references
+         :nv "gr" #'sharper--project-references-refresh)
+        (:map sharper--project-packages-mode-map
+         :nv "RET" #'sharper-transient-project-packages
+         :nv "gr" #'sharper--project-packages-refresh)
+        (:map sharper--nuget-results-mode-map
+         :nv "RET" #'sharper--nuget-search-install)))
 
 
 (use-package! sln-mode :mode "\\.sln\\'")


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ X] It targets the develop branch
  - [ X] I've searched for similar pull requests and found nothing
  - [ X] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ X] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [ X] I've linked any relevant issues and PRs below
  - [ X] All my commit messages are descriptive and distinct

-->



When using evil the keybinds defined in the sharper package were not available. This PR maps sharper commands in a way that is mostly analogous to the keybinds originally defined in the package. I changed the bindings for various refresh commands to "gr", however, to be in line with similar other facilities in Doom.

