### PR TITLE
Correct a typo in a person's name in the ligature module readme

### DIFF
--- a/modules/ui/ligatures/README.org
+++ b/modules/ui/ligatures/README.org
@@ -10,7 +10,7 @@
     - [[#font-ligatures-module-flags][Font ligatures module flags]]
   - [[#plugins][Plugins]]
 - [[#prerequisites][Prerequisites]]
-  - [[#mutsuharus-emacs-mac-port-or-emacs-28-with-harfbuzz-support][Mutsuharu's emacs-mac port or Emacs 28+ with Harfbuzz support]]
+  - [[#mitsuharus-emacs-mac-port-or-emacs-28-with-harfbuzz-support][Mitsuharu's emacs-mac port or Emacs 28+ with Harfbuzz support]]
   - [[#not-emacs-mac-and-emacs--27][Not Emacs-mac and Emacs <= 27]]
 - [[#features][Features]]
   - [[#mathematical-symbols-replacement][Mathematical symbols replacement]]
@@ -63,7 +63,7 @@ This module requires one of three setups for ligatures to work:
 - Mitsuharu's =emacs-mac= build on macOS (available on homebrew), or
 - A patched font for Doom's fallback ligature support.
 
-** Mutsuharu's emacs-mac port or Emacs 28+ with Harfbuzz support
+** Mitsuharu's emacs-mac port or Emacs 28+ with Harfbuzz support
 Ligatures should be handled without any additional configuration.
 
 ** Not Emacs-mac and Emacs <= 27


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

Throughout the readme in the `ligatures` module there were two different spellings of the name `Mitsuharu Yamamoto` who maintains [emacs-mac](https://bitbucket.org/mituharu/emacs-mac).