### PR TITLE
Use org-tree-slide-play-hook to hide blocks

### DIFF
--- a/modules/lang/org/contrib/present.el
+++ b/modules/lang/org/contrib/present.el
@@ -36,9 +36,8 @@ headings as titles, and you have more freedom to place them wherever you like.")
         org-tree-slide-heading-emphasis t)
 
   (add-hook 'org-tree-slide-after-narrow-hook #'org-display-inline-images)
-  (add-hook! 'org-tree-slide-mode-hook
-             #'+org-present-hide-blocks-h
-             #'+org-present-prettify-slide-h)
+  (add-hook 'org-tree-slide-mode-hook #'+org-present-prettify-slide-h)
+  (add-hook 'org-tree-slide-play-hook #'+org-present-hide-blocks-h)
 
   (when (featurep! :editor evil)
     (map! :map org-tree-slide-mode-map


### PR DESCRIPTION
For reasons I don't entirely understand, calling `+org-present-hide-blocks-h` during `org-tree-slide-mode-hook` _does not_ 
hide block headers/footers.

Instead, hooking `org-tree-slide-play-hook` hides those headers/footers.