### PR TITLE
Remove dependence on company for fish and bash completion in eshell

### DIFF
--- a/modules/term/eshell/packages.el
+++ b/modules/term/eshell/packages.el
@@ -9,6 +9,5 @@
 (package! eshell-syntax-highlighting :pin "32d2568ebeb42553a30dda77e03c0e2ec8854199")
 
 (unless IS-WINDOWS
-  (when (featurep! :completion company)
-    (package! fish-completion :pin "10384881817b5ae38cf6197a077a663420090d2c")
-    (package! bash-completion :pin "65e54c6f9c0ffebf94f7c505694bd249b9b53d32")))
+  (package! fish-completion :pin "10384881817b5ae38cf6197a077a663420090d2c")
+  (package! bash-completion :pin "65e54c6f9c0ffebf94f7c505694bd249b9b53d32"))


### PR DESCRIPTION
Bash and fish completion work without company, e.g. when the user uses
the minibuffer for completion.

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] I've searched for similar pull requests and found nothing
  - [ ] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [ ] I've linked any relevant issues and PRs below
  - [ ] All my commit messages are descriptive and distinct

-->
I've removed the feature gate behind company for fish and bash-completion. It works without company and there are people who don't use company. Furthermore it seems to cause some errors, see https://discord.com/channels/406534637242810369/406554085794381833/852098110624235550 
