### PR TITLE
Mu4e hotfixes

### DIFF
--- a/modules/email/mu4e/README.org
+++ b/modules/email/mu4e/README.org
@@ -260,7 +260,7 @@ If you have completely lost your install then you can use this handy command!
 
 #+BEGIN_SRC  shell
 find / -type d -iname '*mu4e*'
-# I reccomend rerouting all of the error to /dev/null
+# I recommend rerouting all of the errors to /dev/null
 find / -type d -iname '*mu4e*' 2> /dev/null
 #+END_SRC
 

--- a/modules/email/mu4e/autoload/mu-lock.el
+++ b/modules/email/mu4e/autoload/mu-lock.el
@@ -22,7 +22,7 @@
                    (insert-file-contents +mu4e-lock-file)
                    (buffer-string))))
            (process (process-attributes pid)))
-      (if (and process (string-match-p "emacs" (alist-get 'args process)))
+      (if (and process (string-match-p "[Ee]macs" (alist-get 'comm process)))
           (cons pid process)
         (delete-file +mu4e-lock-file) nil))))
 

--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -282,11 +282,11 @@ Usefull for affecting HTML export config.")
     (+mu4e-compose-org-msg-handle-toggle (/= 1 (or toggle-p 0)))
     (funcall orig-fn))
 
-  (defadvice! +mu4e-draft-open-signature-a (orig-fn compose-type &optional msg)
+  (defadvice! +mu4e-draft-open-signature-a (orig-fn &rest args)
     "Prevent `mu4e-compose-signature' from being used with `org-msg-mode'."
     :around #'mu4e-draft-open
     (let ((mu4e-compose-signature (unless org-msg-mode mu4e-compose-signature)))
-      (funcall orig-fn compose-type msg)))
+      (apply orig-fn args)))
 
   (map! :map org-msg-edit-mode-map
         "TAB" #'org-msg-tab) ; only <tab> bound by default


### PR DESCRIPTION
Let me know if you want something better, but the commits here should be pretty descriptive.
This fixes two issues that have been reported on Discord for mac and mu4e 1.6 users.

```
fix(mu4e): account for signature change in v1.6

Mu4e 1.6 changes the signature of `mu4e-draft-open'. Since we don't care
about the args replace funcall with apply to make sure it's happy no
matter how many args it expected.


fix(mu4e): improve mu-lock compatability with mac

On mac process args aren't defined, but comm is. Since comm also works
on Linux, we now check for that instead, accounting for a potential
capitalisation difference.


docs(mu4e): fix a typo (errors, plural)

Someone politely requested I add this to my PR on Discord ... why not.
```