### PR TITLE
Add clojure gitignore template

### DIFF
--- a/modules/editor/file-templates/templates/gitignore-mode/__
+++ b/modules/editor/file-templates/templates/gitignore-mode/__
@@ -3,7 +3,7 @@
 *.log
 tmp/
 
-`(let ((type-ignore (yas-choose-value '("(none)" "python" "ruby" "java" "js" "haskell"))))
+`(let ((type-ignore (yas-choose-value '("(none)" "python" "ruby" "java" "js" "haskell" "clojure"))))
     (string-join
        (cond ((string= type-ignore "python")
               '("*.py[cod]"
@@ -51,5 +51,18 @@ tmp/
                "cabal.project.local"
                "cabal.project.local~"
                ".HTF/"
-               ".ghc.environment.*")))
+               ".ghc.environment.*"))
+             ((string= type-ignore "clojure")
+              '("/target"
+                "/classes"
+                "/checkouts"
+                "profiles.clj"
+                "pom.xml"
+                "pom.xml.asc"
+                "*.jar"
+                "*.class"
+                "/.lein-*"
+                "/.nrepl-port"
+                "/.prepl-port"
+                "/.cpcache")))
        "\n"))`


### PR DESCRIPTION
Adds "clojure" to the `yas-choose-value` list when creating a new `.gitignore`.

The values were taken from leiningen default template: https://github.com/technomancy/leiningen/blob/master/resources/leiningen/new/template/gitignore and included a `.cpcache` for projects using clojure `deps.edn`.