### PR TITLE
Enable rg's smart case for +vertico-file-search

### DIFF
--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -45,7 +45,7 @@ orderless."
            (string-trim
             (concat (if all-files "-uu")
                     (unless recursive "--maxdepth 1")
-                    "--null --line-buffered --color=always --max-columns=500 --no-heading --line-number"
+                    "--null --line-buffered --color=always --max-columns=500 --no-heading --line-number --smart-case"
                     " --hidden -g !.git "
                     (mapconcat #'shell-quote-argument args " ")))
            " "))


### PR DESCRIPTION
What vanilla Emacs, Ivy and Helm do by default.

It makes searching much easier & friendlier.