### PR TITLE
Define sh-mode for bats files

### DIFF
--- a/modules/lang/sh/config.el
+++ b/modules/lang/sh/config.el
@@ -11,6 +11,7 @@
 ;;; Packages
 
 (use-package! sh-script ; built-in
+  :mode ("\\.bats\\'" . sh-mode)
   :mode ("\\.\\(?:zunit\\|env\\)\\'" . sh-mode)
   :mode ("/bspwmrc\\'" . sh-mode)
   :config


### PR DESCRIPTION
bats is a superset of shell script for writing automated tests exected
with TAP. sh-mode works very well with bats files.

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [x] I've searched for similar pull requests and found nothing
  - [x] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [x] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [x] I've linked any relevant issues and PRs below
  - [x] All my commit messages are descriptive and distinct

-->

This patch simply add `.bats` file suffix to sh-mode. Note that `.bats` is recommend by the bats project and used in for their own test suites.
