### PR TITLE
updated lorri link

### DIFF
--- a/modules/tools/direnv/README.org
+++ b/modules/tools/direnv/README.org
@@ -68,7 +68,7 @@ Or ~nix-env -i direnv~
 
 * Troubleshooting
 ** direnv + nix is slow
-Consider augmenting direnv with [[https://github.com/target/lorri][lorri]], which will cache nix builds and speed up
+Consider augmenting direnv with [[https://github.com/nix-community/lorri][lorri]], which will cache nix builds and speed up
 direnv tremendously:
 
 #+BEGIN_SRC nix


### PR DESCRIPTION

  - [x] It targets the develop branch
  - [x] I've searched for similar pull requests and found nothing
  - [x] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [x] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [x] I've linked any relevant issues and PRs below
  - [x] All my commit messages are descriptive and distinct

The lorri repository changed locations recently. The old link that doom has merely points to the old repository that points to the new one. The new link is the current link for lorri.