### PR TITLE
Add terraform-format-buffer to terraform-mode-map

### DIFF
--- a/modules/tools/terraform/README.org
+++ b/modules/tools/terraform/README.org
@@ -62,8 +62,9 @@ common Terraform operations (see Keybindings below).
 * Appendix
 ** Keybindings
 *** :localleader
-| key | description           |
-|-----+-----------------------|
-| =i= | Run =terraform init=  |
-| =p= | Run =terraform plan=  |
-| =a= | Run =terraform apply= |
+| key | description                   |
+|-----+-------------------------------|
+| =i= | Run =terraform init=          |
+| =f= | Run =terraform-format-buffer= |
+| =p= | Run =terraform plan=          |
+| =a= | Run =terraform apply=         |

--- a/modules/tools/terraform/config.el
+++ b/modules/tools/terraform/config.el
@@ -9,9 +9,10 @@
 
   (map! :map terraform-mode-map
         :localleader
-        :desc "terraform apply" "a" (cmd! (compile "terraform apply" t))
-        :desc "terraform init"  "i" (cmd! (compile "terraform init"))
-        :desc "terraform plan"  "p" (cmd! (compile "terraform plan"))))
+        :desc "terraform apply"         "a" (cmd! (compile "terraform apply" t))
+        :desc "terraform-format-buffer" "f" #'terraform-format-buffer
+        :desc "terraform init"          "i" (cmd! (compile "terraform init"))
+        :desc "terraform plan"          "p" (cmd! (compile "terraform plan"))))
 
 
 (use-package! company-terraform


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [x] I've searched for similar pull requests and found nothing
  - [x] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [x] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [x] I've linked any relevant issues and PRs below
  - [x] All my commit messages are descriptive and distinct

-->
I've added `terraform-format-buffer` to `terraform-mode-map` after a colleague asked why I had _settled_ for calling `terraform-format-buffer` via `SPC` + `:` each time I needed it. `SPC` + `m` + `f` ought to do nicely.

I thought maybe doing a `(cmd! (compile "terraform fmt"))` like the others in this mode-map might have been nice, but the experience of calling `terraform fmt` on the directory left me with a stale buffer. Using the function for updating only the buffer works just fine, though.
