### PR TITLE
Update Go tool URL in README

### DIFF
--- a/modules/lang/go/README.org
+++ b/modules/lang/go/README.org
@@ -78,7 +78,7 @@ This module requires a valid ~GOPATH~, and the following Go packages:
 #+BEGIN_SRC sh
 export GOPATH=~/work/go
 
-go get -u github.com/motemen/gore/cmd/gore
+go get -u github.com/x-motemen/gore/cmd/gore
 go get -u github.com/stamblerre/gocode
 go get -u golang.org/x/tools/cmd/godoc
 go get -u golang.org/x/tools/cmd/goimports


### PR DESCRIPTION
As Gore repository has been moved we have to update URL because `go get` won't handle redirects.
