### PR TITLE
Fixed the keybind for fold/unfold all

### DIFF
--- a/modules/editor/fold/README.org
+++ b/modules/editor/fold/README.org
@@ -34,8 +34,8 @@ Emacs keybinds when evil +everywhere is disabled.
 | =C-c C-f C-f=          | Fold region               |
 | =C-c C-f C-u= or =C `= | Unfold region             |
 | =C-c C-f C-d=          | Delete folded region      |
-| =C-c C-a C-f=          | Refold all regions        |
-| =C-c C-a C-u=          | Unfold all regions        |
+| =C-c C-f C-a C-f=      | Fold all regions          |
+| =C-c C-f C-a C-u=      | Unfold all regions        |
 | =C-c C-a C-d=          | Delete all folded regions |
 
 * TODO Configuration


### PR DESCRIPTION
The keybinding for fold all and unfold all was wrong (was missing a C-f)

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] I've searched for similar pull requests and found nothing
  - [ ] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [ ] I've linked any relevant issues and PRs below
  - [ ] All my commit messages are descriptive and distinct

-->

Fixes #0000 <!-- remove if not applicable -->

{{{ Summarize what you've changed HERE and why }}}
