### PR TITLE
Remove +org-init-roam-maybe-h function

### DIFF
--- a/modules/lang/org/contrib/roam.el
+++ b/modules/lang/org/contrib/roam.el
@@ -9,7 +9,6 @@
 ;;; Packages
 
 (use-package! org-roam
-  :hook (org-load . +org-init-roam-maybe-h)
   :hook (org-roam-backlinks-mode . turn-on-visual-line-mode)
   :commands (org-roam-buffer-toggle-display
              org-roam-dailies-find-date
@@ -46,14 +45,6 @@
          :desc "Find yesterday"     "y" #'org-roam-dailies-find-yesterday
          :desc "Find directory"     "." #'org-roam-dailies-find-directory))
   :config
-  (defun +org-init-roam-maybe-h ()
-    "Activate `org-roam-mode'. If it fails, fail gracefully."
-    (unless (with-demoted-errors "ORG ROAM ERROR: %s"
-              (org-roam-mode +1)
-              t)
-      (message "To try reinitializing org-roam, run 'M-x org-roam-mode'")
-      (org-roam-mode -1)))
-
   (setq org-roam-directory
         (file-name-as-directory
          (file-truename


### PR DESCRIPTION
The hook is not needed anymore. Org-raom-mode is a major mode now, which means
that it cannot be invoked with the +1 -1 parameters.

The hook is also not required because the mode is used in org-roam-buffer
buffer.

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x ] It targets the develop branch
  - [ x] No other pull requests exist for this issue
  - [x ] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [x ] Any relevant issues and PRs have been linked to
  - [ x] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

Fixes #0000 <!-- remove if not applicable -->

{{{ Summarize what you've changed HERE and why }}}
