### PR TITLE
Conform set-irc-server! indentation to the README

### DIFF
--- a/modules/app/irc/autoload/settings.el
+++ b/modules/app/irc/autoload/settings.el
@@ -9,6 +9,7 @@ SERVER can either be a name for the network (in which case you must specify a
 :host.
 
 See `circe-network-options' for details."
+  (declare (indent 1))
   (after! circe
     (unless (plist-member plist :host)
       (plist-put! plist :host server))


### PR DESCRIPTION
The indentation of set-irc-server! in the irc module's README.org differs from set-irc-server!'s current indentation settings.