### PR TITLE
editor/format: provide default formatter

### DIFF
--- a/modules/editor/format/config.el
+++ b/modules/editor/format/config.el
@@ -51,6 +51,8 @@ This is controlled by `+format-on-save-enabled-modes'."
 (when (featurep! +onsave)
   (add-hook 'after-change-major-mode-hook #'+format-enable-on-save-maybe-h))
 
+;; set default formatter for languages the user has not set any formatters
+(add-hook 'prog-mode-hook 'format-all-ensure-formatter)
 
 ;;
 ;;; Hacks


### PR DESCRIPTION
 Reading the documentation there is no indication that one has to set a formatter per language in order to use it. After reading the upstream's documentation I found out that one has to call  `format-all-ensure-formatter` in order to achieve set.