### PR TITLE
feat(scheme): auto-add guix channels to load-path

### DIFF
--- a/modules/lang/scheme/config.el
+++ b/modules/lang/scheme/config.el
@@ -72,3 +72,9 @@
   :when (featurep! +guile)
   :when (featurep! :checkers syntax)
   :after geiser)
+
+;; Add Guix channels to Guile load path
+(when (and (featurep! +guile) (executable-find "guix"))
+  (after! geiser-guile
+    (add-to-list 'geiser-guile-load-path
+                 (expand-file-name "~/.config/guix/current/share/guile/site/3.0"))))


### PR DESCRIPTION
Guix is detected with a simple `executable-find`, and this trick assumes
that guix is running on version 3 of Guile (which hopefully won't
change for a while)

ping @flatwhatson in case I'm doing something horrible
