### PR TITLE
init commit - Fixed company putting snippets at bottom

### DIFF
--- a/modules/lang/dart/config.el
+++ b/modules/lang/dart/config.el
@@ -31,7 +31,7 @@
 (use-package! flutter
   :when (featurep! +flutter)
   :defer t
-  :init
+  :config
   (map! :map dart-mode-map
         :localleader
         "r" #'flutter-run-or-hot-reload))

--- a/modules/tools/lsp/+lsp.el
+++ b/modules/tools/lsp/+lsp.el
@@ -2,7 +2,7 @@
 
 (defvar +lsp-company-backends
   (if (featurep! :editor snippets)
-      '(:separate company-capf company-yasnippet)
+      '(:separate company-yasnippet company-capf)
     'company-capf)
   "The backends to prepend to `company-backends' in `lsp-mode' buffers.
 Can be a list of backends; accepts any value `company-backends' accepts.")


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x ] It targets the develop branch
  - [x ] I've searched for similar pull requests and found nothing
  - [x ] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [x ] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [x ] I've linked any relevant issues and PRs below
  - [x ] All my commit messages are descriptive and distinct

-->
[https://github.com/hlissner/doom-emacs/issues/5215](url)
Fixes #0000 <!-- remove if not applicable -->

{{{ Summarize what you've changed HERE and why }}}
Previously, using company-mode with both +lsp and snippets would cause the snippets to be put in the company list, but all the way at the bottom.  This change puts them at the top with the lsp results after.