### PR TITLE
Bump jupyter

### DIFF
--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -54,7 +54,7 @@
 (when (featurep! +ipython) ; DEPRECATED
   (package! ob-ipython :pin "7147455230841744fb5b95dcbe03320313a77124"))
 (when (featurep! +jupyter)
-  (package! jupyter :pin "6ce8d01e3a550a3268b415bf9d9b635d4dba5940"))
+  (package! jupyter :pin "1f0612eb936d36abab0f27b09cca691e81fc6e74"))
 (when (featurep! +journal)
   (package! org-journal :pin "043bb9e26f75066dc1787cdc9265daca7a14dd4e"))
 (when (featurep! +noter)


### PR DESCRIPTION
Bump nnicandro/emacs-jupyter@6ce8d01 -> nnicandro/emacs-jupyter@1f0612e

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [x] I've searched for similar pull requests and found nothing
  - [x] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [x] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [x] I've linked any relevant issues and PRs below
  - [x] All my commit messages are descriptive and distinct

-->

Fixes: #5049

nnicandro/emacs-jupyter#320 contains a bug fix for Emacs 28 + native-comp.

- [x] Executed Org Jupyter code block w/o errors
  I got `org-babel-jupyter-session-key: Need a valid session and a kernel to form a key` at the first run, but it's an existing bug.
  See #3171.
- [x] Org + Jupyter code completion working fine
- [x] Org + Jupyter documentation lookup working fine