### PR TITLE
Changed editor/format lsp feature requirement from textDocument/rangeFormatting to textDocument/formatting

### DIFF
--- a/modules/editor/format/autoload/format.el
+++ b/modules/editor/format/autoload/format.el
@@ -112,7 +112,7 @@ Prompts for a formatter if universal arg is set."
          (list +format-with t))
         ((and +format-with-lsp
               (bound-and-true-p lsp-managed-mode)
-              (lsp-feature? "textDocument/rangeFormatting"))
+              (lsp-feature? "textDocument/formatting"))
          (list 'lsp nil))
         ((and +format-with-lsp
               (bound-and-true-p eglot--managed-mode)


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [x] I've searched for similar pull requests and found nothing
  - [x] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [x] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [x] I've linked any relevant issues and PRs below
  - [x] All my commit messages are descriptive and distinct

-->

A lot of lsp servers don't support `textDocument/rangeFormatting` but support `textDocument/formatting`(eg: `rust-analyzer`). The fallback formatter has some issues (like in rust-mode it won't respect the project's cargo files). I think it's better to use lsp as the default formatter as long as the lsp server support file formating. 
