### PR TITLE
Bump ob-restclient pin in modules/lang/org/packages.el

### DIFF
--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -101,7 +101,7 @@
     :recipe (:host github :repo "DEADB17/ob-racket")
     :pin "d8fd51bddb019b0eb68755255f88fc800cfe03cb"))
 (when (featurep! :lang rest)
-  (package! ob-restclient :pin "0ebfc7c5ebf96d2fe1a476439831363a5a43b9b6"))
+  (package! ob-restclient :pin "bfbc4d8e8a348c140f9328542daf5d979f0993e2"))
 (when (featurep! :lang scala)
   (package! ob-ammonite :pin "39937dff395e70aff76a4224fa49cf2ec6c57cca"))
 


### PR DESCRIPTION
Bumping ob-restclient to latest since the upstream implemented a useful org-babel header argument
