### PR TITLE
fix(evil): use evil-collection for package-menu

### DIFF
--- a/modules/editor/evil/init.el
+++ b/modules/editor/evil/init.el
@@ -45,7 +45,6 @@
       kotlin-mode
       occur
       outline
-      package-menu
       simple
       slime
       lispy)


### PR DESCRIPTION
I can't find a rationale for this in the git history, and from looking
through the evil-collection entry I can't think of one.