### PR TITLE
Fix #5128: No format-on-save by lsp-formatters

### DIFF
--- a/modules/editor/format/config.el
+++ b/modules/editor/format/config.el
@@ -74,11 +74,13 @@ This is controlled by `+format-on-save-enabled-modes'."
 (defadvice! +format--all-buffer-from-hook-a (orig-fn &rest args)
   :around #'format-all-buffer--from-hook
   (letf! (defun format-all-buffer--with (formatter mode-result)
-           (and (condition-case-unless-debug e
-                    (format-all--formatter-executable formatter)
-                  (error
-                   (message "Warning: cannot reformat buffer because %S isn't installed"
-                            (gethash formatter format-all--executable-table))
-                   nil))
-                (funcall format-all-buffer--with formatter mode-result)))
+           (when (or (eq formatter 'lsp)
+                     (eq formatter 'eglot)
+                     (condition-case-unless-debug e
+                         (format-all--formatter-executable formatter)
+                       (error
+                        (message "Warning: cannot reformat buffer because %S isn't installed"
+                                 (gethash formatter format-all--executable-table))
+                        nil)))
+             (funcall format-all-buffer--with formatter mode-result)))
     (apply orig-fn args)))


### PR DESCRIPTION
Fixes #5128

In `+format--all-buffer-from-hook-a`, a call to `format-all--formatter-executable` with the formatter being equal to `'lsp` or `'eglot` returns `nil`. That's why `funcall` was never executed in those cases. To fix this issue, this PR introduces special checks for those cases.
