### PR TITLE
Add dap-cpptools to auto-requires of dap for rust

### DIFF
--- a/modules/tools/debugger/config.el
+++ b/modules/tools/debugger/config.el
@@ -24,7 +24,7 @@
     ((:lang php +lsp)        :after php-mode    :require dap-php)
     ((:lang python +lsp)     :after python      :require dap-python)
     ((:lang ruby +lsp)       :after ruby-mode   :require dap-ruby)
-    ((:lang rust +lsp)       :after rustic-mode :require dap-lldb)
+    ((:lang rust +lsp)       :after rustic-mode :require (dap-lldb dap-cpptools))
     ((:lang javascript +lsp)
      :after (js2-mode typescript-mode)
      :require (dap-node dap-chrome dap-firefox ,@(if IS-WINDOWS '(dap-edge)))))


### PR DESCRIPTION
dap-cpptools is, for the time being, the recommended way of setting up 
dap-mode with Rust.

The setup I ended up being able to properly reproduce is available in a small [blog post](https://gagbo.net/post/dap-mode-rust/) and had to rely on `dap-cpptools` after some research and help from Ivan
