### PR TITLE
`SPC TAB N` binding

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -365,6 +365,7 @@
         :desc "Display workspaces"           "d" #'+workspace/display
         :desc "Rename workspace"             "r" #'+workspace/rename
         :desc "Create workspace"             "c" #'+workspace/new
+        :desc "Create named workspace"       "C" #'+workspace/new-named
         :desc "Delete workspace"             "k" #'+workspace/delete
         :desc "Save workspace"               "S" #'+workspace/save
         :desc "Switch to other workspace"    "o" #'+workspace/other

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -306,6 +306,7 @@
         :desc "Switch workspace"          "."   #'+workspace/switch-to
         :desc "Switch to last workspace"  "`"   #'+workspace/other
         :desc "New workspace"             "n"   #'+workspace/new
+        :desc "New named workspace"       "N"   #'+workspace/new-named
         :desc "Load workspace from file"  "l"   #'+workspace/load
         :desc "Save workspace to file"    "s"   #'+workspace/save
         :desc "Delete session"            "x"   #'+workspace/kill-session

--- a/modules/ui/workspaces/autoload/workspaces.el
+++ b/modules/ui/workspaces/autoload/workspaces.el
@@ -307,6 +307,12 @@ workspace, otherwise the new workspace is blank."
     ((debug error) (+workspace-error (cadr e) t))))
 
 ;;;###autoload
+(defun +workspace/new-named (name)
+  "Create a new workspace with a given NAME."
+  (interactive "sWorkspace Name: ")
+  (+workspace/new name))
+
+;;;###autoload
 (defun +workspace/switch-to (index)
   "Switch to a workspace at a given INDEX. A negative number will start from the
 end of the workspace list."


### PR DESCRIPTION
This PR adds a small wrapper around `+workspace/new` for the primary use of binding to `SPC TAB N` and interactively prompting the user for the name of their new workspace. While both `+workspace/new` and `+workspace-new` can receive a named argument, neither are set up for user prompting in this way.

This binding offers a shortcut to the common pattern of creating a new workspace via `SPC TAB n` and then immediately renaming it via `SPC TAB r`.