### PR TITLE
remove duplicate '+' from kotlin +lsp

### DIFF
--- a/docs/modules.org
+++ b/docs/modules.org
@@ -123,7 +123,7 @@ Modules that bring support for a language or group of languages to Emacs.
 + [[file:../modules/lang/javascript/README.org][javascript]] =+lsp= - JavaScript, TypeScript, and CoffeeScript support
 + [[file:../modules/lang/json/README.org][json]] =+lsp= - TODO
 + [[file:../modules/lang/julia/README.org][julia]] =+lsp= - TODO
-+ [[file:../modules/lang/kotlin/README.org][kotlin]] =+lsp+= - TODO
++ [[file:../modules/lang/kotlin/README.org][kotlin]] =+lsp= - TODO
 + [[file:../modules/lang/latex/README.org][latex]] =+latexmk +cdlatex +fold +lsp= - TODO
 + lean - TODO
 + [[file:../modules/lang/ledger/README.org][ledger]] - TODO


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] I've searched for similar pull requests and found nothing
  - [ ] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [ ] I've linked any relevant issues and PRs below
  - [ ] All my commit messages are descriptive and distinct

-->