### PR TITLE
docs: add how to remove emacs26 in installation guide

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -130,6 +130,12 @@ Or through snap:
 snap install emacs --classic
 #+END_SRC
 
+In some cases, you may need to delete old version of emacs and it's dependencies first, before installing emacs27:
+#+BEGIN_SRC bash
+sudo apt remove emacs
+sudo apt autoremove
+#+END_SRC
+
 ***** Other dependencies
 Then install Doom's other dependencies:
 #+BEGIN_SRC bash


### PR DESCRIPTION
In some cases, ubuntu may contain a preinstalled version of Emacs26, which cannot be simply removed with "sudo apt remove emacs", and needs additional "sudo apt autoremove" to properly uninstall emacs26. Only this will result with the command "emacs" opening other version than emacs26.

Ref https://unix.stackexchange.com/a/84488

