### PR TITLE
Add yasnippet minor mode when beancount is on

### DIFF
--- a/modules/lang/beancount/config.el
+++ b/modules/lang/beancount/config.el
@@ -2,6 +2,7 @@
 
 (use-package! beancount
   :mode ("\\.beancount\\'" . beancount-mode)
+  :hook(beancount-mode . yas-minor-mode-on)
   :init
   (add-hook 'beancount-mode-hook #'outline-minor-mode)
 


### PR DESCRIPTION
e.g.
```
# -*- mode: snippet -*-
# name: today's bean
# key: bean
# --
`(format-time-string "%Y-%m-%d" (current-time))` * "" "${1:Things}"
${2:account}
```

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] I've searched for similar pull requests and found nothing
  - [ ] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [ ] I've linked any relevant issues and PRs below
  - [ ] All my commit messages are descriptive and distinct

-->

Fixes #0000 <!-- remove if not applicable -->

{{{ Summarize what you've changed HERE and why }}}
