### PR TITLE
Fix #4468: +org-defer-mode-in-agenda-buffers-h tries to select killed buffer

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -705,9 +705,10 @@ the user tries to visit one of these buffers they'll see a gimped, half-broken
 org buffer. To avoid that, restart `org-mode' when they're switched to so they
 can grow up to be fully-fledged org-mode buffers."
       (dolist (buffer org-agenda-new-buffers)
-        (with-current-buffer buffer
-          (add-hook 'doom-switch-buffer-hook #'+org--restart-mode-h
-                    nil 'local)))))
+        (when (buffer-live-p buffer)      ; Ensure buffer is not killed
+          (with-current-buffer buffer
+            (add-hook 'doom-switch-buffer-hook #'+org--restart-mode-h
+                      nil 'local))))))
 
   (defvar recentf-exclude)
   (defadvice! +org--optimize-backgrounded-agenda-buffers-a (fn file)


### PR DESCRIPTION
It may happen that `org-agenda-new-buffers` contains a killed buffer. Perhaps it happens for me more because I dynamically update my agenda after startup, or because I used sticky agenda. Whatever the case, I'll occasionally get into a state where `+org-defer-mode-in-agenda-buffers-h` will try to add a hook to a killed buffer. I added a check to just skip those.

The original reporter of #4468 encountered this issue when killing the agenda buffer directly instead of calling `org-agenda-quit` (`org-agenda-Quit` for sticky buffers). I am seeing this issue even though I am always calling `org-agenda-Quit` to delete the sticky buffer.

