### PR TITLE
 Adding new line on string on how to upgrade Emacs

### DIFF
--- a/bin/doom
+++ b/bin/doom
@@ -32,7 +32,7 @@
    (concat "Detected Emacs " emacs-version " (at " (car command-line-args) ").\n\n"
            "Doom only supports Emacs 27.1 and newer. A guide to install a newer version\n"
            "of Emacs can be found at:\n\n  "
-           (format "https://doomemacs.org/docs/getting_started.org#%s"
+           (format "https://doomemacs.org/docs/getting_started.org#%s\n"
                    (cond ((eq system-type 'darwin) "on-macos")
                          ((memq system-type '(cygwin windows-nt ms-dos)) "on-windows")
                          ("on-linux")))


### PR DESCRIPTION
The current string presented breaks the address on how to upgrade Emacs:

```
❯ doom install
Detected Emacs 26.3 (at emacs).

Doom only supports Emacs 27.1 and newer. A guide to install a newer version
of Emacs can be found at:

  https://doomemacs.org/docs/getting_started.org#on-linuxAborting...
```

Just adding a `\n` at the end of the string would solve it.