### PR TITLE
Improve multiple-cursors compatibility with evil-multiedit

### DIFF
--- a/modules/editor/multiple-cursors/config.el
+++ b/modules/editor/multiple-cursors/config.el
@@ -173,7 +173,10 @@
         (when +mc--compat-evil-prev-state
           (unwind-protect
               (cl-case +mc--compat-evil-prev-state
-                ((normal visual) (evil-force-normal-state))
+                ;; For `evil-multiedit', marked occurrences aren't saved after
+                ;; exiting mc, so we should return to normal state anyway
+                ((normal visual multiedit multiedit-insert)
+                 (evil-force-normal-state))
                 (t (message "Don't know how to handle previous state: %S"
                             +mc--compat-evil-prev-state)))
             (setq +mc--compat-evil-prev-state nil)


### PR DESCRIPTION
After exiting `multiple-cursors`, when the previous state is
multiedit{,-insert}, return to normal state.

Use case:
- Mark occurrences with evil-multiedit
- `iedit-switch-to-mc-mode` ("M-M")
- Make some edit
- "C-g" to exit `multiple-cursors`

Expected behaviour: Return to evil's normal-state
Observed behaviour before the patch: Emacs stays on emacs-state