### PR TITLE
Fix formatting ignoring buffer-local variables

### DIFF
--- a/modules/editor/format/autoload/format.el
+++ b/modules/editor/format/autoload/format.el
@@ -164,7 +164,7 @@ See `+format/buffer' for the interactive version of this function, and
                   ;; buffer as possible, in case the formatter is an elisp
                   ;; function, like `gofmt'.
                   (cl-loop for (var . val)
-                           in (cl-remove-if-not #'listp (buffer-local-variables (current-buffer)))
+                           in (cl-remove-if-not #'listp (buffer-local-variables origin-buffer))
                            ;; Making enable-multibyte-characters buffer-local
                            ;; causes an error.
                            unless (eq var 'enable-multibyte-characters)


### PR DESCRIPTION
After the fix in 78dde6efdd81e4d11a21ba87a7f9b141d274e947, buffer-local variables such as `tab-width` are ignored for formatting, because `(current-buffer)` is used within the temp buffer instead of `origin-buffer`.

For example in `sh-mode`, [`set-formatter!`](https://github.com/hlissner/doom-emacs/blob/a1c80a5dcddec2bb14cec6acaf6dd15b167a0aa1/modules/lang/sh/config.el#L20) uses `tab-width`. If `dtrt-indent` detects it as `2`, the global value `4` is used instead because variables are copied from `(current-buffer)`, which doesn't have the local variables of `origin-buffer`.
