### PR TITLE
use format-buffer-h instead of the original format-all-buffer hook

### DIFF
--- a/modules/editor/format/config.el
+++ b/modules/editor/format/config.el
@@ -64,6 +64,7 @@ This is controlled by `+format-on-save-enabled-modes'."
 ;;   2. Applies changes via RCS patch, line by line, to protect buffer markers
 ;;      and avoid any jarring cursor+window scrolling.
 (advice-add #'format-all-buffer--with :override #'+format-buffer-a)
+(advice-add #'format-all-buffer--from-hook :override #'+format-buffer-h)
 
 ;; format-all-mode "helpfully" raises an error when it doesn't know how to
 ;; format a buffer.


### PR DESCRIPTION
The original hook for formatting on save was being called which doesn't take into account e.g. `+format-with` local variables.