### PR TITLE
Allow mu4e to be started early

### DIFF
--- a/modules/email/mu4e/autoload/mu-lock.el
+++ b/modules/email/mu4e/autoload/mu-lock.el
@@ -35,6 +35,7 @@ If STRICT only accept an unset lock file."
 (defun +mu4e-lock-file-delete-maybe ()
   "Check `+mu4e-lock-file', and delete it if this process is responsible for it."
   (when (+mu4e-lock-available)
+    (require 'filenotify)
     (delete-file +mu4e-lock-file)
     (file-notify-rm-watch +mu4e-lock--request-watcher)))
 
@@ -49,6 +50,7 @@ Else, write to this process' PID to the lock file"
     (delete-file +mu4e-lock-request-file))
   (if (not (+mu4e-lock-available))
       (user-error "Unfortunately another Emacs is already doing stuff with Mu4e, and you can only have one at a time")
+    (require 'filenotify)
     (write-region (number-to-string (emacs-pid)) nil +mu4e-lock-file)
     (delete-file +mu4e-lock-request-file)
     (call-process "touch" nil nil nil +mu4e-lock-request-file)
@@ -63,6 +65,7 @@ Else, write to this process' PID to the lock file"
 (defvar +mu4e-lock--request-watcher nil)
 
 (defun +mu4e-lock-add-watcher ()
+  (require 'filenotify)
   (setq +mu4e-lock--file-just-deleted nil)
   (file-notify-rm-watch +mu4e-lock--file-watcher)
   (setq +mu4e-lock--file-watcher
@@ -75,6 +78,7 @@ Else, write to this process' PID to the lock file"
   (when (equal (nth 1 event) 'created)
     (when +mu4e-lock-relaxed
       (mu4e~stop)
+      (require 'filenotify)
       (file-notify-rm-watch +mu4e-lock--file-watcher)
       (message "Someone else wants to use Mu4e, releasing lock")
       (delete-file +mu4e-lock-file)

--- a/modules/email/mu4e/autoload/mu-lock.el
+++ b/modules/email/mu4e/autoload/mu-lock.el
@@ -1,4 +1,6 @@
 ;;; email/mu4e/autoload/mu-lock.el -*- lexical-binding: t; -*-
+;;;###autoload (autoload 'file-notify-rm-watch "filenotify")
+;;;###autoload (autoload 'file-notify-add-watch "filenotify")
 
 (defvar +mu4e-lock-file (expand-file-name "mu4e_lock" temporary-file-directory)
   "Location of the lock file which stores the PID of the process currenty running mu4e")
@@ -35,7 +37,6 @@ If STRICT only accept an unset lock file."
 (defun +mu4e-lock-file-delete-maybe ()
   "Check `+mu4e-lock-file', and delete it if this process is responsible for it."
   (when (+mu4e-lock-available)
-    (require 'filenotify)
     (delete-file +mu4e-lock-file)
     (file-notify-rm-watch +mu4e-lock--request-watcher)))
 
@@ -50,7 +51,6 @@ Else, write to this process' PID to the lock file"
     (delete-file +mu4e-lock-request-file))
   (if (not (+mu4e-lock-available))
       (user-error "Unfortunately another Emacs is already doing stuff with Mu4e, and you can only have one at a time")
-    (require 'filenotify)
     (write-region (number-to-string (emacs-pid)) nil +mu4e-lock-file)
     (delete-file +mu4e-lock-request-file)
     (call-process "touch" nil nil nil +mu4e-lock-request-file)
@@ -65,7 +65,6 @@ Else, write to this process' PID to the lock file"
 (defvar +mu4e-lock--request-watcher nil)
 
 (defun +mu4e-lock-add-watcher ()
-  (require 'filenotify)
   (setq +mu4e-lock--file-just-deleted nil)
   (file-notify-rm-watch +mu4e-lock--file-watcher)
   (setq +mu4e-lock--file-watcher
@@ -78,7 +77,6 @@ Else, write to this process' PID to the lock file"
   (when (equal (nth 1 event) 'created)
     (when +mu4e-lock-relaxed
       (mu4e~stop)
-      (require 'filenotify)
       (file-notify-rm-watch +mu4e-lock--file-watcher)
       (message "Someone else wants to use Mu4e, releasing lock")
       (delete-file +mu4e-lock-file)


### PR DESCRIPTION
`mu4e` complains about a missing function if loaded too early. I don't know if
there's a cleaner way to do this, but it's needed AFAICT.

  - [x] It targets the develop branch
  - [x] I've searched for similar pull requests and found nothing
  - [x] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [x] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [x] I've linked any relevant issues and PRs below
  - [x] All my commit messages are descriptive and distinct