### PR TITLE
Remove remaining `Emacs27+` checks

### DIFF
--- a/core/cli/doctor.el
+++ b/core/cli/doctor.el
@@ -84,14 +84,13 @@ in."
               "typically installed. If you're seeing a vanilla Emacs splash screen, this "
               "may explain why. If you use Chemacs, you may ignore this warning."))
 
-  (when EMACS27+
-    (print! (start "Checking for great Emacs features..."))
-    (unless (functionp 'json-serialize)
-      (warn! "Emacs was not built with native JSON support")
-      (explain! "Users will see a substantial performance gain by building Emacs with "
-                "jansson support (i.e. a native JSON library), particularly LSP users. "
-                "You must install a prebuilt Emacs binary with this included, or compile "
-                "Emacs with the --with-json option.")))
+  (print! (start "Checking for great Emacs features..."))
+  (unless (functionp 'json-serialize)
+    (warn! "Emacs was not built with native JSON support")
+    (explain! "Users will see a substantial performance gain by building Emacs with "
+              "jansson support (i.e. a native JSON library), particularly LSP users. "
+              "You must install a prebuilt Emacs binary with this included, or compile "
+              "Emacs with the --with-json option."))
 
   (print! (start "Checking for private config conflicts..."))
   (let ((xdg-dir (concat (or (getenv "XDG_CONFIG_HOME")

--- a/core/core.el
+++ b/core/core.el
@@ -21,7 +21,6 @@ envvar will enable this at startup.")
 (defconst doom-interactive-p (not noninteractive)
   "If non-nil, Emacs is in interactive mode.")
 
-(defconst EMACS27+   (> emacs-major-version 26))
 (defconst EMACS28+   (> emacs-major-version 27))
 (defconst IS-MAC     (eq system-type 'darwin))
 (defconst IS-LINUX   (eq system-type 'gnu/linux))
@@ -577,7 +576,7 @@ TRIGGER-HOOK is a list of quoted hooks and/or sharp-quoted functions."
              ;; because the latter is triggered too late (after the file has
              ;; opened and modes are all set up).
              (advice-add 'after-find-file :before fn '((depth . -101))))
-            ((add-hook hook fn (if EMACS27+ -101))))
+            ((add-hook hook fn -101)))
       fn)))
 
 

--- a/modules/completion/helm/config.el
+++ b/modules/completion/helm/config.el
@@ -96,10 +96,7 @@ Can be negative.")
     ;; `completion-styles', since that would be overly intrusive. E.g., it
     ;; results in `company-capf' returning far to many completion candidates.
     ;; Instead, append those styles so that they act as a fallback.
-    (add-to-list 'completion-styles
-                 (if EMACS27+
-                     (if fuzzy 'flex 'helm)
-                   (if fuzzy 'helm-flex 'helm)) t))
+    (add-to-list 'completion-styles (if fuzzy 'flex 'helm) t))
   :config
   (set-popup-rule! "^\\*helm" :vslot -100 :size 0.22 :ttl nil)
 

--- a/modules/config/default/config.el
+++ b/modules/config/default/config.el
@@ -34,10 +34,7 @@
 (after! epa
   ;; With GPG 2.1+, this forces gpg-agent to use the Emacs minibuffer to prompt
   ;; for the key passphrase.
-  (set (if EMACS27+
-           'epg-pinentry-mode
-         'epa-pinentry-mode) ; DEPRECATED `epa-pinentry-mode'
-       'loopback)
+  (set 'epg-pinentry-mode 'loopback)
   ;; Default to the first secret key available in your keyring.
   (setq-default
    epa-file-encrypt-to

--- a/modules/editor/evil/init.el
+++ b/modules/editor/evil/init.el
@@ -211,7 +211,7 @@ variable for an explanation of the defaults (in comments). See
       tar-mode
       (term term ansi-term multi-term)
       tetris
-      ,@(if EMACS27+ '(thread))
+      thread
       tide
       timer-list
       transmission
@@ -299,9 +299,8 @@ and complains if a module is loaded too early (during startup)."
       (+evil-collection-init '(process-menu simple)))
     (add-transient-hook! 'tabulated-list-mode
       (+evil-collection-init 'tabulated-list))
-    (when EMACS27+
-      (add-transient-hook! 'tab-bar-mode
-        (+evil-collection-init 'tab-bar)))
+    (add-transient-hook! 'tab-bar-mode
+      (+evil-collection-init 'tab-bar))
 
     ;; HACK Do this ourselves because evil-collection break's `eval-after-load'
     ;;      load order by loading their target plugin before applying keys. This

--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -117,18 +117,17 @@ we have to clean it up ourselves."
   ;; HACK Fixes #1929: icons break file renaming in Emacs 27+, because the icon
   ;;      is considered part of the filename, so we disable icons while we're in
   ;;      wdired-mode.
-  (when EMACS27+
-    (defvar +wdired-icons-enabled -1)
+  (defvar +wdired-icons-enabled -1)
 
-    (defadvice! +dired-disable-icons-in-wdired-mode-a (&rest _)
-      :before #'wdired-change-to-wdired-mode
-      (setq-local +wdired-icons-enabled (if all-the-icons-dired-mode 1 -1))
-      (when all-the-icons-dired-mode
-        (all-the-icons-dired-mode -1)))
+  (defadvice! +dired-disable-icons-in-wdired-mode-a (&rest _)
+    :before #'wdired-change-to-wdired-mode
+    (setq-local +wdired-icons-enabled (if all-the-icons-dired-mode 1 -1))
+    (when all-the-icons-dired-mode
+      (all-the-icons-dired-mode -1)))
 
-    (defadvice! +dired-restore-icons-after-wdired-mode-a (&rest _)
-      :after #'wdired-change-to-dired-mode
-      (all-the-icons-dired-mode +wdired-icons-enabled))))
+  (defadvice! +dired-restore-icons-after-wdired-mode-a (&rest _)
+    :after #'wdired-change-to-dired-mode
+    (all-the-icons-dired-mode +wdired-icons-enabled)))
 
 
 (use-package! dired-x

--- a/modules/tools/lookup/config.el
+++ b/modules/tools/lookup/config.el
@@ -165,13 +165,8 @@ Dictionary.app behind the scenes to get definitions.")
     :when (featurep! :completion ivy)
     :config
     (set-popup-rule! "^\\*xref\\*$" :ignore t)
-    ;; xref initialization is different in Emacs 27 - there are two different
-    ;; variables which can be set rather than just one
-    (when EMACS27+
-      (setq xref-show-definitions-function #'ivy-xref-show-defs))
-    ;; Necessary in Emacs <27. In Emacs 27 it will affect all xref-based
-    ;; commands other than xref-find-definitions too (eg project-find-regexp)
-    (setq xref-show-xrefs-function #'ivy-xref-show-xrefs)
+    (setq xref-show-definitions-function #'ivy-xref-show-defs
+          xref-show-xrefs-function       #'ivy-xref-show-xrefs)
 
     ;; HACK Fix #4386: `ivy-xref-show-xrefs' calls `fetcher' twice, which has
     ;; side effects that breaks in some cases (i.e. on `dired-do-find-regexp').

--- a/modules/ui/popup/autoload/popup.el
+++ b/modules/ui/popup/autoload/popup.el
@@ -612,18 +612,3 @@ Accepts the same arguments as `display-buffer-in-side-window'. You must set
                           (setq window--sides-shown t))
                         (window--display-buffer
                          buffer best-window 'reuse alist)))))))))
-
-
-;;
-;; Emacs backwards compatibility
-
-(unless EMACS27+
-  (defadvice! +popup--set-window-dedicated-a (window)
-    "Ensure `window--display-buffer' respects `display-buffer-mark-dedicated'.
-
-This was not so until recent Emacs 27 builds, where it causes breaking errors.
-This advice ensures backwards compatibility for Emacs <= 26 users."
-    :filter-return #'window--display-buffer
-    (when (and (windowp window) display-buffer-mark-dedicated)
-      (set-window-dedicated-p window display-buffer-mark-dedicated))
-    window))


### PR DESCRIPTION
- Remove remaining `EMACS27+` checks, since the whole codebase is
  assumed to run at version 27 or above now
- Remove `EMACS27+` definition since it's no longer needed

---

I wasn't sure if you purposely didn't remove these in the dropping 26.x support commit, or if you just missed them. Figured this was the easiest way to find out.