### PR TITLE
Moved snippets above lsp in company list

### DIFF
--- a/modules/tools/lsp/+lsp.el
+++ b/modules/tools/lsp/+lsp.el
@@ -2,7 +2,7 @@
 
 (defvar +lsp-company-backends
   (if (featurep! :editor snippets)
-      '(:separate company-capf company-yasnippet)
+      '(:separate company-yasnippet company-capf)
     'company-capf)
   "The backends to prepend to `company-backends' in `lsp-mode' buffers.
 Can be a list of backends; accepts any value `company-backends' accepts.")


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] I've searched for similar pull requests and found nothing
  - [ ] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [ ] I've linked any relevant issues and PRs below
  - [ ] All my commit messages are descriptive and distinct

-->

Fixes #0000 <!-- remove if not applicable -->

{{{ Summarize what you've changed HERE and why }}}
Previously using company with both snippets and lsp would cause the lsp results to be listed first, then the snippets at the bottom.  This behavior essentially ruins the snippet integration since you could have to scroll through hundreds of entries to get to them.  This change moves them to the top of the list, similar to how VSCode displays snippets/lsp.