### PR TITLE
vertico: add missing autoload

### DIFF
--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -93,6 +93,7 @@ If ARG (universal argument), include all files, even hidden or compressed ones."
                      (expand-file-name new-path))))))
       (call-interactively 'backward-delete-char))))
 
+;;;###autoload
 (defun +vertico--embark-target-package ()
     "Targets Doom's package! statements and returns the package name"
     (when (or (derived-mode-p 'emacs-lisp-mode) (derived-mode-p 'org-mode))


### PR DESCRIPTION
This autoload is required for `embark-act` to work when first opening an `.el` file. Otherwise we get this error:

```
Symbol’s function definition is void: +vertico--embark-target-package
```
