### PR TITLE
remove ripgrep dependency from ivy and helm readmes

### DIFF
--- a/modules/completion/helm/README.org
+++ b/modules/completion/helm/README.org
@@ -8,10 +8,6 @@
   - [[#module-flags][Module Flags]]
   - [[#plugins][Plugins]]
 - [[#prerequisites][Prerequisites]]
-  - [[#install][Install]]
-    - [[#macos][MacOS]]
-    - [[#arch-linux][Arch Linux]]
-    - [[#opensuse][openSUSE]]
 - [[#features][Features]]
   - [[#jump-to-navigation][Jump-to navigation]]
   - [[#project-search--replace][Project search & replace]]
@@ -58,25 +54,7 @@ Ivy is considered a first-class citizen in Doom, however it is still possible to
 + [[https://github.com/yyoncho/helm-icons][helm-icons]]* (=+icons=)
 
 * Prerequisites
-This module depends on:
-
-+ [[https://github.com/BurntSushi/ripgrep][ripgrep]] (rg)
-
-** Install
-*** MacOS
-#+BEGIN_SRC sh
-brew install ripgrep
-#+END_SRC
-
-*** Arch Linux
-#+BEGIN_SRC sh :dir /sudo::
-sudo pacman --needed --noconfirm -S ripgrep
-#+END_SRC
-
-*** openSUSE
-#+BEGIN_SRC sh :dir /sudo::
-sudo zypper install ripgrep
-#+END_SRC
+This module has no prerequisites.
 
 * Features
 Much like Ivy, Helm is a /large/ framework and as such

--- a/modules/completion/ivy/README.org
+++ b/modules/completion/ivy/README.org
@@ -9,10 +9,6 @@
   - [[#plugins][Plugins]]
   - [[#hacks][Hacks]]
 - [[#prerequisites][Prerequisites]]
-  - [[#install][Install]]
-    - [[#macos][MacOS]]
-    - [[#arch-linux][Arch Linux]]
-    - [[#opensuse][openSUSE]]
 - [[#features][Features]]
   - [[#jump-to-navigation][Jump-to navigation]]
   - [[#project-search--replace][Project search & replace]]
@@ -64,25 +60,7 @@ lighter, simpler and faster in many cases.
   command)
 
 * Prerequisites
-This module depends on:
-
-+ [[https://github.com/BurntSushi/ripgrep][ripgrep]] (rg)
-
-** Install
-*** MacOS
-#+BEGIN_SRC sh
-brew install ripgrep
-#+END_SRC
-
-*** Arch Linux
-#+BEGIN_SRC sh :dir /sudo::
-sudo pacman -S ripgrep
-#+END_SRC
-
-*** openSUSE
-#+BEGIN_SRC sh :dir /sudo::
-sudo zypper install ripgrep
-#+END_SRC
+This module has no prerequisites.
 
 * Features
 Ivy and its ilk are large plugins. Covering everything about them is outside of


### PR DESCRIPTION
Doom already has the install instructions in the broader documentation,
and since ripgrep is a dependency for doom in general these are
redundant.