### PR TITLE
+lispy: avoid overriding user's key themes

### DIFF
--- a/modules/editor/lispy/config.el
+++ b/modules/editor/lispy/config.el
@@ -29,14 +29,17 @@
   :when (featurep! :editor evil)
   :hook (lispy-mode . lispyville-mode)
   :init
-  (setq lispyville-key-theme
-        '((operators normal)
-          c-w
-          (prettify insert)
-          (atom-movement t)
-          slurp/barf-lispy
-          additional
-          additional-insert))
+  ;; Use `defvar' instead of `setq' to avoid overriding user's preferences when
+  ;; reloading (re-evaluation) and `lispyville-set-key-theme' is executed
+  ;; immediately after
+  (defvar lispyville-key-theme
+    '((operators normal)
+      c-w
+      (prettify insert)
+      (atom-movement t)
+      slurp/barf-lispy
+      additional
+      additional-insert))
   :config
   (lispyville-set-key-theme)
 ;; REVIEW Delete this once https://github.com/noctuid/lispyville/pull/297 is merged


### PR DESCRIPTION
Currently when executing `doom/reload`, `lispyville-set-key-theme` is executed
immediately after `setq lispyville-key-theme ...` so users' configuration will
be overridden. Use `defvar` instead of `setq` to prevent this.