### PR TITLE
Guard default Deft bindings

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -163,7 +163,8 @@
 
        :desc "Toggle last org-clock"          "c" #'+org/toggle-last-clock
        :desc "Cancel current org-clock"       "C" #'org-clock-cancel
-       :desc "Open deft"                      "d" #'deft
+       (:when (featurep! :ui deft)
+        :desc "Open deft"                      "d" #'deft)
        (:when (featurep! :lang org +noter)
         :desc "Org noter"                    "e" #'org-noter)
 

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -522,7 +522,8 @@
 
        :desc "Toggle last org-clock"        "c" #'+org/toggle-last-clock
        :desc "Cancel current org-clock"     "C" #'org-clock-cancel
-       :desc "Open deft"                    "d" #'deft
+       (:when (featurep! :ui deft)
+        :desc "Open deft"                    "d" #'deft)
        (:when (featurep! :lang org +noter)
         :desc "Org noter"                  "e" #'org-noter)
 


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->
Deft is an opt-in module so the default keybinding has to be guarded to
account for it not always being loaded.
