### PR TITLE
lang/org: Add flag +strike

### DIFF
--- a/modules/lang/org/README.org
+++ b/modules/lang/org/README.org
@@ -73,6 +73,7 @@ https://www.mfoot.com/blog/2015/11/22/literate-emacs-configuration-with-org-mode
 + =+pretty= Enables pretty unicode symbols for bullets and priorities, and
   better syntax highlighting for latex. Keep in mind: this can be expensive. If
   org becomes too slow, it'd be wise to disable this flag.
++ =+strike= Enables strikes-through for finished tasks.
 + =+roam= Enables org-roam integration. This requires ~sqlite3~ to be installed
   on your system.
 

--- a/modules/lang/org/contrib/strike.el
+++ b/modules/lang/org/contrib/strike.el
@@ -1,0 +1,8 @@
+;;; lang/org/contrib/strike.el -*- lexical-binding: t; -*-
+;;;###if (featurep! +strike)
+
+(after! org
+  (setq org-fontify-done-headline t)
+  (custom-set-faces!
+    '(org-done :strike-through t)
+    '(org-headline-done :strike-through t)))


### PR DESCRIPTION
This push request adds the +strike flag, which enables a strike-through for finished tasks, to the org module.