### PR TITLE
fix(coq): disable spinner by default

### DIFF
--- a/modules/lang/coq/config.el
+++ b/modules/lang/coq/config.el
@@ -69,7 +69,7 @@
     :references #'company-coq-grep-symbol
     :documentation #'company-coq-doc)
 
-  (setq company-coq-disabled-features '(hello company-defaults))
+  (setq company-coq-disabled-features '(hello company-defaults spinner))
 
   (if (featurep! :completion company)
       (define-key coq-mode-map [remap company-complete-common]


### PR DESCRIPTION
This was disabled upstream in
https://github.com/cpitclaudel/company-coq/commit/7423ee253951a439b2491e1cd2ea8bb876d25cb7
due to a serious performance impact on some systems (even if the spinner
isn't visible in the modeline).


<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->
