### PR TITLE
lang/latex +fold: fix error when yas-snippet-{beg,end} are nil

### DIFF
--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -120,7 +120,8 @@ If no viewers are found, `latex-preview-pane' is used.")
     (add-hook! 'TeX-fold-mode-hook
       (defun +latex-fold-snippet-contents-h ()
         (add-hook! 'yas-after-exit-snippet-hook :local
-          (TeX-fold-region yas-snippet-beg yas-snippet-end)))))
+          (when (and yas-snippet-beg yas-snippet-end)
+            (TeX-fold-region yas-snippet-beg yas-snippet-end))))))
 
   (add-hook! 'mixed-pitch-mode-hook
     (defun +latex-fold-set-variable-pitch-h ()


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [X] It targets the develop branch
  - [X] I've searched for similar pull requests and found nothing
  - [X] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [X] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [X] I've linked any relevant issues and PRs below
  - [X] All my commit messages are descriptive and distinct

-->

This hook sometimes errors out because yasnippet ...forgets? to set `yas-snippet-{beg,end}`.
It occurs for *some* snippets and I think it only started about a month ago. Not sure why