### PR TITLE
Point FAQ to Github, not Discourse

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ kind!
 [discord]: https://discord.gg/qvGgnVx
 [discourse]: https://discourse.doomemacs.org
 [documentation]: docs/index.org
-[faq]: https://discourse.doomemacs.org/t/doom-emacs-faq/45
+[faq]: docs/faq.org
 [getting-started]: docs/getting_started.org
 [install]: docs/getting_started.org#install
 [backtrace]: docs/getting_started.org#how-to-extract-a-backtrace-from-an-error


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [ ] I've searched for similar pull requests and found nothing
  - [ ] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr (GRR, this requires Discourse also???)
  - [ ] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [x] I've linked any relevant issues and PRs below
  - [x] All my commit messages are descriptive and distinct

-->

This changes the FAQ link to a link that works for all users.

Is there a reason this currently points to Discourse which (seems to) force one to have a login to even see the content?

I tried to check the "do-not-PR" list but it has the same issue - of evidently being locked behind needing a Discourse account?