### PR TITLE
Doc: Install Emacs 27 on Windows WSL

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -405,7 +405,7 @@ bin/doom command.
    #+BEGIN_SRC sh
    sudo add-apt-repository ppa:kelleyk/emacs
    sudo apt update
-   sudo apt install emacs26
+   sudo apt install emacs27
    #+END_SRC
 7. Then Doom's dependencies:
    #+BEGIN_SRC sh


### PR DESCRIPTION
Update the installation instructions for installing Emacs on Windows WSL from version 26 to 27, as Emacs 26 will be discontinued.