### PR TITLE
Explicitly set xref handlers when eglot is enabled

### DIFF
--- a/modules/tools/lsp/+eglot.el
+++ b/modules/tools/lsp/+eglot.el
@@ -17,9 +17,11 @@
   :config
   (set-popup-rule! "^\\*eglot-help" :size 0.15 :quit t :select t)
   (set-lookup-handlers! 'eglot--managed-mode
+    :definition      #'xref-find-definitions
+    :references      #'xref-find-references
     :implementations #'eglot-find-implementation
     :type-definition #'eglot-find-typeDefinition
-    :documentation #'+eglot-lookup-documentation)
+    :documentation   #'+eglot-lookup-documentation)
 
   (add-to-list 'doom-debug-variables '(eglot-events-buffer-size . 0))
 


### PR DESCRIPTION
Otherwise major mode's handlers might take place. For
example as in go-mode

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [X] It targets the develop branch
  - [X] I've searched for similar pull requests and found nothing
  - [X] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [X] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [ ] I've linked any relevant issues and PRs below
  - [X] All my commit messages are descriptive and distincthlissner

-->

Fixes #0000 <!-- remove if not applicable -->

{{{ Summarize what you've changed HERE and why }}}
