### PR TITLE
vertico: remove +fuzzy check in +vertico-file-search

### DIFF
--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -49,11 +49,8 @@ orderless."
                     (when (doom-region-active-p)
                       (replace-regexp-in-string
                        "[! |]" (lambda (substr)
-                                 (cond ((and (string= substr " ")
-                                             (not (featurep! +fuzzy)))
-                                        "  ")
-                                       ((string= substr "|")
-                                        "\\\\\\\\|")
+                                 (cond ((string= substr " ") "  ")
+                                       ((string= substr "|") "\\\\\\\\|")
                                        ((concat "\\\\" substr))))
                        (rxt-quote-pcre (doom-thing-at-point-or-region))))))
          (ripgrep-command (mapconcat #'identity `("rg" ,@args "." "-e ARG OPTS" ) " ")))


### PR DESCRIPTION
Doesn't do anything, it's a leftover from when the function was ported from the ivy module.


  - [X] It targets the develop branch
  - [X] I've searched for similar pull requests and found nothing
  - [X] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [X] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [X] I've linked any relevant issues and PRs below
  - [X] All my commit messages are descriptive and distinct