### PR TITLE
fix(multiple-cursors): keybind conflict with embark

### DIFF
--- a/modules/editor/multiple-cursors/config.el
+++ b/modules/editor/multiple-cursors/config.el
@@ -19,6 +19,14 @@
         "C-p" #'evil-multiedit-prev))
 
 
+(use-package! iedit
+  :when (featurep! :completion vertico)
+  :defer t
+  :init
+  ;; Fix conflict with embark.
+  (setq iedit-toggle-key-default nil))
+
+
 (use-package! evil-mc
   :when (featurep! :editor evil)
   :commands (evil-mc-make-cursor-here


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

Fixes #5374 <!-- remove if not applicable -->

Disabled iedit's default keybinding because it conflicts with embark in the new `:completion vertico` module, and iedit would pop up an annoying warning buffer about it. Since iedit is only used in Doom as a dependency of evil-multiedit, this should only negatively impact users who use iedit directly without vim keybindings (probably a tiny number of people).