### PR TITLE
docs/mu4e: configure for other than IMAP backends

### DIFF
--- a/modules/email/mu4e/README.org
+++ b/modules/email/mu4e/README.org
@@ -17,6 +17,7 @@
 - [[#configuration][Configuration]]
   - [[#offlineimap][offlineimap]]
   - [[#mbsync][mbsync]]
+  - [[#other-backends][other backends]]
   - [[#mu-and-mu4e][mu and mu4e]]
 - [[#troubleshooting][Troubleshooting]]
   - [[#no-such-file-or-directory-mu4e][=No such file or directory, mu4e=]]
@@ -43,7 +44,8 @@ via IMAP) and ~mu~ (to index my mail into a format ~mu4e~ can understand).
 * Prerequisites
 This module requires:
 
-+ Either ~mbsync~ (default) or ~offlineimap~ (to sync mail with)
++ Either ~mbsync~ (default) or ~offlineimap~ (to sync IMAP mail with). In case
+  of a different backend, please read below.
 + ~mu~, to index your downloaded messages and to provide the ~mu4e~ package.
 
 ** MacOS
@@ -134,6 +136,18 @@ Next you can download your email with ~mbsync --all~. This may take a while, but
 should be quicker than =offlineimap= ;).
 
 You can now proceed with the [[#mu-and-mu4e][mu and mu4e]] section.
+
+** other backends
+In case you are neither using =offlinemap= nor =mbsync= (example you're syncing
+using POP3(s) protocol instead of IMAP(s)), you need to disable the mu4e backend
+and manually set your mail retrieval command accordingly:
+
+#+BEGIN_SRC elisp
+;; in ~/.doom.d/config.el
+;; Example: we are using `mpop` to query a configured `account1` on a POP3 mail server
+(after! mu4e
+  (setq mu4e-get-mail-command "mpop account1"))
+#+END_SRC
 
 ** mu and mu4e
 You should have your email downloaded already. If you have not, you need to set


### PR DESCRIPTION
  - [x] It targets the develop branch
  - [x] I've searched for similar pull requests and found nothing
  - (no idea) This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [ ] I've linked any relevant issues and PRs below
  - [x] All my commit messages are descriptive and distinct

Slightly improve documentation on how to configure the `mu4e` module when not using an IMAP backend (i.e. neither `offlineimap` nor `mbsync`). This is mentioned in the [config.el](https://github.com/hlissner/doom-emacs/blob/f408016c6ff6c3fe02f7b43125e6adb587a34bdb/modules/email/mu4e/config.el#L4) but took me a while to figure this out.

I'm not sure about the Org formatting, in case please let me know!

thanks for reviewing this small patch