### PR TITLE
lang/json/doctor: only check for jq if ivy is on

### DIFF
--- a/modules/lang/json/doctor.el
+++ b/modules/lang/json/doctor.el
@@ -1,4 +1,5 @@
 ;;; lang/json/doctor.el -*- lexical-binding: t; -*-
 
-(unless (executable-find "jq")
-  (warn! "Couldn't find jq. counsel-jq won't work."))
+(when (and (featurep! :completion ivy)
+           (not (executable-find "jq")))
+  (warn! "Couldn't find jq. counsel-jq won't work." ))


### PR DESCRIPTION
since `counsel-jq` is only relevant for ivy


- [X] It targets the develop branch
- [X] I've searched for similar pull requests and found nothing
- [X] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
- [X] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
- [X] I've linked any relevant issues and PRs below
- [X] All my commit messages are descriptive and distinct