### PR TITLE
doctor: Warn if `shfmt` is missing

### DIFF
--- a/modules/lang/sh/doctor.el
+++ b/modules/lang/sh/doctor.el
@@ -3,3 +3,7 @@
 (when (featurep! :checkers syntax)
  (unless (executable-find "shellcheck")
   (warn! "Couldn't find shellcheck. Shell script linting will not work")))
+
+(when (featurep! :editor format)
+  (unless (executable-find "shfmt")
+    (warn! "Couldn't find shfmt. Code formatting in sh buffers will not work.")))


### PR DESCRIPTION
- [x] It targets the develop branch
- [x] I've searched for similar pull requests and found nothing
- [x] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
- [x] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
- [x] I've linked any relevant issues and PRs below
- [x] All my commit messages are descriptive and distinct

This PR adds a check to `doom doctor` for a missing `shfmt` executable, but only if `:editor format` is installed. I should probably alter my last PR to account for `format` (and check for other missing ones).
