### PR TITLE
Fix lispy `j` collision

### DIFF
--- a/modules/editor/lispy/config.el
+++ b/modules/editor/lispy/config.el
@@ -39,16 +39,6 @@
           additional-insert))
   :config
   (lispyville-set-key-theme)
-
-  (let ((lisp-family '(lisp-mode
-                       emacs-lisp-mode
-                       ielm-mode
-                       scheme-mode
-                       racket-mode
-                       hy-mode
-                       lfe-mode
-                       dune-mode
-                       clojure-mode
-                       fennel-mode)))
-    (setq evil-escape-excluded-major-modes
-          (nconc lisp-family evil-escape-excluded-major-modes))))
+  (add-hook! 'evil-escape-inhibit-functions
+    (defun +lispy-inhibit-evil-escape-fn ()
+      (and lispy-mode (evil-insert-state-p)))))

--- a/modules/editor/lispy/config.el
+++ b/modules/editor/lispy/config.el
@@ -38,4 +38,17 @@
           additional
           additional-insert))
   :config
-  (lispyville-set-key-theme))
+  (lispyville-set-key-theme)
+
+  (let ((lisp-family '(lisp-mode
+                       emacs-lisp-mode
+                       ielm-mode
+                       scheme-mode
+                       racket-mode
+                       hy-mode
+                       lfe-mode
+                       dune-mode
+                       clojure-mode
+                       fennel-mode)))
+    (setq evil-escape-excluded-major-modes
+          (nconc lisp-family evil-escape-excluded-major-modes))))


### PR DESCRIPTION
With evil mode, `j` is used for both `special-lispy-down` and `evil-escape` which is bounded to `evil-escape-key-sequence`, "jk" by default.

A demo:
https://user-images.githubusercontent.com/58051033/127784994-05af014c-b857-41c1-ad10-865f198c42c8.mp4
