### PR TITLE
editor/evil: Add gr keybinding to refresh `helpful` buffers

### DIFF
--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -494,6 +494,9 @@ directives. By default, this only recognizes C directives.")
        :v  "gR"  #'+eval:replace-region
        ;; Restore these keybinds, since the blacklisted/overwritten gr/gR will
        ;; undo them:
+       (:after helpful
+        :map helpful-mode-map
+        :n "gr" #'helpful-update)
        (:after compile
         :map (compilation-mode-map compilation-minor-mode-map)
         :n "gr" #'recompile)


### PR DESCRIPTION
I think this was just underlooked? Otherwise there's no way to sync to the latest changes in state without <kbd>M-x</kbd>ing or bindings this in your private config.