### PR TITLE
Set the lsp-ui-sideline-actions-icon to the default

### DIFF
--- a/modules/tools/lsp/+lsp.el
+++ b/modules/tools/lsp/+lsp.el
@@ -185,7 +185,7 @@ instead is more sensible."
         lsp-ui-sideline-show-hover nil
         ;; Re-enable icon scaling (it's disabled by default upstream for Emacs
         ;; 26.x compatibility; see emacs-lsp/lsp-ui#573)
-        lsp-ui-sideline-actions-icon t
+        lsp-ui-sideline-actions-icon lsp-ui-sideline-actions-icon-default
         ;; REVIEW Temporarily disabled, due to immense slowness on every
         ;;        keypress. See emacs-lsp/lsp-ui#613
         lsp-ui-doc-enable nil)


### PR DESCRIPTION
When Emacs 26.x support was in place this was originally:

```elisp
lsp-ui-sideline-actions-icon (if EMACS27+ lsp-ui-sideline-actions-icon-default)
```

But when it was removed it became:

```elisp
lsp-ui-sideline-actions-icon t
```

The docs for lsp-ui-sideline-actions-icon say:

```
Image file for actions.  It must be a png file.
```

Setting this to `t` results in lsp icons being missing from the buffer and a whole lot of these messages:

```
[lsp-ui-sideline]: Error with actions icon: (error Invalid image specification)
```

So the solution seems to me to be to set it to:

```elisp
lsp-ui-sideline-actions-icon lsp-ui-sideline-actions-icon-default
```

I've set this in my emacs and it restores the lightbulb icons on the lsp messages and the messages stop occurring.
