### PR TITLE
enable deft key binding only when deft module enabled

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -163,7 +163,8 @@
 
        :desc "Toggle last org-clock"          "c" #'+org/toggle-last-clock
        :desc "Cancel current org-clock"       "C" #'org-clock-cancel
-       :desc "Open deft"                      "d" #'deft
+       (:when (featurep! :ui deft)
+        :desc "Open deft"                     "d" #'deft)
        (:when (featurep! :lang org +noter)
         :desc "Org noter"                    "e" #'org-noter)
 


### PR DESCRIPTION


enable deft key binding only when deft module enabled
