### PR TITLE
bump flycheck-kotlin to support newer ktlint

### DIFF
--- a/modules/lang/kotlin/packages.el
+++ b/modules/lang/kotlin/packages.el
@@ -4,4 +4,4 @@
 (package! kotlin-mode :pin "0e4bafb31d1fc2a0a420a521c2723d5526646c0b")
 
 (when (featurep! :checkers syntax)
-  (package! flycheck-kotlin :pin "5104ee9a3fdb7f0a0a3d3bcfd8dd3c45a9929310"))
+  (package! flycheck-kotlin :pin "bf1b398bdde128806a0a7479ebbe369bbaa40dae"))


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [x] I've searched for similar pull requests and found nothing
  - [ ] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [x] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [x] I've linked any relevant issues and PRs below
  - [x] All my commit messages are descriptive and distinct

-->

Trying to work with kotlin-ls & ktlint but the existing flycheck kotlin plugin wouldn't cooperate with the `brew install ktlint`-available ktlint (0.41.0). flycheck-kotlin had fixed it upstream, and so I've upstreamed my bump :)
