### PR TITLE
Vertico improvements: theming, bugfixes, new bindings, adaptations to upstream changes

### DIFF
--- a/modules/completion/vertico/README.org
+++ b/modules/completion/vertico/README.org
@@ -18,6 +18,7 @@
     - [[#general][General]]
     - [[#jump-to-files-buffers-or-projects][Jump to files, buffers or projects]]
     - [[#search][Search]]
+  - [[#consult-modifications][Consult modifications]]
   - [[#marginalia][Marginalia]]
   - [[#orderless-filtering][Orderless filtering]]
 - [[#configuration][Configuration]]
@@ -181,6 +182,14 @@ or the last workspace by typing =0 SPC=.
 | =SPC s p= | Search project                            |
 | =SPC s P= | Search another project                    |
 | =SPC s s= | Search the current buffer (incrementally) |
+
+** Consult modifications
+This module modifies the default keybindings used in
+~consult-completing-read-multiple~:
+| Keybind | Description                                                 |
+|---------+-------------------------------------------------------------|
+| =TAB=   | Select or deselect current candidate                        |
+| =RET=   | Enters selected candidates (also toggles current candidate) |
 
 ** Marginalia
 | Keybind | Description                     |

--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -168,6 +168,7 @@ Supports exporting consult-grep to wgrep, file to wdeired, and consult-location 
   "Jump to file under DIR (recursive).
 If INITIAL is non-nil, use as initial input."
   (interactive)
+  (require 'consult)
   (let* ((default-directory (or dir default-directory))
          (prompt-dir (consult--directory-prompt "Find" default-directory))
          (cmd (split-string-and-unquote consult-find-command " "))
@@ -181,7 +182,7 @@ If INITIAL is non-nil, use as initial input."
       :require-match t
       :initial (if initial (shell-quote-argument initial))
       :add-history (thing-at-point 'filename)
-      :category '+vertico
+      :category 'file
       :history '(:input +vertico/find-file-in--history)))))
 
 ;;;###autoload

--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -4,6 +4,10 @@
 ;;;###autoload
 (defvar orderless-match-faces)
 
+;; To prevent "Defining as dynamic an already lexical var" from +vertico/embark-preview
+;;;###autoload
+(defvar embark-quit-after-action)
+
 ;;;###autoload
 (defadvice! +vertico--company-capf--candidates-a (fn &rest args)
   "Highlight company matches correctly, and try default completion styles before
@@ -146,7 +150,7 @@ Supports exporting consult-grep to wgrep, file to wdeired, and consult-location 
   (unless (bound-and-true-p consult--preview-function)
     (save-selected-window
       (let ((embark-quit-after-action nil))
-        (embark-default-action)))))
+        (embark-dwim)))))
 
 ;;;###autoload
 (defun +vertico/next-candidate-preview (&optional n)

--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -14,6 +14,12 @@ orderless."
     (apply fn args)))
 
 ;;;###autoload
+(defadvice! +vertico--consult-recent-file-a (&rest _args)
+  "`consult-recent-file' needs to have `recentf-mode' on to work correctly"
+  :before #'consult-recent-file
+  (recentf-mode +1))
+
+;;;###autoload
 (cl-defun +vertico-file-search (&key query in all-files (recursive t) prompt args)
   "Conduct a file search using ripgrep.
 

--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -8,7 +8,7 @@
 (defadvice! +vertico--company-capf--candidates-a (fn &rest args)
   "Highlight company matches correctly, and try default completion styles before
 orderless."
-  :around 'company-capf--candidates
+  :around #'company-capf--candidates
   (let ((orderless-match-faces [completions-common-part])
         (completion-styles +vertico-company-completion-styles))
     (apply fn args)))

--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -237,3 +237,20 @@ targets."
                  (if (cdr targets) "…" "")))
        (if prefix (lookup-key keymap prefix) keymap)
        nil nil t))))
+
+;;;###autoload
+(defun +vertico/crm-select ()
+  "Enter candidate in `consult-completing-read-multiple'"
+  (interactive)
+  (let ((idx vertico--index))
+    (unless (get-text-property 0 'consult--crm-selected (nth vertico--index vertico--candidates))
+      (setq idx (1+ idx)))
+  (run-at-time 0 nil (cmd! (vertico--goto idx) (vertico--exhibit))))
+  (vertico-exit))
+
+;;;###autoload
+(defun +vertico/crm-exit ()
+  "Enter candidate in `consult-completing-read-multiple'"
+  (interactive)
+  (run-at-time 0 nil #'vertico-exit)
+  (vertico-exit))

--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -218,3 +218,22 @@ If INITIAL is non-nil, use as initial input."
     (setq buffers nil)
     (with-current-buffer (switch-to-buffer (marker-buffer mark))
       (goto-char (marker-position mark)))))
+
+;;;###autoload
+(defun +vertico/embark-which-key-indicator ()
+  "An embark indicator that displays keymaps using which-key.
+The which-key help message will show the type and value of the
+current target followed by an ellipsis if there are further
+targets."
+  (lambda (&optional keymap targets prefix)
+    (if (null keymap)
+        (kill-buffer which-key--buffer)
+      (which-key--show-keymap
+       (if (eq (caar targets) 'embark-become)
+           "Become"
+         (format "Act on %s '%s'%s"
+                 (caar targets)
+                 (embark--truncate-target (cdar targets))
+                 (if (cdr targets) "…" "")))
+       (if prefix (lookup-key keymap prefix) keymap)
+       nil nil t))))

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -173,11 +173,19 @@ overrides `completion-styles' during company completion sessions.")
   :config
   (when (featurep! +icons)
     (add-hook 'marginalia-mode-hook #'all-the-icons-completion-marginalia-setup))
+  (advice-add #'marginalia--project-root :override #'doom-project-root)
   (pushnew! marginalia-command-categories
+            '(+default/find-file-under-here. file)
+            '(doom/find-file-in-emacsd . project-file)
+            '(doom/find-file-in-other-project . project-file)
+            '(doom/find-file-in-private-config . file)
+            '(doom/describe-active-minor-mode . minor-mode)
+            '(flycheck-error-list-set-filter . builtin)
             '(persp-switch-to-buffer . buffer)
             '(projectile-find-file . project-file)
-            '(doom/describe-active-minor-mode . minor-mode)
-            '(flycheck-error-list-set-filter . builtin)))
+            '(projectile-recentf . project-file)
+            '(projectile-switch-to-buffer . buffer)
+            '(projectile-switch-project . project-file)))
 
 
 (use-package! embark-consult

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -118,7 +118,10 @@ overrides `completion-styles' during company completion sessions.")
         :category buffer
         :state    ,#'consult--buffer-state
         :items    ,(lambda () (mapcar #'buffer-name (org-buffer-list)))))
-    (add-to-list 'consult-buffer-sources '+vertico--consult-org-source 'append)))
+    (add-to-list 'consult-buffer-sources '+vertico--consult-org-source 'append))
+  (map! :map consult-crm-map
+        :desc "Select candidate" "TAB" #'+vertico/crm-select
+        :desc "Enter candidates" "RET" #'+vertico/crm-exit))
 
 
 (use-package! consult-flycheck

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -73,7 +73,7 @@ overrides `completion-styles' during company completion sessions.")
     [remap locate]                        #'consult-locate
     [remap load-theme]                    #'consult-theme
     [remap man]                           #'consult-man
-    [remap recentf-open-files]            (cmd! (recentf-mode +1) (consult-recent-file))
+    [remap recentf-open-files]            #'consult-recent-file
     [remap switch-to-buffer]              #'consult-buffer
     [remap switch-to-buffer-other-window] #'consult-buffer-other-window
     [remap switch-to-buffer-other-frame]  #'consult-buffer-other-frame

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -140,11 +140,7 @@ overrides `completion-styles' during company completion sessions.")
   :config
   (set-popup-rule! "^\\*Embark Export Grep" :size 0.35 :ttl 0 :quit nil)
 
-  (setq embark-action-indicator
-        (lambda (map _target)
-          (which-key--show-keymap "Embark" map nil nil 'no-paging)
-          #'which-key--hide-popup-ignore-command)
-        embark-become-indicator embark-action-indicator)
+  (setq embark-indicator #'+vertico/embark-which-key-indicator)
   ;; add the package! target finder before the file target finder,
   ;; so we don't get a false positive match.
   (let ((pos (or (cl-position

--- a/modules/completion/vertico/packages.el
+++ b/modules/completion/vertico/packages.el
@@ -4,22 +4,22 @@
 (package! vertico
   :recipe (:host github :repo "minad/vertico"
            :files ("*.el" "extensions/*.el"))
-  :pin "4a9029714e847832d3ecb3ae74a7049306924f2e")
+  :pin "9de6709cddc09740d23d24fb425fa3c174d0e956")
 
 (package! orderless :pin "1e84120a28525ccb47b602fc19b7afbeffbbe502")
 
-(package! consult :pin "28f9ba8bdfdb13257862a658715b6ceb96f4951e")
+(package! consult :pin "69bbd213dc8a98abe94a4f5b1920e3d689d31caa")
 (when (featurep! :checkers syntax)
   (package! consult-flycheck :pin "92b259e6a8ebe6439f67d3d7ffa44b7e64b76478"))
 
-(package! embark :pin "be03ce9ce1630b32e29cc50118d058c05696cb35")
-(package! embark-consult :pin "be03ce9ce1630b32e29cc50118d058c05696cb35")
+(package! embark :pin "1a7e6b556142216fa5f9b897bd5eca73968f3c49")
+(package! embark-consult :pin "1a7e6b556142216fa5f9b897bd5eca73968f3c49")
 
-(package! marginalia :pin "a3a8edbf25db4b1e167f1fdff6f60a065d0bf9cb")
+(package! marginalia :pin "11235445365c6ab119acabe91828e9182097ece7")
 
 (package! wgrep :pin "f9687c28bbc2e84f87a479b6ce04407bb97cfb23")
 
 (when (featurep! +icons)
   (package! all-the-icons-completion
     :recipe (:host github :repo "iyefrat/all-the-icons-completion")
-    :pin "24cdb3b42c6ca0a8926ad6958c76d7928fc559ce"))
+    :pin "d1d4b2f0dfbfa94d33fe50e8089c06601adfe674"))

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -56,7 +56,7 @@
          :desc "Jump to symbol in any workspace"     "J"   #'helm-lsp-global-workspace-symbol)
         (:when (featurep! :completion vertico)
          :desc "Jump to symbol in current workspace" "j"   #'consult-lsp-symbols
-         :desc "Jump to symbol in any workspace"     "J"   (cmd! #'consult-lsp-symbols '(4)))
+         :desc "Jump to symbol in any workspace"     "J"   (cmd!! #'consult-lsp-symbols 'all-workspaces))
         (:when (featurep! :ui treemacs +lsp)
          :desc "Errors list"                         "X"   #'lsp-treemacs-errors-list
          :desc "Incoming call hierarchy"             "y"   #'lsp-treemacs-call-hierarchy

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -118,7 +118,8 @@
              ((featurep! :completion ivy)       #'swiper)
              ((featurep! :completion helm)      #'swiper))
        :desc "Search all open buffers"      "B"
-       (cond ((featurep! :completion ivy)       #'swiper-all)
+       (cond ((featurep! :completion vertico)   (cmd!! #'consult-line-multi 'all-buffers))
+             ((featurep! :completion ivy)       #'swiper-all)
              ((featurep! :completion helm)      #'swiper-all))
        :desc "Search current directory"     "d" #'+default/search-cwd
        :desc "Search other directory"       "D" #'+default/search-other-cwd

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -708,7 +708,8 @@
              ((featurep! :completion ivy)       #'swiper)
              ((featurep! :completion helm)      #'swiper))
        :desc "Search all open buffers"      "B"
-       (cond ((featurep! :completion ivy)       #'swiper-all)
+       (cond ((featurep! :completion vertico)   (cmd!! #'consult-line-multi 'all-buffers))
+             ((featurep! :completion ivy)       #'swiper-all)
              ((featurep! :completion helm)      #'swiper-all))
        :desc "Search current directory"     "d" #'+default/search-cwd
        :desc "Search other directory"       "D" #'+default/search-other-cwd

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -386,7 +386,7 @@
          :desc "Jump to symbol in any workspace"     "J"   #'helm-lsp-global-workspace-symbol)
         (:when (featurep! :completion vertico)
          :desc "Jump to symbol in current workspace" "j"   #'consult-lsp-symbols
-         :desc "Jump to symbol in any workspace"     "J"   (cmd! #'consult-lsp-symbols '(4)))
+         :desc "Jump to symbol in any workspace"     "J"   (cmd!! #'consult-lsp-symbols 'all-workspaces))
         (:when (featurep! :ui treemacs +lsp)
          :desc "Errors list"                         "X"   #'lsp-treemacs-errors-list
          :desc "Incoming call hierarchy"             "y"   #'lsp-treemacs-call-hierarchy

--- a/modules/tools/lsp/packages.el
+++ b/modules/tools/lsp/packages.el
@@ -10,4 +10,4 @@
   (when (featurep! :completion helm)
     (package! helm-lsp :pin "c2c6974dadfac459b1a69a1217441283874cea92"))
   (when (featurep! :completion vertico)
-    (package! consult-lsp :pin "c882749e91e4de3bae17d825ac9950cc074b1595")))
+    (package! consult-lsp :pin "e8a50f2c94f40c86934ca2eaff007f9c00586272")))

--- a/modules/ui/doom/packages.el
+++ b/modules/ui/doom/packages.el
@@ -1,5 +1,5 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; ui/doom/packages.el
 
-(package! doom-themes :pin "5221b0600d9da16e0e3af332ff1fe2ef624f0af4")
+(package! doom-themes :pin "9e2680b9188ebd58c490598684bb7545ba01950d")
 (package! solaire-mode :pin "030964f7c62696c8cfb29125df6e7649d2bf9aeb")


### PR DESCRIPTION
This PR contains:
- bumps for `:completion vertico` and `:ui doom`
- teco's recent theming improvements for marginalia and orderless
- better keys for `consult-crm`
- a fix for `<leader> c j` since it used `cmd!` instead of `cmd!!`
- binding the new `consult-line-multi` to `<leader s B>` (the prefix argument makes it search all buffers, without it it just searches buffers of the current project) 
- usage of the recently introduced new embark indicator format
- add marginalia annotations to functions that don't have them
- advise the marginalia annotations for the `project-file` category to use projectile
- a bugfix for `consult-recent-file`
- bugfixes for `+vertico/find-file-in`
- replacing an obsolete embark function
cc: @tecosaur @elken @minad