### PR TITLE
Fixed #5176: centaur-tabs' gt/gT asking for more key input.

### DIFF
--- a/modules/ui/tabs/autoload.el
+++ b/modules/ui/tabs/autoload.el
@@ -4,15 +4,15 @@
 ;;;###autoload (autoload '+tabs:next-or-goto "ui/tabs/autoload" nil t)
 (evil-define-command +tabs:next-or-goto (index)
   "Switch to the next tab, or to INDEXth tab if a count is given."
-  (interactive "<C>")
-  (if current-prefix-arg
-      (centaur-tabs-select-visible-nth-tab current-prefix-arg)
+  (interactive "P")
+  (if index
+      (centaur-tabs-select-visible-nth-tab index)
     (centaur-tabs-forward)))
 
 ;;;###autoload (autoload '+tabs:previous-or-goto "ui/tabs/autoload" nil t)
 (evil-define-command +tabs:previous-or-goto (index)
   "Switch to the previous tab, or to INDEXth tab if a count is given."
-  (interactive "<C>")
-  (if current-prefix-arg
-      (centaur-tabs-select-visible-nth-tab current-prefix-arg)
+  (interactive "P")
+  (if index
+      (centaur-tabs-select-visible-nth-tab index)
     (centaur-tabs-backward)))


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [x] I've searched for similar pull requests and found nothing
  - [x] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [x] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [x] I've linked any relevant issues and PRs below
  - [x] All my commit messages are descriptive and distinct

-->

Fixes #5176  <!-- remove if not applicable -->

I changed the `+tabs:next-or-goto` and `+tabs:previous-or-goto` functions to use `(interactive "P")` so they accept the prefix as tab index. This reduce the extra key strike when you just want next ore previous, and works with a big tab index. Also the current implementation doesn't work with index(it doesn't use the index at all). 