### PR TITLE
Fix doom/help-packages to correctly print config locations

### DIFF
--- a/core/autoload/help.el
+++ b/core/autoload/help.el
@@ -594,7 +594,7 @@ If prefix arg is present, refresh the cache."
               (insert "This package is configured in the following locations:")
               (dolist (location configs)
                 (insert "\n" indent)
-                (cl-destructuring-bind (file line _match)
+                (cl-destructuring-bind (file line _match &rest)
                     (split-string location ":")
                   (doom--help-insert-button location
                                             (expand-file-name file doom-emacs-dir)


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [] It targets the develop branch
  - [] I've searched for similar pull requests and found nothing
  - [] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [] I've linked any relevant issues and PRs below
  - [] All my commit messages are descriptive and distinct

-->

Sometimes the `doom/help-packages` function encounters an error while printing the list of locations where the specified package is configured, if the line of code contains colon characters. This happens because the colon is interpreted as a separator between arguments to `cl-destructuring-bind`, thus causing a "wrong number of arguments" type of error if exactly three arguments are expected (filename, line number and line of code).

With the proposed fix, `cl-destructuring-bind` can accept an arbitrary number of arguments (three or more), thus removing the error without impacting code logic since only the first two are actually used.
