### PR TITLE
Fix command to show git log of current buffer file

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -325,7 +325,7 @@
         :desc "Magit blame"                "B"   #'magit-blame-addition
         :desc "Magit clone"                "C"   #'magit-clone
         :desc "Magit fetch"                "F"   #'magit-fetch
-        :desc "Magit buffer log"           "L"   #'magit-log
+        :desc "Magit buffer log"           "L"   #'magit-log-buffer-file
         :desc "Git stage file"             "S"   #'magit-stage-file
         :desc "Git unstage file"           "U"   #'magit-unstage-file
         (:prefix ("f" . "find")

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -445,7 +445,7 @@
         :desc "Magit blame"               "B"   #'magit-blame-addition
         :desc "Magit clone"               "C"   #'magit-clone
         :desc "Magit fetch"               "F"   #'magit-fetch
-        :desc "Magit buffer log"          "L"   #'magit-log
+        :desc "Magit buffer log"          "L"   #'magit-log-buffer-file
         :desc "Git stage file"            "S"   #'magit-stage-file
         :desc "Git unstage file"          "U"   #'magit-unstage-file
         (:prefix ("f" . "find")


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [x] I've searched for similar pull requests and found nothing
  - [x] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [x] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [x] I've linked any relevant issues and PRs below
  - [x] All my commit messages are descriptive and distinct

-->

Currently <kbd>SPC g L</kbd> runs `magit-log` which opens a context window for git log with an option selected that limits the log to the file open in buffer. The user then has to press <kbd>l</kbd> to actually see the log. The same result can be achieved by calling `magit-log-buffer-file` instead

