### PR TITLE
The dart config was setting the 'flutter-run-or-hot-reload' keybind w…

### DIFF
--- a/modules/lang/dart/config.el
+++ b/modules/lang/dart/config.el
@@ -31,7 +31,7 @@
 (use-package! flutter
   :when (featurep! +flutter)
   :defer t
-  :init
+  :config
   (map! :map dart-mode-map
         :localleader
         "r" #'flutter-run-or-hot-reload))

--- a/modules/lang/dart/config.el
+++ b/modules/lang/dart/config.el
@@ -32,8 +32,8 @@
   :when (featurep! +flutter)
   :defer t
   :init
-  :after dart
-  (map! :map dart-mode-map
+  (map! :after dart-mode
+        :map dart-mode-map
         :localleader
         "r" #'flutter-run-or-hot-reload))
 

--- a/modules/lang/dart/config.el
+++ b/modules/lang/dart/config.el
@@ -31,7 +31,8 @@
 (use-package! flutter
   :when (featurep! +flutter)
   :defer t
-  :config
+  :init
+  :after dart
   (map! :map dart-mode-map
         :localleader
         "r" #'flutter-run-or-hot-reload))


### PR DESCRIPTION
…ith init, so if you changed the localleader in your settings, it would stay as SPC m rather than what localleader was mapped to

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] I've searched for similar pull requests and found nothing
  - [ ] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [ ] I've linked any relevant issues and PRs below
  - [ ] All my commit messages are descriptive and distinct

-->

Fixes #0000 <!-- remove if not applicable -->

{{{ Summarize what you've changed HERE and why }}}
Previously, if you changed the localleader in you config, then the flutter-run-or-hot-reload command would stay mapped to SPC M rather than to whatever the new localleader is set to.