### PR TITLE
Improve `:completion vertico`

### DIFF
--- a/modules/completion/vertico/README.org
+++ b/modules/completion/vertico/README.org
@@ -81,8 +81,6 @@ keybindings are available:
 
 | Keybind               | Description                                        |
 |-----------------------+----------------------------------------------------|
-| =C-p=                 | Go to previous candidate                           |
-| =C-n=                 | Go to next candidate                               |
 | =C-k=                 | (evil) Go to previous candidate                    |
 | =C-j=                 | (evil) Go to next candidate                        |
 | =C-M-k=               | (evil) Go to previous group                        |

--- a/modules/completion/vertico/README.org
+++ b/modules/completion/vertico/README.org
@@ -18,13 +18,14 @@
     - [[#general][General]]
     - [[#jump-to-files-buffers-or-projects][Jump to files, buffers or projects]]
     - [[#search][Search]]
-  - [[#consult-modifications][Consult modifications]]
-    - [[#async-search-commands][Async Search commands]]
+  - [[#consult][Consult]]
+    - [[#multiple-candidate-search][Multiple candidate search]]
+    - [[#async-search-commands][Async search commands]]
   - [[#marginalia][Marginalia]]
   - [[#orderless-filtering][Orderless filtering]]
 - [[#configuration][Configuration]]
   - [[#vertico][Vertico]]
-  - [[#consult][Consult]]
+  - [[#consult-1][Consult]]
   - [[#marginalia-1][Marginalia]]
   - [[#embark][Embark]]
 
@@ -60,7 +61,10 @@ like =ivy= and =helm= do. The primary packages are:
 + [[https://github.com/iyefrat/all-the-icons-completion][all-the-icons-completion]] (=+icons=)
 
 * Prerequisites
-This module has no prerequisites.
+Some of the advanced filtering features in async =consult= commands require
+=grep= and =ripgrep= to be built with support for [[https://www.pcre.org/][PCRE]] lookahead, see [[#async-search-commands][Async
+search commands]] for more information. You can check if this is true for your
+machine by running ~doom doctor~.
 
 * Features
 
@@ -188,7 +192,8 @@ or the last workspace by typing =0 SPC=.
 | =SPC s P= | Search another project                    |
 | =SPC s s= | Search the current buffer (incrementally) |
 
-** Consult modifications
+** Consult
+*** Multiple candidate search
 This module modifies the default keybindings used in
 ~consult-completing-read-multiple~:
 | Keybind | Description                                                 |
@@ -196,7 +201,7 @@ This module modifies the default keybindings used in
 | =TAB=   | Select or deselect current candidate                        |
 | =RET=   | Enters selected candidates (also toggles current candidate) |
 
-*** Async Search commands
+*** Async search commands
 Consult async commands (e.g. ~consult-ripgrep~) will have a preceding separator
 character (usually =#=) before the search input. This is known as the =perl=
 splitting style. Input typed after the separator will be fed to the async
@@ -204,6 +209,12 @@ command until you type a second seperator, afterwhich the candidate list will be
 filtered with Emacs instead (and can be filtered using =orderless=, for
 example). The specific seperator character can be changed by editing it, and
 might be different if the initial input already contains =#=.
+
+Note that grep-like async commands translate the input (between the first and
+second =#=) to an Orderless-light expression: space separated inputs are all
+matched in any order. If the grep backend does not support PCRE lookahead, it'll
+only accept 3 space separated inputs to prevent long lookup times, and further
+filtering should be done after a second =#=.
 
 For more information [[https://github.com/minad/consult#asynchronous-search][see here]].
 

--- a/modules/completion/vertico/README.org
+++ b/modules/completion/vertico/README.org
@@ -18,6 +18,7 @@
     - [[#general][General]]
     - [[#jump-to-files-buffers-or-projects][Jump to files, buffers or projects]]
     - [[#search][Search]]
+    - [[#file-path-completion][File Path Completion]]
   - [[#consult][Consult]]
     - [[#multiple-candidate-search][Multiple candidate search]]
     - [[#async-search-commands][Async search commands]]
@@ -191,6 +192,14 @@ or the last workspace by typing =0 SPC=.
 | =SPC s p= | Search project                            |
 | =SPC s P= | Search another project                    |
 | =SPC s s= | Search the current buffer (incrementally) |
+
+*** File Path Completion
+Note that Emacs allows you to switch directories with shadow paths, for example
+starting at =/foo/bar/baz=, typing =/foo/bar/baz/~/= will switch the searched
+path to the home directory. For more information see ~substitute-in-file-name~
+and ~file-name-shadow-mode~. This module will erase the "shadowed" portion of
+the path from the minibuffer, so in the previous example the path will be reset
+to =~/=.
 
 ** Consult
 *** Multiple candidate search

--- a/modules/completion/vertico/README.org
+++ b/modules/completion/vertico/README.org
@@ -19,9 +19,14 @@
     - [[#jump-to-files-buffers-or-projects][Jump to files, buffers or projects]]
     - [[#search][Search]]
   - [[#consult-modifications][Consult modifications]]
+    - [[#async-search-commands][Async Search commands]]
   - [[#marginalia][Marginalia]]
   - [[#orderless-filtering][Orderless filtering]]
 - [[#configuration][Configuration]]
+  - [[#vertico][Vertico]]
+  - [[#consult][Consult]]
+  - [[#marginalia-1][Marginalia]]
+  - [[#embark][Embark]]
 
 * Description
 This module enhances the Emacs search and completion experience, and also
@@ -191,6 +196,17 @@ This module modifies the default keybindings used in
 | =TAB=   | Select or deselect current candidate                        |
 | =RET=   | Enters selected candidates (also toggles current candidate) |
 
+*** Async Search commands
+Consult async commands (e.g. ~consult-ripgrep~) will have a preceding separator
+character (usually =#=) before the search input. This is known as the =perl=
+splitting style. Input typed after the separator will be fed to the async
+command until you type a second seperator, afterwhich the candidate list will be
+filtered with Emacs instead (and can be filtered using =orderless=, for
+example). The specific seperator character can be changed by editing it, and
+might be different if the initial input already contains =#=.
+
+For more information [[https://github.com/minad/consult#asynchronous-search][see here]].
+
 ** Marginalia
 | Keybind | Description                     |
 |---------+---------------------------------|
@@ -221,10 +237,25 @@ you can use to further specify each space separated input in the following ways:
 
 * Configuration
 If you want to further configure this module, here are some good places to start:
-
-+ Vertico provides several [[https://github.com/minad/vertico#extensions][extentions]] that can be used to extend it's interface
-+ You can add more Marginalia annotation levels and change the existing ones by
+** Vertico
+ Vertico provides several [[https://github.com/minad/vertico#extensions][extentions]] that can be used to extend it's interface
+** Consult
+Much of the behaviour of Consult commands can be changed with
+~consult-customize~. The =vertico= module already does this, if you want to
+override the module's modifications, do:
+#+begin_src emacs-lisp
+(setq consult--read-config nil)
+(consult-customize
+;...
+)
+#+end_src
+If you are changing the preview keys (set to =C-SPC=, =C-M-j=, and =C-M-k=),
+remember to change their bindings on ~vertico-map~ as well, as the bindings
+there get previews to work to an extent on non-consult commands as well.
+** Marginalia
+You can add more Marginalia annotation levels and change the existing ones by
   editing ~marginalia-annotator-registry~
-+ You can change the available commands in Embark for category ~$cat~ by editing
+** Embark
+You can change the available commands in Embark for category ~$cat~ by editing
   ~embark-$cat-map~, and even add new categories. Note that you add categories
   by defining them [[https://github.com/minad/marginalia/#adding-custom-annotators-or-classifiers][through marginalia]], and embark picks up on them.

--- a/modules/completion/vertico/README.org
+++ b/modules/completion/vertico/README.org
@@ -85,11 +85,11 @@ keybindings are available:
 | =C-n=                 | Go to next candidate                               |
 | =C-k=                 | (evil) Go to previous candidate                    |
 | =C-j=                 | (evil) Go to next candidate                        |
+| =C-M-k=               | (evil) Go to previous group                        |
+| =C-M-j=               | (evil) Go to next group                            |
 | =C-;= or =<leader> a= | Open an ~embark-act~ menu to chose a useful action |
 | =C-c C-;=             | export the current candidate list to a buffer      |
 | =C-SPC=               | Preview the current candidate                      |
-| =C-M-k=               | (evil) Go to previous candidate and preview.       |
-| =C-M-j=               | (evil) Go to next candidate and preview.           |
 
 ~embark-act~ will prompt you with a =which-key= menu with useful commands on the
 selected candidate or candidate list, depending on the completion category. Note
@@ -274,9 +274,9 @@ override the module's modifications, do:
 ;...
 )
 #+end_src
-If you are changing the preview keys (set to =C-SPC=, =C-M-j=, and =C-M-k=),
-remember to change their bindings on ~vertico-map~ as well, as the bindings
-there get previews to work to an extent on non-consult commands as well.
+If you are changing the preview key (set to =C-SPC=), remember to change the
+binding on ~vertico-map~ as well, as the binding there gets previews to work to
+an extent on non-consult commands as well.
 ** Marginalia
 You can add more Marginalia annotation levels and change the existing ones by
   editing ~marginalia-annotator-registry~

--- a/modules/completion/vertico/README.org
+++ b/modules/completion/vertico/README.org
@@ -228,12 +228,13 @@ pressing space and entering another input. In essence, when trying to match
 
 Doom has some builtin [[https://github.com/oantolin/orderless#style-dispatchers][style dispatchers]] for more finegrained filtering, which
 you can use to further specify each space separated input in the following ways:
-| Input            | Description                                |
-|------------------+--------------------------------------------|
-| =!foo=           | match without literal input =foo=          |
-| =`bar= or =bar`= | match input =bar= as an initialism         |
-| ==baz= or =baz== | match only with literal input =baz=        |
-| =~qux= or =qux~= | match input =qux= with fuzzy/flex matching |
+| Input            | Description                                  |
+|------------------+----------------------------------------------|
+| =!foo=           | match without literal input =foo=            |
+| =%foo= or =foo%= | perform ~char-fold-to-regexp~ on input =foo= |
+| =`foo= or =foo`= | match input =foo= as an initialism           |
+| ==foo= or =foo== | match only with literal input =foo=          |
+| =~foo= or =foo~= | match input =foo= with fuzzy/flex matching   |
 
 * Configuration
 If you want to further configure this module, here are some good places to start:

--- a/modules/completion/vertico/README.org
+++ b/modules/completion/vertico/README.org
@@ -223,6 +223,10 @@ For more information [[https://github.com/minad/consult#asynchronous-search][see
 |---------+---------------------------------|
 | =M-A=   | Cycle between annotation levels |
 
+Marginalia annotations for symbols (e.g. =SPC h f= and =SPC h v=) come with
+extra information the nature of the symbol. For the meaning of the annotations
+see ~marginalia--symbol-class~.
+
 ** Orderless filtering
 When using orderless to filter through candidates, the default behaviour is for
 each space separated input to match the candidate as a regular expression or

--- a/modules/completion/vertico/autoload/magit.el
+++ b/modules/completion/vertico/autoload/magit.el
@@ -1,0 +1,8 @@
+;;; completion/vertico/autoload/magit.el -*- lexical-binding: t; -*-
+;;;###if (featurep! :tools magit)
+
+;;;###autoload
+(defun +vertico/embark-magit-status (file)
+  "Run `magit-status` on repo containing the embark target."
+  (interactive "GFile: ")
+  (magit-status (locate-dominating-file file ".git")))

--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -180,7 +180,6 @@ If INITIAL is non-nil, use as initial input."
       (split-string (cdr (apply #'doom-call-process cmd)) "\n" t)
       :prompt default-directory
       :sort nil
-      :require-match t
       :initial (if initial (shell-quote-argument initial))
       :add-history (thing-at-point 'filename)
       :category 'file

--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -41,14 +41,14 @@ orderless."
   (let* ((project-root (or (doom-project-root) default-directory))
          (directory (or in project-root))
          (consult-ripgrep-args
-            (concat "rg "
-                    (if all-files "-uu ")
-                    (unless recursive "--maxdepth 1 ")
-                    "--line-buffered --color=never --max-columns=1000 "
-                    "--path-separator /   --smart-case --no-heading --line-number "
-                    "--hidden -g !.git "
-                    (mapconcat #'shell-quote-argument args " ")
-                    "."))
+          (concat "rg "
+                  (if all-files "-uu ")
+                  (unless recursive "--maxdepth 1 ")
+                  "--line-buffered --color=never --max-columns=1000 "
+                  "--path-separator /   --smart-case --no-heading --line-number "
+                  "--hidden -g !.git "
+                  (mapconcat #'shell-quote-argument args " ")
+                  "."))
          (prompt (if (stringp prompt) (string-trim prompt) "Search"))
          (query (or query
                     (when (doom-region-active-p)
@@ -257,7 +257,7 @@ targets."
   (let ((idx vertico--index))
     (unless (get-text-property 0 'consult--crm-selected (nth vertico--index vertico--candidates))
       (setq idx (1+ idx)))
-  (run-at-time 0 nil (cmd! (vertico--goto idx) (vertico--exhibit))))
+    (run-at-time 0 nil (cmd! (vertico--goto idx) (vertico--exhibit))))
   (vertico-exit))
 
 ;;;###autoload
@@ -284,10 +284,10 @@ targets."
 (defun +vertico/consult-fd (&optional dir initial)
   (interactive "P")
   (if doom-projectile-fd-binary
-  (let* ((prompt-dir (consult--directory-prompt "Fd" dir))
-         (default-directory (cdr prompt-dir)))
-    (find-file (consult--find (car prompt-dir) #'+vertico--consult--fd-builder initial)))
-  (consult-find dir initial)))
+      (let* ((prompt-dir (consult--directory-prompt "Fd" dir))
+             (default-directory (cdr prompt-dir)))
+        (find-file (consult--find (car prompt-dir) #'+vertico--consult--fd-builder initial)))
+    (consult-find dir initial)))
 
 ;;;###autoload
 (defun +vertico-embark-vertico-indicator ()

--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -233,7 +233,7 @@ If INITIAL is non-nil, use as initial input."
       (forward-line (string-to-number line)))))
 
 ;;;###autoload
-(defun +vertico/embark-which-key-indicator ()
+(defun +vertico-embark-which-key-indicator ()
   "An embark indicator that displays keymaps using which-key.
 The which-key help message will show the type and value of the
 current target followed by an ellipsis if there are further

--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -289,3 +289,14 @@ targets."
          (default-directory (cdr prompt-dir)))
     (find-file (consult--find (car prompt-dir) #'+vertico--consult--fd-builder initial)))
   (consult-find dir initial)))
+
+;;;###autoload
+(defun +vertico-embark-vertico-indicator ()
+  "An embark indicator that colorizes the vertico candidate differently on act"
+  (let ((fr face-remapping-alist))
+    (lambda (&optional keymap _targets prefix)
+      (when (bound-and-true-p vertico--input)
+        (setq-local face-remapping-alist
+                    (if keymap
+                        (cons '(vertico-current . embark-target) fr)
+                      fr))))))

--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -134,20 +134,6 @@ Supports exporting consult-grep to wgrep, file to wdeired, and consult-location 
       (let ((embark-quit-after-action nil))
         (embark-dwim)))))
 
-;;;###autoload
-(defun +vertico/next-candidate-preview (&optional n)
-  "Go forward N candidates and preivew"
-  (interactive)
-  (vertico-next (or n 1))
-  (+vertico/embark-preview))
-
-;;;###autoload
-(defun +vertico/previous-candidate-preview (&optional n)
-  "Go backward N candidates and preivew"
-  (interactive)
-  (vertico-previous (or n 1))
-  (+vertico/embark-preview))
-
 (defvar +vertico/find-file-in--history nil)
 ;;;###autoload
 (defun +vertico/find-file-in (&optional dir initial)

--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -117,8 +117,8 @@ If ARG (universal argument), include all files, even hidden or compressed ones."
   "Targets Doom's package! statements and returns the package name"
   (when (or (derived-mode-p 'emacs-lisp-mode) (derived-mode-p 'org-mode))
     (save-excursion
-      (search-backward "(")
-      (when (looking-at "(\\s-*package!\\s-*\\(\\(\\sw\\|\\s_\\)+\\)\\s-*")
+      (when (and (search-backward "(" nil t)
+                 (looking-at "(\\s-*package!\\s-*\\(\\(\\sw\\|\\s_\\)+\\)\\s-*"))
         (let ((pkg (match-string 1)))
           (set-text-properties 0 (length pkg) nil pkg)
           `(package . ,pkg))))))

--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -190,6 +190,7 @@ If INITIAL is non-nil, use as initial input."
   "Go to an entry in evil's (or better-jumper's) jumplist."
   (interactive
    (let (buffers)
+     (require 'consult)
      (unwind-protect
          (list
           (consult--read

--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -96,23 +96,6 @@ If ARG (universal argument), include all files, even hidden or compressed ones."
   (consult-line (thing-at-point 'symbol)))
 
 ;;;###autoload
-(defun +vertico/backward-updir ()
-  "Delete char before or go up directory for file cagetory vertico buffers."
-  (interactive)
-  (let ((metadata (completion-metadata (minibuffer-contents)
-                                       minibuffer-completion-table
-                                       minibuffer-completion-predicate)))
-    (if (and (eq (char-before) ?/)
-             (eq (completion-metadata-get metadata 'category) 'file))
-        (let ((new-path (minibuffer-contents)))
-          (delete-region (minibuffer-prompt-end) (point-max))
-          (insert (abbreviate-file-name
-                   (file-name-directory
-                    (directory-file-name
-                     (expand-file-name new-path))))))
-      (call-interactively 'backward-delete-char))))
-
-;;;###autoload
 (defun +vertico-embark-target-package-fn ()
   "Targets Doom's package! statements and returns the package name"
   (when (or (derived-mode-p 'emacs-lisp-mode) (derived-mode-p 'org-mode))

--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -299,3 +299,13 @@ targets."
                     (if keymap
                         (cons '(vertico-current . embark-target) fr)
                       fr))))))
+
+;;;###autoload
+(defun +vertico-basic-remote-try-completion (string table pred point)
+  (and (vertico--remote-p string)
+       (completion-basic-try-completion string table pred point)))
+
+;;;###autoload
+(defun +vertico-basic-remote-all-completions (string table pred point)
+  (and (vertico--remote-p string)
+       (completion-basic-all-completions string table pred point)))

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -105,7 +105,7 @@ overrides `completion-styles' during company completion sessions.")
             (format "%s --color=never -i -H -E .git --regex %s"
                     doom-projectile-fd-binary
                     (if IS-WINDOWS "--path-separator=/" ""))
-        consult-find-args))
+          consult-find-args))
 
   (consult-customize
    consult-ripgrep consult-git-grep consult-grep

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -53,11 +53,17 @@ overrides `completion-styles' during company completion sessions.")
      ;; Flex matching
      ((string-prefix-p "~" pattern) `(orderless-flex . ,(substring pattern 1)))
      ((string-suffix-p "~" pattern) `(orderless-flex . ,(substring pattern 0 -1)))))
+  (add-to-list
+   'completion-styles-alist
+   '(+vertico-basic-remote
+     +vertico-basic-remote-try-completion
+     +vertico-basic-remote-all-completions
+     "Use basic completion on remote files only"))
   (setq completion-styles '(orderless)
         completion-category-defaults nil
         ;; note that despite override in the name orderless can still be used in
         ;; find-file etc.
-        completion-category-overrides '((file (styles . (orderless partial-completion))))
+        completion-category-overrides '((file (styles +vertico-basic-remote orderless partial-completion)))
         orderless-style-dispatchers '(+vertico-orderless-dispatch)
         orderless-component-separator "[ &]")
   ;; ...otherwise find-file gets different highlighting than other commands

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -41,6 +41,9 @@ overrides `completion-styles' during company completion sessions.")
      ((string= "!" pattern) `(orderless-literal . ""))
      ;; Without literal
      ((string-prefix-p "!" pattern) `(orderless-without-literal . ,(substring pattern 1)))
+     ;; Character folding
+     ((string-prefix-p "%" pattern) `(char-fold-to-regexp . ,(substring pattern 1)))
+     ((string-suffix-p "%" pattern) `(char-fold-to-regexp . ,(substring pattern 0 -1)))
      ;; Initialism matching
      ((string-prefix-p "`" pattern) `(orderless-initialism . ,(substring pattern 1)))
      ((string-suffix-p "`" pattern) `(orderless-initialism . ,(substring pattern 0 -1)))

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -169,8 +169,9 @@ overrides `completion-styles' during company completion sessions.")
         (nthcdr pos embark-target-finders)))
   (setq embark-package-map (make-sparse-keymap))
   (map! (:map embark-file-map
-         :desc "Open target with sudo" "s"   #'doom/sudo-find-file
-         :desc "Open in new workspace" "TAB" #'+vertico/embark-open-in-new-workspace)
+         :desc "Open target with sudo" "s" #'doom/sudo-find-file
+         (:when (featurep! :ui workspaces)
+          :desc "Open in new workspace" "TAB" #'+vertico/embark-open-in-new-workspace))
         (:map embark-package-map
          "h" #'doom/help-packages
          "b" #'doom/bump-package

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -149,7 +149,7 @@ overrides `completion-styles' during company completion sessions.")
          :desc "Actions" "a" #'embark-act)) ; to be moved to :config default if accepted
   :config
   (set-popup-rule! "^\\*Embark Export Grep" :size 0.35 :ttl 0 :quit nil)
-  (cl-nsubstitute #'+vertico/embark-which-key-indicator #'embark-mixed-indicator embark-indicators)
+  (cl-nsubstitute #'+vertico-embark-which-key-indicator #'embark-mixed-indicator embark-indicators)
   (add-to-list 'embark-indicators #'+vertico-embark-vertico-indicator)
   ;; add the package! target finder before the file target finder,
   ;; so we don't get a false positive match.

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -91,11 +91,12 @@ overrides `completion-styles' during company completion sessions.")
         consult-async-input-throttle 0.2
         consult-async-input-debounce 0.1)
 
-  (when doom-projectile-fd-binary
-    (setq consult-find-command
-          (format "%s -i -H -E .git --regex %s ARG OPTS"
-                  doom-projectile-fd-binary
-                  (if IS-WINDOWS "--path-separator=/" ""))))
+  (setq +vertico-consult-fd-args
+        (if doom-projectile-fd-binary
+            (format "%s --color=never -i -H -E .git --regex %s"
+                    doom-projectile-fd-binary
+                    (if IS-WINDOWS "--path-separator=/" ""))
+        consult-find-args))
 
   (consult-customize
    consult-ripgrep consult-git-grep consult-grep
@@ -145,8 +146,7 @@ overrides `completion-styles' during company completion sessions.")
          :desc "Actions" "a" #'embark-act)) ; to be moved to :config default if accepted
   :config
   (set-popup-rule! "^\\*Embark Export Grep" :size 0.35 :ttl 0 :quit nil)
-
-  (setq embark-indicator #'+vertico/embark-which-key-indicator)
+  (cl-nsubstitute #'+vertico/embark-which-key-indicator #'embark-mixed-indicator embark-indicators)
   ;; add the package! target finder before the file target finder,
   ;; so we don't get a false positive match.
   (let ((pos (or (cl-position

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -167,18 +167,19 @@ overrides `completion-styles' during company completion sessions.")
         cons
         '+vertico-embark-target-package-fn
         (nthcdr pos embark-target-finders)))
-  (setq embark-package-map (make-sparse-keymap))
+  (embark-define-keymap +vertico/embark-doom-package-map
+    "Keymap for Embark package actions for packages installed by Doom."
+    ("h" doom/help-packages)
+    ("b" doom/bump-package)
+    ("c" doom/help-package-config)
+    ("u" doom/help-package-homepage))
+  (setf (alist-get 'package embark-keymap-alist) #'+vertico/embark-doom-package-map)
   (map! (:map embark-file-map
          :desc "Open target with sudo" "s" #'doom/sudo-find-file
          (:when (featurep! :tools magit)
           :desc "Open magit-status of target" "g"   #'+vertico/embark-magit-status)
          (:when (featurep! :ui workspaces)
-          :desc "Open in new workspace" "TAB" #'+vertico/embark-open-in-new-workspace))
-        (:map embark-package-map
-         "h" #'doom/help-packages
-         "b" #'doom/bump-package
-         "c" #'doom/help-package-config
-         "u" #'doom/help-package-homepage)))
+          :desc "Open in new workspace" "TAB" #'+vertico/embark-open-in-new-workspace))))
 
 
 (use-package! marginalia

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -147,6 +147,7 @@ overrides `completion-styles' during company completion sessions.")
   :config
   (set-popup-rule! "^\\*Embark Export Grep" :size 0.35 :ttl 0 :quit nil)
   (cl-nsubstitute #'+vertico/embark-which-key-indicator #'embark-mixed-indicator embark-indicators)
+  (add-to-list 'embark-indicators #'+vertico-embark-vertico-indicator)
   ;; add the package! target finder before the file target finder,
   ;; so we don't get a false positive match.
   (let ((pos (or (cl-position

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -170,6 +170,8 @@ overrides `completion-styles' during company completion sessions.")
   (setq embark-package-map (make-sparse-keymap))
   (map! (:map embark-file-map
          :desc "Open target with sudo" "s" #'doom/sudo-find-file
+         (:when (featurep! :tools magit)
+          :desc "Open magit-status of target" "g"   #'+vertico/embark-magit-status)
          (:when (featurep! :ui workspaces)
           :desc "Open in new workspace" "TAB" #'+vertico/embark-open-in-new-workspace))
         (:map embark-package-map

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -82,7 +82,6 @@ overrides `completion-styles' during company completion sessions.")
     [remap persp-switch-to-buffer]        #'+vertico/switch-workspace-buffer)
   (advice-add #'completing-read-multiple :override #'consult-completing-read-multiple)
   (advice-add #'multi-occur :override #'consult-multi-occur)
-  (setq prefix-help-command #'embark-prefix-help-command)
   :config
   (setq consult-project-root-function #'doom-project-root
         consult-narrow-key "<"
@@ -134,6 +133,8 @@ overrides `completion-styles' during company completion sessions.")
 (use-package! embark
   :defer t
   :init
+  (setq which-key-use-C-h-commands nil
+        prefix-help-command #'embark-prefix-help-command)
   (map! [remap describe-bindings] #'embark-bindings
         "C-;"               #'embark-act  ; to be moved to :config default if accepted
         (:map minibuffer-local-map

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -7,6 +7,8 @@ The completion/vertico module uses the orderless completion style by default,
 but this returns too broad a candidate set for company completion. This variable
 overrides `completion-styles' during company completion sessions.")
 
+(defvar +vertico-consult-fd-args nil
+  "Shell command and arguments the vertico module uses for fd.")
 
 ;;
 ;;; Packages
@@ -99,13 +101,13 @@ overrides `completion-styles' during company completion sessions.")
         consult-async-refresh-delay  0.15
         consult-async-input-throttle 0.2
         consult-async-input-debounce 0.1)
-
-  (setq +vertico-consult-fd-args
-        (if doom-projectile-fd-binary
-            (format "%s --color=never -i -H -E .git --regex %s"
-                    doom-projectile-fd-binary
-                    (if IS-WINDOWS "--path-separator=/" ""))
-          consult-find-args))
+  (unless +vertico-consult-fd-args
+    (setq +vertico-consult-fd-args
+          (if doom-projectile-fd-binary
+              (format "%s --color=never -i -H -E .git --regex %s"
+                      doom-projectile-fd-binary
+                      (if IS-WINDOWS "--path-separator=/" ""))
+            consult-find-args)))
 
   (consult-customize
    consult-ripgrep consult-git-grep consult-grep

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -26,7 +26,7 @@ overrides `completion-styles' during company completion sessions.")
   ;; Cleans up path when moving directories with shadowed paths syntax, e.g.
   ;; cleans ~/foo/bar/// to /, and ~/foo/bar/~/ to ~/.
   (add-hook 'rfn-eshadow-update-overlay-hook #'vertico-directory-tidy)
-  (map! :map vertico-map [backspace] #'+vertico/backward-updir))
+  (map! :map vertico-map [backspace] #'vertico-directory-delete-char))
 
 
 (use-package! orderless

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -117,12 +117,10 @@ overrides `completion-styles' during company completion sessions.")
    +default/search-cwd +default/search-other-cwd
    +default/search-notes-for-symbol-at-point
    consult--source-file consult--source-project-file consult--source-bookmark
-   :preview-key (list (kbd "C-SPC") (kbd "C-M-j") (kbd "C-M-k")))
+   :preview-key (kbd "C-SPC"))
   (consult-customize
    consult-theme
-   :preview-key
-   (list (kbd "C-SPC") (kbd "C-M-j") (kbd "C-M-k")
-         :debounce 0.5 'any))
+   :preview-key (list (kbd "C-SPC") :debounce 0.5 'any))
   (after! org
     (defvar +vertico--consult-org-source
       `(:name     "Org"

--- a/modules/completion/vertico/doctor.el
+++ b/modules/completion/vertico/doctor.el
@@ -1,0 +1,11 @@
+;;; completion/vertico/doctor.el -*- lexical-binding: t; -*-
+
+(require 'consult)
+
+(unless (consult--grep-lookahead-p "grep" "-P")
+  (warn! "The installed grep binary was not built with support for PCRE lookaheads.
+  Some advanced consult filtering features will not work as a result, see the module readme."))
+
+(unless (consult--grep-lookahead-p "rg" "-P")
+  (warn! "The installed ripgrep binary was not built with support for PCRE lookaheads.
+  Some advanced consult filtering features will not work as a result, see the module readme."))

--- a/modules/completion/vertico/packages.el
+++ b/modules/completion/vertico/packages.el
@@ -20,6 +20,4 @@
 (package! wgrep :pin "f9687c28bbc2e84f87a479b6ce04407bb97cfb23")
 
 (when (featurep! +icons)
-  (package! all-the-icons-completion
-    :recipe (:host github :repo "iyefrat/all-the-icons-completion")
-    :pin "96500418541b7376cd0b3e4583b9509c0dd92b27"))
+  (package! all-the-icons-completion :pin "96500418541b7376cd0b3e4583b9509c0dd92b27"))

--- a/modules/completion/vertico/packages.el
+++ b/modules/completion/vertico/packages.el
@@ -6,16 +6,16 @@
            :files ("*.el" "extensions/*.el"))
   :pin "81a4b35f8d11dfad56de1727ee9bdd3b4461d07c")
 
-(package! orderless :pin "1a7011ac9c476dbb083c5ead88462a5f520ef8aa")
+(package! orderless :pin "62f71c34baca0b7d0adeab4a1c07d85ffcee80d9")
 
-(package! consult :pin "105a1ac50169382368a36ed53d7af908d02ffa07")
+(package! consult :pin "a07ca383318cdce6935a370f1d17687ba9f225c3")
 (when (featurep! :checkers syntax)
   (package! consult-flycheck :pin "92b259e6a8ebe6439f67d3d7ffa44b7e64b76478"))
 
-(package! embark :pin "19145d5a3367038f0a9a114b7387c8a896037aec")
-(package! embark-consult :pin "19145d5a3367038f0a9a114b7387c8a896037aec")
+(package! embark :pin "3a90a3e3c6cd035503d0c9de5c22875028e6da00")
+(package! embark-consult :pin "3a90a3e3c6cd035503d0c9de5c22875028e6da00")
 
-(package! marginalia :pin "c6ca58bea819c3b5e4b3295ad693c5cd0ae5db31")
+(package! marginalia :pin "cb1d3ba604dda17d8d44e7355ad76a1651830a30")
 
 (package! wgrep :pin "f9687c28bbc2e84f87a479b6ce04407bb97cfb23")
 

--- a/modules/completion/vertico/packages.el
+++ b/modules/completion/vertico/packages.el
@@ -4,22 +4,22 @@
 (package! vertico
   :recipe (:host github :repo "minad/vertico"
            :files ("*.el" "extensions/*.el"))
-  :pin "9de6709cddc09740d23d24fb425fa3c174d0e956")
+  :pin "81a4b35f8d11dfad56de1727ee9bdd3b4461d07c")
 
-(package! orderless :pin "1e84120a28525ccb47b602fc19b7afbeffbbe502")
+(package! orderless :pin "1a7011ac9c476dbb083c5ead88462a5f520ef8aa")
 
-(package! consult :pin "69bbd213dc8a98abe94a4f5b1920e3d689d31caa")
+(package! consult :pin "105a1ac50169382368a36ed53d7af908d02ffa07")
 (when (featurep! :checkers syntax)
   (package! consult-flycheck :pin "92b259e6a8ebe6439f67d3d7ffa44b7e64b76478"))
 
-(package! embark :pin "1a7e6b556142216fa5f9b897bd5eca73968f3c49")
-(package! embark-consult :pin "1a7e6b556142216fa5f9b897bd5eca73968f3c49")
+(package! embark :pin "19145d5a3367038f0a9a114b7387c8a896037aec")
+(package! embark-consult :pin "19145d5a3367038f0a9a114b7387c8a896037aec")
 
-(package! marginalia :pin "11235445365c6ab119acabe91828e9182097ece7")
+(package! marginalia :pin "c6ca58bea819c3b5e4b3295ad693c5cd0ae5db31")
 
 (package! wgrep :pin "f9687c28bbc2e84f87a479b6ce04407bb97cfb23")
 
 (when (featurep! +icons)
   (package! all-the-icons-completion
     :recipe (:host github :repo "iyefrat/all-the-icons-completion")
-    :pin "d1d4b2f0dfbfa94d33fe50e8089c06601adfe674"))
+    :pin "96500418541b7376cd0b3e4583b9509c0dd92b27"))

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -64,7 +64,9 @@
        (:when (featurep! :tools lsp +eglot)
         :desc "LSP Execute code action"              "a" #'eglot-code-actions
         :desc "LSP Rename"                           "r" #'eglot-rename
-        :desc "LSP Find declaration"                 "j" #'eglot-find-declaration))
+        :desc "LSP Find declaration"                 "j" #'eglot-find-declaration
+        (:when (featurep! :completion vertico)
+         :desc "Jump to symbol in current workspace" "j" #'consult-eglot-symbols)))
 
       ;;; <leader> f --- file
       (:prefix-map ("f" . "file")

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -40,9 +40,7 @@
        :desc "Find type definition"                  "t"   #'+lookup/type-definition
        :desc "Delete trailing whitespace"            "w"   #'delete-trailing-whitespace
        :desc "Delete trailing newlines"              "W"   #'doom/delete-trailing-newlines
-       :desc "List errors"                           "x"   #'flymake-show-diagnostics-buffer
-       (:when (featurep! :checkers syntax)
-        :desc "List errors"                         "x"   #'flycheck-list-errors)
+       :desc "List errors"                           "x"   #'+default/diagnostics
        (:when (and (featurep! :tools lsp) (not (featurep! :tools lsp +eglot)))
         :desc "LSP Code actions"                      "a"   #'lsp-execute-code-action
         :desc "LSP Organize imports"                  "o"   #'lsp-organize-imports

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -412,9 +412,7 @@
        :desc "Find type definition"                  "t"   #'+lookup/type-definition
        :desc "Delete trailing whitespace"            "w"   #'delete-trailing-whitespace
        :desc "Delete trailing newlines"              "W"   #'doom/delete-trailing-newlines
-       :desc "List errors"                           "x"   #'flymake-show-diagnostics-buffer
-       (:when (featurep! :checkers syntax)
-        :desc "List errors"                         "x"   #'flycheck-list-errors))
+       :desc "List errors"                           "x"   #'+default/diagnostics)
 
       ;;; <leader> f --- file
       (:prefix-map ("f" . "file")

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -398,7 +398,9 @@
        (:when (featurep! :tools lsp +eglot)
         :desc "LSP Execute code action" "a" #'eglot-code-actions
         :desc "LSP Rename" "r" #'eglot-rename
-        :desc "LSP Find declaration" "j" #'eglot-find-declaration)
+        :desc "LSP Find declaration"                 "j"   #'eglot-find-declaration
+        (:when (featurep! :completion vertico)
+         :desc "Jump to symbol in current workspace" "j"   #'consult-eglot-symbols))
        :desc "Compile"                               "c"   #'compile
        :desc "Recompile"                             "C"   #'recompile
        :desc "Jump to definition"                    "d"   #'+lookup/definition

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -209,11 +209,9 @@
          "M-RET" #'vertico-exit-input
          "C-SPC" #'+vertico/embark-preview
          "C-j"   #'vertico-next
-         "C-M-j" #'+vertico/next-candidate-preview
-         "C-S-j" #'vertico-next-group
+         "C-M-j" #'vertico-next-group
          "C-k"   #'vertico-previous
-         "C-M-k" #'+vertico/previous-candidate-preview
-         "C-S-k" #'vertico-previous-group)))
+         "C-M-k" #'vertico-previous-group)))
 
 
 ;;; :ui

--- a/modules/config/default/autoload/default.el
+++ b/modules/config/default/autoload/default.el
@@ -44,3 +44,22 @@ If ARG (universal argument), runs `compile' from the current directory."
   (while (server-running-p)
     (sleep-for 1))
   (server-start))
+
+;;;###autoload
+(defun +default/diagnostics (&rest arg)
+  "List diagnostics for the current buffer/project.
+If the the vertico and lsp modules are active, list lsp diagnostics for the
+current project. Otherwise list them for the current buffer"
+  (interactive)
+  (cond ((and (featurep! :completion vertico)
+              (featurep! :tools lsp)
+              (bound-and-true-p lsp-mode))
+         (consult-lsp-diagnostics arg))
+        ((and (featurep! :checkers syntax)
+              (bound-and-true-p flycheck-mode))
+         (flycheck-list-errors))
+        ((bound-and-true-p flymake-mode)
+         (flymake-show-diagnostics-buffer))
+        (t
+         (user-error "No diagnostics backend detected. Enable flycheck or \
+flymake, or set up lsp-mode if applicable (see :lang lsp)"))))

--- a/modules/editor/evil/+commands.el
+++ b/modules/editor/evil/+commands.el
@@ -78,7 +78,7 @@
 (evil-ex-define-cmd "make"        #'+evil:make)
 (evil-ex-define-cmd "mk"          #'+evil:make) ; convenience alias
 (evil-ex-define-cmd "debug"       #'+debugger/start)
-(evil-ex-define-cmd "er[rors]"    #'flycheck-list-errors)
+(evil-ex-define-cmd "er[rors]"    #'+default/diagnostics)
 
 ;;; File operations
 (evil-ex-define-cmd "cp"          #'+evil:copy-this-file)

--- a/modules/email/notmuch/packages.el
+++ b/modules/email/notmuch/packages.el
@@ -9,4 +9,4 @@
 (when (featurep! :completion helm)
   (package! helm-notmuch :pin "97a01497e079a7b6505987e9feba6b603bbec288"))
 (when (featurep! :completion vertico)
-  (package! consult-notmuch :pin "67cf219fcce211237347a783ce6982402341d5fd"))
+  (package! consult-notmuch :pin "a5133b9e1f19b6d51e51dd5c5e3a4f236ca29b57"))

--- a/modules/tools/lsp/+eglot.el
+++ b/modules/tools/lsp/+eglot.el
@@ -48,3 +48,10 @@ server getting expensively restarted when reverting buffers."
                           (+lsp-optimization-mode -1))))
                 server)))
       (funcall fn server))))
+
+
+(use-package! consult-eglot
+  :defer t
+  :when (featurep! :completion vertico)
+  :init
+  (map! :map eglot-mode-map [remap xref-find-apropos] #'consult-eglot-symbols))

--- a/modules/tools/lsp/+lsp.el
+++ b/modules/tools/lsp/+lsp.el
@@ -216,3 +216,10 @@ instead is more sensible."
 (use-package! lsp-ivy
   :when (featurep! :completion ivy)
   :commands lsp-ivy-workspace-symbol lsp-ivy-global-workspace-symbol)
+
+
+(use-package! consult-lsp
+  :defer t
+  :when (featurep! :completion vertico)
+  :init
+  (map! :map lsp-mode-map [remap xref-find-apropos] #'consult-lsp-symbols))

--- a/modules/tools/lsp/packages.el
+++ b/modules/tools/lsp/packages.el
@@ -2,7 +2,10 @@
 ;;; tools/lsp/packages.el
 
 (if (featurep! +eglot)
-    (package! eglot :pin "c17bdf6c98d6bf0f1a85f1175556e1038654402f")
+    (progn
+      (package! eglot :pin "c17bdf6c98d6bf0f1a85f1175556e1038654402f")
+      (when (featurep! :completion vertico)
+        (package! consult-eglot :pin "a6aeb6fa078cc7ea6537793868f606b55ac63088")))
   (package! lsp-mode :pin "82fa7743602e9a6366ecd128efcd620ecc97fcf4")
   (package! lsp-ui :pin "b625f3cb5e88559ab99bec58f7a14272edb296bc")
   (when (featurep! :completion ivy)


### PR DESCRIPTION
- Fix a minor issue with the new prefix-help-command settings
- add more thorough explanations to the readme
- Bump the module, and adapt to upstream changes
- update `all-the-icons-completion`'s recipe as it got accepted to melpa
- highlight vertico candidate on embark-act
- explain in the readme how the consult async regexp checks work, and add doctor checks for pcre support in grep and ripgrep
- fix `+vertico/find-file-in`not creating new files
- fix `consult-notmuch` bug (#5369)
- remap `xref-find-apropos` to `consult-lsp-symbols`
- unify error listing under `+default/diagnostics` and use `consult-lsp-diagnostics` if applicable
  (sidenote - should the which key listing still be `List Errors`? `List Diagnostics` is more correct, but less obvious in meanings also might require the change of the `:er[ror]` ex command)
- try basic completion style first when completing for remotes (adapts #5313)
- explain symbol annotations in readme
- feature gate embark action that opens file in new workspace
- add magit status embark action
- some whitespace fixes
- `+vertico/jump-list` fix
- embark package target finder and keymap fixes
- file path completion fixes and docs improvements
- consult-eglot support

Note that the second commit closes #5291, since it was deemed to probably be best solved in a readme explanation. This might also be a good time to decide if you want to keep `C-M-j` and `C-M-k` around as move+preview keys, since we're on the subject (If we end up keeping them around, it might be a good idea to add `C-M-n` and `C-M-p` as well. I think I had a reason for not doing this but I don't remember what it was).