### PR TITLE
Add configuration to ensure that CIDER is used for babel

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -113,6 +113,11 @@
                        '(t (:eval cider-modeline-icon))
                        'append)))))
 
+  ;; Ensure that CIDER is used for sessions in org buffers.
+  (when (featurep! :lang org)
+    (after! ob-clojure
+      (setq! org-babel-clojure-backend 'cider)))
+
   ;; The CIDER welcome message obscures error messages that the above code is
   ;; supposed to be make visible.
   (setq cider-repl-display-help-banner nil)


### PR DESCRIPTION
More than a year ago a change was added to ob-clojure that prevented
evaluating a Clojure code block without setting
`org-babel-clojure-backend`. This change sets this to a default value of
CIDER, since that is the main tool used in Doom.

Without this change, manual configuration is required to use Clojure in
org babel documents.