### PR TITLE
[:input layout bepo] Remove "W" convenience remap

### DIFF
--- a/modules/input/layout/autoload/bepo.el
+++ b/modules/input/layout/autoload/bepo.el
@@ -189,8 +189,7 @@ See `+layout-bepo-cr-rotation-style' for the meaning of CR-STYLE."
       '(evil-normal-state-map evil-motion-state-map evil-operator-state-map)
       "é" "w"
       "É" "W"
-      "w" (kbd "C-w")
-      "W" (kbd "C-w C-w"))))
+      "w" (kbd "C-w"))))
 
 ;;;###autoload
 (defun +layout-bepo-rotate-keymaps (keymaps &optional cr-style)
@@ -324,5 +323,4 @@ Remappings are done according to CR-STYLE (see
     (evil-collection-translate-key '(normal motion operator visual) keymaps
       "é" "w"
       "É" "W"
-      "w" (kbd "C-w")
-      "W" (kbd "C-w C-w"))))
+      "w" (kbd "C-w"))))


### PR DESCRIPTION
`W` was used to emulate `C-w C-w`, which is useful to quickly change windows
most of the time. But this currently conflicts with edebug evil-collection bindings.
(gives `Key sequence W W starts with non-prefix key W` on the first loaded elisp buffer.).

Better to leave the key alone, avoid error messages altogether, and let users redefine
the binding if they want to.
