### PR TITLE
don't explicitly set `projectile-completion-system`

### DIFF
--- a/modules/completion/helm/config.el
+++ b/modules/completion/helm/config.el
@@ -172,7 +172,6 @@ Can be negative.")
              helm-projectile-switch-project
              helm-projectile-switch-to-buffer)
   :init
-  (setq projectile-completion-system 'helm)
   (defvar helm-projectile-find-file-map (make-sparse-keymap))
   :config
   (set-keymap-parent helm-projectile-find-file-map helm-map))

--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -64,7 +64,6 @@ results buffer.")
         ivy-fixed-height-minibuffer t
         ivy-read-action-function #'ivy-hydra-read-action
         ivy-read-action-format-function #'ivy-read-action-format-columns
-        projectile-completion-system 'ivy
         ;; don't show recent files in switch-buffer
         ivy-use-virtual-buffers nil
         ;; ...but if that ever changes, show their full path


### PR DESCRIPTION
The default value is `'auto`, which handles the detection of the active
completion system, see the definition of `projectile-completing-read`.

-------

- [X] It targets the develop branch
- [X] I've searched for similar pull requests and found nothing
- [X] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
- [X] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
- [X] I've linked any relevant issues and PRs below
- [X] All my commit messages are descriptive and distinct