### PR TITLE
fix(lsp): support +pyright with eglot

### DIFF
--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -327,3 +327,8 @@
   (use-package! lsp-pyright
     :when (featurep! +pyright)
     :after lsp-mode))
+
+(eval-when! (and (featurep! +pyright)
+                 (featurep! :tools lsp +eglot))
+  (after! eglot
+    (add-to-list 'eglot-server-programs '(python-mode . ("pyright-langserver" "--stdio")))))


### PR DESCRIPTION
eglot does not work out-of-the-box with pyright, so I add the five lines