### PR TITLE
Fix an error on mu4e-bookmarks

### DIFF
--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -91,7 +91,7 @@
 
   (plist-put (cdr (assoc :flags mu4e-header-info)) :shortname " Flags") ; default=Flgs
   (add-to-list 'mu4e-bookmarks
-               '(:name "Flagged messages" :query "flag:flagged" :key ?f) t)
+               '("flag:flagged" "Flagged messages" ?f) t)
 
   ;; TODO avoid assuming that all-the-icons is present
   (defvar +mu4e-header-colorized-faces


### PR DESCRIPTION
Hi, 

Adding 'Flagged messages' to mu4e-bookmarks with attributes results in mu4e loading failure. 
Change the line not to use attributes.

```
error in process filter: mu4e-error: [mu4e] Invalid bookmark in mu4e-bookmarks
error in process filter: [mu4e] Invalid bookmark in mu4e-bookmarks
```
