### PR TITLE
Add org-cite to :tools/biblio

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -85,6 +85,7 @@
 
        :tools
        ;;ansible
+       ;;biblio            ; Writes a PhD for you (citation needed)
        ;;debugger          ; FIXME stepping through code, to help you add bugs
        ;;direnv
        ;;docker

--- a/modules/tools/biblio/README.org
+++ b/modules/tools/biblio/README.org
@@ -1,0 +1,151 @@
+#+TITLE:   tools/biblio
+#+DATE:    April 11, 2020
+#+SINCE:   3.0
+#+STARTUP: inlineimages
+
+* Table of Contents :TOC_3:noexport:
+- [[#description][Description]]
+  - [[#maintainers][Maintainers]]
+  - [[#module-flags][Module Flags]]
+  - [[#plugins][Plugins]]
+- [[#prerequisites][Prerequisites]]
+  - [[#pdf-viewing][PDF viewing]]
+  - [[#bibtex-completion][Bibtex completion]]
+- [[#features][Features]]
+- [[#configuration][Configuration]]
+  - [[#org-cite][Org-cite]]
+    - [[#processor-configuration][Processor configuration]]
+    - [[#other-configuration-options][Other configuration options]]
+  - [[#path-configuration][Path configuration]]
+  - [[#templates][Templates]]
+- [[#troubleshooting][Troubleshooting]]
+
+* Description
+This module adds tools to help when working with bibliographies and citations.
+Minimal modifications have been made to the packages and the configuration
+details are listed in [[*Configuration][Configuration]] below. Some sensible defaults have been
+selected so it should be possible to use without modifications.
+
+** Maintainers
++ [[https://github.com/bdarcus][bdarcus]]
++ [[https://github.com/brianmcgillion][bmg]]
+
+** Module Flags
+This module provides no flags.
+
+** Plugins
++  [[https://github.com/tmalsburg/helm-bibtex][bibtex-completion]]
++ ~:completion vertico~
+  + [[https://github.com/bdarcus/citar][citar]]
++ ~:completion helm~
+  + [[https://github.com/tmalsburg/helm-bibtex][helm-bibtex]]
++ ~:completion ivy~
+  + [[https://github.com/tmalsburg/helm-bibtex][ivy-bibtex]]
+
+* Prerequisites
+There are no hard dependencies for this module.
+
+** PDF viewing
+An application for opening PDF files is required. By default =DocView= is used
+though it is highly recommended to enable =:tools pdf= in your personal ~init.el~
+file to enable [[https://github.com/politza/pdf-tools][pdf-tools]].
+
+** Bibtex completion
+For vertico, helm, or ivy bibtex completion you should enable =:completion vertico=, =:completion helm=, or
+=:completion ivy= respectively.
+
+* Features
+Both [[https://github.com/tmalsburg/helm-bibtex][helm-bibtex]] (includes helm-bibtex, ivy-bibtex and bibtex-completion code)
+and [[https://github.com/bdarcus/bibtex-actions][citar]] provide an extensive range of features so it is best to check their
+respective sites for a full list of features.
+
+On a high-level you can expect:
++ bibliography management
++ Notes per reference
++ citation support
++ citation lookup
++ org integration for writing literate latex (org-roam)
++ fast indexing and searching of references.
+
+To understand the interaction of these packages this [[https://www.reddit.com/r/emacs/comments/cxu0qg/emacs_org_and_bibtex_as_alternative_to_zotero_and/eyqe4vq/][reddit]] thread will explain
+the unique features and the overlapping functionality if any.
+
+In addition, this module provides support for native Org-mode citations: =org-cite=.
+
+* Configuration
+
+For all these packages it is advisable to use ~(after! package)~ in your
+~config.el~ to override any default settings and tune the packages to your
+needs.
+
+** Org-cite
+
+*** Processor configuration
+
+=Org-cite= provides rich features and flexible configuration options via its "processor" capabilities.
+
+1. /insert/ provides =org-cite-insert= integration for inserting and editing citations.
+2. /activate/ provides fontification, previews, etc.
+3. /follow/ integrates contextual citation actions with =org-open-at-point=.
+4. /export/ for different output targets.
+
+This module makes available the following processors:
+
+1. The core =oc-basic=, =oc-natbib=, =oc-biblatex=, and =oc-csl=.
+2. [[https://github.com/bdarcus/bibtex-actions][citar]] for integration with =vertico= completion.
+
+For user-interface, the module configures these processors as follows for the different completion modules:
+
+| Feature  | Vertico | Ivy      | Helm     |
+|----------+---------+----------+----------|
+| Insert   | citar   | oc-basic | oc-basic |
+| Activate | citar   | oc-basic | oc-basic |
+| Follow   | citar   | oc-basic | oc-basic |
+
+
+*** Other configuration options
+
+If you like, you can also set the =oc-csl= processor to look in a specific
+directory for your CSL styles:
+
+#+BEGIN_SRC emacs-lisp
+(setq org-cite-csl-styles-dir "~/Zotero/styles")
+#+END_SRC
+
+** Path configuration
+
+You must set the path variable for either =citar= (if using =vertico=
+completion) or =bibtex-completion= (if using =ivy= or =helm=); this module will
+in turn set the =org-cite-global-bibliography= path variable to this:
+
+#+BEGIN_src emacs-lisp
+(setq! bibtex-completion-bibliography '("/path/to/references.bib"))
+#+END_src
+
+#+BEGIN_src emacs-lisp
+(setq! citar-bibliography '("/path/to/references.bib"))
+#+END_src
+
+You may also set the respective note and library path variables as well for
+enhanced functionality:
+
+#+BEGIN_src emacs-lisp
+(setq! bibtex-completion-library-path '("/path/to/library/path/")
+       bibtex-completion-notes-path "/path/to/your/notes/")
+#+END_src
+
+#+BEGIN_src emacs-lisp
+(setq! citar-library-paths '("/path/to/library/files/")
+       citar-notes-paths '("/path/to/your/notes/"))
+#+END_src
+
+** Templates
+
+This module provides reasonable default templates for the packages. However, if
+you wish to change these refer to the respective packages for in-depth
+instructions.
+
+* Troubleshooting
+# Common issues and their solution, or places to look for help.
+
+Look to the respective package repositories.

--- a/modules/tools/biblio/config.el
+++ b/modules/tools/biblio/config.el
@@ -1,11 +1,12 @@
 ;;; tools/biblio/config.el -*- lexical-binding: t; -*-
 
 (use-package! bibtex-completion
+  :when (or (featurep! :completion ivy)
+            (featurep! :completion helm))
   :defer t
   :config
   (setq bibtex-completion-additional-search-fields '(keywords)
-        bibtex-completion-pdf-field "file"));; This tell bibtex-completion to look at the File field of the bibtex to figure out which pdf to open
-
+        bibtex-completion-pdf-field "file"));; This tells bibtex-completion to look at the File field of the bibtex to figure out which pdf to open
 
 (use-package! ivy-bibtex
   :when (featurep! :completion ivy)
@@ -14,7 +15,46 @@
   (add-to-list 'ivy-re-builders-alist '(ivy-bibtex . ivy--regex-plus)))
 
 
-(use-package! citar
-  :when (featurep! :completion vertico)
-  :after embark
-  :defer t)
+;;; Org-Cite configuration
+
+(use-package! oc
+  :after org
+  :config
+  (map! :map org-mode-map
+        :localleader
+        :desc "Insert citation" "@" #'org-cite-insert)
+  (setq org-cite-global-bibliography
+        (let ((paths
+               (cond
+                ((boundp 'citar-bibliography) citar-bibliography)
+                ((boundp 'bibtex-completion-bibliography) bibtex-completion-bibliography))))
+          ;; Always return bibliography paths as list for org-cite.
+          (if (stringp paths) (list paths) paths))
+        ;; setup export processor; default csl/citeproc-el, with biblatex for
+        ;; latex
+        org-cite-export-processors
+        '((latex biblatex)
+          (t csl))
+        org-cite-insert-processor 'citar
+        org-cite-follow-processor 'citar
+        org-cite-activate-processor 'citar
+        org-support-shift-select t))
+
+
+  ;;; Org-cite processors
+(use-package! oc-biblatex
+  :after oc)
+
+(use-package! oc-csl
+  :after oc)
+
+(use-package! oc-natbib
+  :after oc)
+
+;;;; Third-party
+
+(use-package! citar-org
+  :when (featurep! :lang org +roam2)
+  :config
+  ;; Include property drawer metadata for 'org-roam' v2.
+  (setq citar-org-note-include '(org-id org-roam-ref)))

--- a/modules/tools/biblio/packages.el
+++ b/modules/tools/biblio/packages.el
@@ -1,12 +1,13 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; tools/biblio/packages.el
 
-(package! bibtex-completion :pin "b85662081de98077f13f1a9fac03764702325d28")
 (when (featurep! :completion ivy)
-  (package! ivy-bibtex :pin "b85662081de98077f13f1a9fac03764702325d28"))
+  (package! bibtex-completion :pin "bb47f355b0da8518aa3fb516019120c14c8747c9")
+  (package! ivy-bibtex :pin "bb47f355b0da8518aa3fb516019120c14c8747c9"))
 (when (featurep! :completion helm)
-  (package! helm-bibtex :pin "b85662081de98077f13f1a9fac03764702325d28"))
+  (package! bibtex-completion :pin "bb47f355b0da8518aa3fb516019120c14c8747c9")
+  (package! helm-bibtex :pin "bb47f355b0da8518aa3fb516019120c14c8747c9"))
 (when (featurep! :completion vertico)
-  (package! citar :pin "fd33f5c4f7981036a969b5ca8aaf42380848ab32"))
+  (package! citar :pin "41ec5d4d5d625f7d784b4de20d14b7bceaf1730c"))
 
-(package! citeproc :pin "0857973409e3ef2ef0238714f2ef7ff724230d1c")
+(package! citeproc :pin "c8ff95862823cdff067e8cc9bb7f5ef537e8f1d9")

--- a/modules/tools/biblio/packages.el
+++ b/modules/tools/biblio/packages.el
@@ -8,3 +8,5 @@
   (package! helm-bibtex :pin "b85662081de98077f13f1a9fac03764702325d28"))
 (when (featurep! :completion vertico)
   (package! citar :pin "fd33f5c4f7981036a969b5ca8aaf42380848ab32"))
+
+(package! citeproc :pin "0857973409e3ef2ef0238714f2ef7ff724230d1c")


### PR DESCRIPTION
Sorry; because of the massive recent merges, and my shaky git skills, I had to redo #5212 to get the git correct. 

## Summary

This adds support for native org-mode `org-cite` citations. Specifically it:

1. configures the native `org-cite` processors
2. adds the `oc-bibtex-actions` processor for the vertico module, with "follow", "activate", and "insert" capabilities
3. ~adds and configures the new `org-ref` OC rewrite: https://github.com/jkitchin/org-ref-cite~ (removed for now because of unclear future)
3. installs [citeproc-el](https://github.com/andras-simonyi/citeproc-el), which is required for the `oc-csl` export processor, and will be needed also for forthcoming preview functionality

_Should bump org along with this_, as this depends on a recent change in org (namely that now loads oc-basic, while it didn't initially; so I removed that `use-package!` statement).

https://git.savannah.gnu.org/cgit/emacs/org-mode.git/commit/?id=745f0913fc153322f5abb11aba377415106bd97a

## Issues and Questions

### What to do with #2888?

1. Drop `org-ref` from there (can revisit in the future).
2. Merge this.
3. That can rebase on this and just focus on `org-roam-bibtex`.

On `org-ref` specifically:

It's status has evolved quite a bit over the last few months.

Its author initially published a development repo for an org-ref-cite package, which would have fit beautifully here, and which I initially added.

But since then he basically dropped that and in effect reimplemented aspects of org-cite in an incompatible syntax in org-ref v3.

In the process he removed some of the problematic dependencies and such, and it is possible to use org-cite (for citations) with org-ref (for its other functionality).

It's also possible to use org-ref for all of this, and ignore org-cite.

IMO this was a bad move from the broader org POV, and puts developers, users, and projects like Doom in an awkward situation. [An explanation](https://github.com/jkitchin/org-ref#what-about-org-cite) is included in the README, the first part I agree with, the second which I think is just personal opinion that many will not agree with.

I personally don't think we should support it and focus instead on native org citations. But others may have reasonable differences of opinion.

### Keybindings?

This is tricky. 

We need to bind **`org-cite-insert`** and **`org-open-at-point`**, as these are the two entry points for the org-cite module. 

But how, and where? 

For now, I have added a binding for `org-cite-insert`.

But `org-open-at-point` is also more general, so probably should be in more than one place. 

A biblio submenu would also be helpful given the above, and that `bibtex-actions` (for `vertico`) has multiple entry points, and a keymap to access them (which is also used by `embark`).