### PR TITLE
Make ibuffer-visit-buffer workspace-aware

### DIFF
--- a/modules/emacs/ibuffer/config.el
+++ b/modules/emacs/ibuffer/config.el
@@ -54,7 +54,17 @@
     (defun +ibuffer/open-for-current-workspace ()
       "Open an ibuffer window for the current workspace"
       (interactive)
-      (+ibuffer-workspace (+workspace-current-name))))
+      (+ibuffer-workspace (+workspace-current-name)))
+
+    (defun +ibuffer/visit-buffer-in-its-workspace ()
+      "Visit buffer, but switch to its workspace if it exists."
+      (interactive)
+      (if-let* ((buf (ibuffer-current-buffer t)))
+          (progn
+            (+workspaces/switch-to-buffer buf)
+            (ibuffer-visit-buffer))))
+
+    (define-key ibuffer-mode-map [remap ibuffer-visit-buffer] #'+ibuffer/visit-buffer-in-its-workspace))
 
   (when (featurep! :completion ivy)
     (defadvice! +ibuffer-use-counsel-maybe-a (_file &optional _wildcards)

--- a/modules/ui/workspaces/config.el
+++ b/modules/ui/workspaces/config.el
@@ -106,6 +106,18 @@ stored in `persp-save-dir'.")
                (setq uniquify-buffer-name-style +workspace--old-uniquify-style))
              (advice-remove #'doom-buffer-list #'+workspace-buffer-list)))))
 
+  (defun +workspaces/switch-to-buffer (buf)
+    "Switch to buffer's workspace"
+    (when (bound-and-true-p persp-mode)
+      (if-let* ((workspace-name (cl-find-if (lambda (worksp-name)
+                                               (+workspace-contains-buffer-p buf (persp-get-by-name worksp-name)))
+                                             (+workspace-list-names))))
+          (+workspace-switch workspace-name)
+        ;; REVIEW do we need this user-facing message or is defaulting to this
+        ;; behaviour enough?
+        ;; should we maybe create a new workspace?
+        (message "%s doesn't belong to any workspace" buf))))
+
   ;; Per-workspace `winner-mode' history
   (add-to-list 'window-persistent-parameters '(winner-ring . t))
 


### PR DESCRIPTION
Fixes #5061 

check if the buffer that is being visited belongs to any
existing workspace and then switch to the workspace before opening the
buffer

** 2 review items marked in code comments

Please review and suggest the best ideas and I will address and/or delete comments accordingly. 

** Performance 

I tried it locally and it worked, but I usually run <6 workspace with 10 buffers each. I am not show what kind of performance 
degradation we should expect for power-users with 10 workspace with 100 buffers in each. 

** On even if ibuffer is commented out in init.el

After testing locally, I realised that this patch works even when ibuffer customisations aren't activated as they aren't in my config
https://github.com/petr-tik/dot-doom-emacs/blob/master/init.el#L69

I understand I could move my patch from modules/ui/workspaces/config.el to the sexp here
https://github.com/hlissner/doom-emacs/blob/5b3f52f5fb98cc3af653b043d809254cebe04e6a/modules/emacs/ibuffer/config.el#L42

When I turned ibuffer on in my config, I experienced an unpleasant slowdown in ibuffer generation (i guess it's projectile running slowly on my tramp projects), so i would personally prefer to leave it where it is, but am happy to take guidance and move under ibuffer/config.el