### PR TITLE
Fix '+tmux/cd' to send newline

### DIFF
--- a/modules/tools/tmux/autoload/tmux.el
+++ b/modules/tools/tmux/autoload/tmux.el
@@ -65,11 +65,11 @@ but do not execute them."
   (apply #'+tmux +tmux-last-command))
 
 ;;;###autoload
-(defun +tmux/cd (&optional arg directory)
+(defun +tmux/cd (&optional directory)
   "Change the pwd of the currently active tmux pane to DIRECTORY (defaults to
 `default-directory', or to `doom-project-root' with the universal argument)."
   (interactive "PD")
-  (+tmux/run (format "cd %s" (or directory default-directory)) arg))
+  (+tmux/run (format "cd %s" (or directory default-directory))))
 
 ;;;###autoload
 (defun +tmux/cd-to-here ()

--- a/modules/tools/tmux/autoload/tmux.el
+++ b/modules/tools/tmux/autoload/tmux.el
@@ -69,7 +69,7 @@ but do not execute them."
   "Change the pwd of the currently active tmux pane to DIRECTORY (defaults to
 `default-directory', or to `doom-project-root' with the universal argument)."
   (interactive "PD")
-  (+tmux/run (format "cd %s" (or directory default-directory))))
+  (+tmux/run (format "cd '%s'" (or directory default-directory))))
 
 ;;;###autoload
 (defun +tmux/cd-to-here ()


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [x] I've searched for similar pull requests and found nothing
  - [ ] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [x] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [x] I've linked any relevant issues and PRs below
  - [x] All my commit messages are descriptive and distinct

-->

Hey,

I recently started testing `tmux` module and found out that `+tmux/cd` (and other functions using it: `+tmux/cd-to-here` and `+tmux/cd-to-project`) never sends newline - looks like `arg` argument is somehow obsolete there? I'm not very proficient in elisp, so I may be wrong though :)