### PR TITLE
Prevent extra variable from being passed in macro.

### DIFF
--- a/modules/tools/pdf/config.el
+++ b/modules/tools/pdf/config.el
@@ -126,7 +126,9 @@
   (defadvice! +pdf-suppress-large-file-prompts-a (orig-fn size op-type filename &optional offer-raw)
     :around #'abort-if-file-too-large
     (unless (string-match-p "\\.pdf\\'" filename)
-      (funcall orig-fn size op-type filename offer-raw))))
+      (if offer-raw
+          (funcall orig-fn size op-type filename offer-raw)
+        (funcall orig-fn size op-type filename)))))
 
 
 (use-package! saveplace-pdf-view


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [X] It targets the develop branch
  - [X] I've searched for similar pull requests and found nothing
  - [X] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [X] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [X] I've linked any relevant issues and PRs below
  - [X] All my commit messages are descriptive and distinct

-->

There was an issue recently brought to light on reddit ([this](https://www.reddit.com/r/DoomEmacs/comments/o4b1yz/pdftools_error_after_opening_a_pdf_and_unable_to/) post) about not being able to open files after working with a PDF. I also have been running into an identical error while working with org capture wherein I could not capture anything without this error popping up.

As the error says, it comes from passing too many arguments to the function `abort-if-file-too-large` which only takes 3 arguments but is being passed an extra `nil`. To prevent this, I've changed the pdf module to only pass the 4th parameter when it is non-nil to begin with.
