### PR TITLE
cli/packages fixes

### DIFF
--- a/core/cli/packages.el
+++ b/core/cli/packages.el
@@ -402,9 +402,10 @@ declaration) or dependency thereof that hasn't already been."
                      (print! (start "\033[K(%d/%d) Fetching %s...%s") i total package esc)
                      (doom--straight-with (straight-vc-fetch-from-remote recipe)
                        (when .it
-                         (setq output .output)
                          (straight-merge-package package)
                          (setq target-ref (straight-vc-get-commit type local-repo))
+                         (setq output (doom--commit-log-between ref target-ref)
+                               commits (length (split-string output "\n" t)))
                          (or (not (doom--same-commit-p target-ref ref))
                              (cl-return)))))
 

--- a/core/cli/packages.el
+++ b/core/cli/packages.el
@@ -447,7 +447,8 @@ declaration) or dependency thereof that hasn't already been."
                        (doom--abbrev-commit ref)
                        (doom--abbrev-commit target-ref)
                        (if (and (integerp commits) (> commits 0))
-                           (format " [%d commit(s)]" commits)))
+                           (format " [%d commit(s)]" commits)
+                         ""))
                (unless (string-empty-p output)
                  (let ((lines (split-string output "\n")))
                    (setq output


### PR DESCRIPTION
This PR has two distinct fixes:

The first commit fixes a bug in the commit counting introduced in a3df5bf, which prints `nil` instead of the empty string when the repo moves from commit A to commit B where A isn't reachable from B. (this can be reproduced by pinning a package to a previous commit and running `doom sync -u`)

The second commit has a fix for the recent regression in `doom sync -u`/`doom upgrade` output for unpinned packages, and adds the commit counting logic for updating unpinned packages (which also had the `nil` bug since either way `commits` was set to `nil` there too).


- [X] It targets the develop branch
- [X] I've searched for similar pull requests and found nothing
- [X] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
- [X] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
- [X] I've linked any relevant issues and PRs below
- [X] All my commit messages are descriptive and distinct