### PR TITLE
Fix typo in emacs/undo README.md

### DIFF
--- a/modules/emacs/undo/README.org
+++ b/modules/emacs/undo/README.org
@@ -36,8 +36,8 @@ This module has no dedicated maintainers.
   history if it is available.
 + undo-tree only
   + Text properties are stripped from undo history to shrink it.
-  + Undo-tree is too chatty about saving its history files. This has be
-    "silenced". i.e. It's visible in \*Messages\*, but won't appear in your
+  + Undo-tree is too chatty about saving its history files. This has been
+    "silenced", i.e. it's visible in \*Messages\*, but won't appear in your
     minibuffer.
 + unfo-fu only
   + Doom defines =undo-fu-mode= to make it easier to add hooks/mode-local


### PR DESCRIPTION
This is a small fix for a typo found in `emacs/undo` readme.