### PR TITLE
Consider mapping org-mode-map "f" to org-footnote-action

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -804,7 +804,7 @@ between the two."
          "/" #'consult-org-agenda)
         "A" #'org-archive-subtree
         "e" #'org-export-dispatch
-        "f" #'org-footnote-new
+        "f" #'org-footnote-action
         "h" #'org-toggle-heading
         "i" #'org-toggle-item
         "I" #'org-id-get-create


### PR DESCRIPTION
It's currently mapped to `org-footnote-new`, but `org-footnote-action` does the same when in a context where you want to insert a new footnote, plus has additional useful functionality in different contexts, like jumping between definition and reference, sorting/renaming/deleting footnotes. See [the Org Mode manual](https://orgmode.org/manual/Creating-Footnotes.html) (search for "footnote action") and [the docstring of `org-footnote-action`](https://code.orgmode.org/bzg/org-mode/src/master/lisp/org-footnote.el#L955-L967).