### PR TITLE
Allow evil users to quickly close the LSP signature buffer

### DIFF
--- a/modules/tools/lsp/+lsp.el
+++ b/modules/tools/lsp/+lsp.el
@@ -58,6 +58,13 @@ about it (it will be logged to *Messages* however).")
   ;; REVIEW Remove this once this is fixed upstream.
   (add-to-list 'lsp-client-packages 'lsp-racket)
 
+  (add-hook! 'doom-escape-hook
+    (defun +lsp-signature-stop-maybe-h ()
+      "Close the displayed `lsp-signature'."
+      (when lsp-signature-mode
+        (lsp-signature-stop)
+        t)))
+
   (set-popup-rule! "^\\*lsp-help" :size 0.35 :quit t :select t)
   (set-lookup-handlers! 'lsp-mode
     :definition #'+lsp-lookup-definition-handler


### PR DESCRIPTION
in normal state by ESC.

We should have a way to quickly escape this beside "C-g":
![image](https://user-images.githubusercontent.com/32123754/127293577-053f1b43-5c30-43dc-abd0-c5b149573c80.png)
