### PR TITLE
Fix +vertico-file-search when separator is used

### DIFF
--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -53,7 +53,7 @@ orderless."
         (pcase type
           (`separator
            (replace-regexp-in-string (regexp-quote (char-to-string separator))
-                                     (concat "\\" separator)
+                                     (concat "\\" (char-to-string separator))
                                      query t t))
           (`perl
            (when (string-match-p initial query)


### PR DESCRIPTION
instead of the Perl style.
`concat` can't operate on characters.