### PR TITLE
vertico: require embark in +vertico/embark-export-write

### DIFF
--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -109,6 +109,7 @@ If ARG (universal argument), include all files, even hidden or compressed ones."
 
 Supports exporting consult-grep to wgrep, file to wdeired, and consult-location to occur-edit"
   (interactive)
+  (require 'embark)
   (require 'wgrep)
   (pcase-let ((`(,type . ,candidates)
                (run-hook-with-args-until-success 'embark-candidate-collectors)))


### PR DESCRIPTION
needed now that embark is lazy loaded

- [X] It targets the develop branch
- [X] I've searched for similar pull requests and found nothing
- [X] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
- [X] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
- [X] I've linked any relevant issues and PRs below
- [X] All my commit messages are descriptive and distinct