### PR TITLE
feat(julia): Adds support for Julia Snail

### DIFF
--- a/modules/lang/julia/README.org
+++ b/modules/lang/julia/README.org
@@ -8,27 +8,34 @@
   - [[#module-flags][Module Flags]]
   - [[#plugins][Plugins]]
 - [[#prerequisites][Prerequisites]]
+  - [[#julia-snail][Julia Snail]]
   - [[#language-server][Language Server]]
     - [[#lsp-julia][~lsp-julia~]]
     - [[#eglot-jl][~eglot-jl~]]
 - [[#features][Features]]
+  - [[#julia-snail-1][Julia Snail]]
+    - [[#keybindings][Keybindings]]
   - [[#language-server-1][Language Server]]
 - [[#configuration][Configuration]]
+  - [[#julia-snail-multimedia-support][Julia Snail multimedia support]]
   - [[#change-the-default-environment-for-the-julia-language-server][Change the default environment for the Julia language server]]
 
 * Description
 This module adds support for [[https://julialang.org/][the Julia language]] to Doom Emacs.
 
 + Syntax highlighting and latex symbols from ~julia-mode~
-+ REPL integration from ~julia-repl~
++ REPL integration from ~julia-repl~ or ~julia-snail~
 + Code completion and syntax checking, requires ~:tools lsp~ and ~+lsp~
 
 ** Module Flags
 + =+lsp= Enable LSP server support.
++ =+snail= Enables [[http://github.com/gcv/julia-snail][Julia Snail]] integration
 
 ** Plugins
 + [[https://github.com/JuliaEditorSupport/julia-emacs/][julia-mode]]
 + [[https://github.com/tpapp/julia-repl][julia-repl]]
++ =+snail=
+  + [[https://github.com/gcv/julia-snail][julia-snail]]
 + =+lsp= and =:tools lsp=
   + [[https://github.com/non-jedi/lsp-julia][lsp-julia]]
   + [[https://github.com/emacs-lsp/lsp-mode][lsp]]
@@ -38,6 +45,10 @@ This module adds support for [[https://julialang.org/][the Julia language]] to D
 
 * Prerequisites
 This module requires =julia= and an language server if =+lsp= is enabled.
+
+** Julia Snail
+~+snail~ requires =:term vterm= to be enabled. Optionally, =:lang markdown= can
+be enabled to support nice rendering of docstrings.
 
 ** Language Server
 ~+lsp~ requires ~LanguageServer.jl~ and ~SymbolServer.jl~. The =lsp-julia= and
@@ -93,12 +104,34 @@ But to let ~eglot-jl~ use the environment bundled with it, set it to
 #+END_SRC
 
 * Features
+** Julia Snail
+~+snail~ adds an alternate (CIDER/SLIME inspired) REPL experience on top of =julia-mode=.
+It supports completion with =completion-at-point=, cross referencing via =xref=,
+remote REPLs with =tramp=, and multimedia buffers (i.e. from Plots).
+
+*** Keybindings
+| Binding             | Description                       |
+|---------------------+-----------------------------------|
+| =<localleader> '​=   | =julia-snail=                     |
+| =<localleader> R=   | =julia-snail-update-module-cache= |
+| =<localleader> h=   | =julia-snail-doc-lookup=          |
+| =<localleader> e b= | =julia-snail-send-buffer-file=    |
+| =<localleader> e d= | =julia-snail-send-dwim=           |
+| =<localleader> e D= | =julia-snail-send-line=           |
+
+
 ** Language Server
 ~+lsp~ adds code completion, syntax checking, formatting and other ~lsp-mode~ or
 ~eglot~ features. It requires ~LanguageServer.jl~, the installation of which is
 described above.
 
 * Configuration
+** Julia Snail multimedia support
+For multimedia buffers within ~julia-snail~ to work, Emacs must support images.
+To enable multimedia, set ~julia-snail-multimedia-display~ to ~t~ before
+starting the REPL. Additional configuration for the multimedia window can be
+found in the [[https://github.com/gcv/julia-snail#multimedia-and-plotting][julia snail docs]].
+
 ** Change the default environment for the Julia language server
 ~lsp-julia~ requires a variable be set for the Julia environment. This is set to
 v1.0 by default as it is the current LTS.

--- a/modules/lang/julia/autoload.el
+++ b/modules/lang/julia/autoload.el
@@ -6,16 +6,17 @@
 ;;;###autoload (defvar inferior-julia-program-name (or (executable-find "julia-basic") "julia"))
 
 ;;;###autoload
-(defun +julia/open-repl ()
-  "Run an inferior instance of `julia' inside Emacs."
-  (interactive)
-  (if (require 'julia-repl nil t)
-      (prog1 (julia-repl)
-        (julia-repl-use-emacsclient))
-    (let ((buffer (get-buffer-create "*Julia*")))
-      (unless (comint-check-proc "*Julia*")
-        (apply #'make-comint-in-buffer "Julia" "*Julia*" julia-program julia-arguments))
-      (pop-to-buffer buffer)
-      (with-current-buffer buffer
-        (inferior-julia-mode))
-      buffer)))
+(when (not (featurep! :lang julia +snail))
+ (defun +julia/open-repl ()
+   "Run an inferior instance of `julia' inside Emacs."
+   (interactive)
+   (if (require 'julia-repl nil t)
+       (prog1 (julia-repl)
+         (julia-repl-use-emacsclient))
+     (let ((buffer (get-buffer-create "*Julia*")))
+       (unless (comint-check-proc "*Julia*")
+         (apply #'make-comint-in-buffer "Julia" "*Julia*" julia-program julia-arguments))
+       (pop-to-buffer buffer)
+       (with-current-buffer buffer
+         (inferior-julia-mode))
+       buffer))))

--- a/modules/lang/julia/config.el
+++ b/modules/lang/julia/config.el
@@ -42,8 +42,8 @@
                    "\\)"))
         1 font-lock-type-face)))))
 
-
 (use-package! julia-repl
+  :unless (featurep! +snail)
   :preface (defvar +julia-repl-start-hook nil)
   :hook (julia-mode . julia-repl-mode)
   :hook (+julia-repl-start . +julia-override-repl-escape-char-h)
@@ -66,6 +66,22 @@
   (defun +julia-override-repl-escape-char-h ()
     "Use C-c instead of C-x for escaping."
     (term-set-escape-char ?\C-c)))
+
+(use-package! julia-snail
+  :when (featurep! +snail)
+  :hook (julia-mode . julia-snail-mode)
+  :config
+  (set-lookup-handlers! '(julia-mode julia-snail-repl-mode)
+    :documentation #'julia-snail-doc-lookup)
+  (map! :map julia-snail-mode-map
+        (:localleader
+         ("'" #'julia-snail
+          "R" #'julia-snail-update-module-cache
+          "h" #'julia-snail-doc-lookup
+          (:prefix ("e" . "eval")
+           "b" #'julia-snail-send-buffer-file
+           "d" #'julia-snail-send-dwim
+           "D" #'julia-snail-send-line)))))
 
 
 (when (featurep! +lsp)

--- a/modules/lang/julia/config.el
+++ b/modules/lang/julia/config.el
@@ -1,5 +1,8 @@
 ;;; lang/julia/config.el -*- lexical-binding: t; -*-
 
+(after! projectile
+  (pushnew! projectile-project-root-files "Project.toml"))
+
 (use-package! julia-mode
   :interpreter "julia"
   :config

--- a/modules/lang/julia/doctor.el
+++ b/modules/lang/julia/doctor.el
@@ -4,6 +4,10 @@
              (featurep! :tools lsp))
          "This module requires (:tools lsp)")
 
+(when (featurep! +snail)
+  (assert! (not (featurep! +lsp)) "Julia Snail and LSP are mutually exclusive")
+  (assert! (featurep! :term vterm) "Julia Snail requires vterm"))
+
 (when (featurep! +lsp)
   (let ((args
          (cond ((require 'eglot-jl nil t)

--- a/modules/lang/julia/packages.el
+++ b/modules/lang/julia/packages.el
@@ -1,8 +1,12 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; lang/julia/packages.el
 
-(package! julia-mode :pin "fe6f6f7a80f8d60ecffa5b2cb43667bb9dc11705")
-(package! julia-repl :pin "79e686e3ebf164bd39fc2ea5cf09d38d0e1d763a")
+(if (featurep! +snail)
+    ; Snail has its own dependency on julia-modde
+    (package! julia-snail :pin "5b95b278772de8339ac198fe6eaadb0427d680fb")
+  (progn
+    (package! julia-mode :pin "fe6f6f7a80f8d60ecffa5b2cb43667bb9dc11705")
+    (package! julia-repl :pin "79e686e3ebf164bd39fc2ea5cf09d38d0e1d763a")))
 
 (when (featurep! +lsp)
   (if (featurep! :tools lsp +eglot)


### PR DESCRIPTION
[Julia snail](https://github.com/gcv/julia-snail) is an alternative development setup for Julia that takes inspiration from CIDER/SLIME. I find it much easier to use than vanilla `julia-mode` and I don't get hit with too much context switching going from Clojure to Julia.

I've added a `+snail` flag to the julia module that enables `julia-snail-mode` in julia buffers and associated the matching keybinds from CIDER, which replaces `julia-repl`. The module still uses `julia-mode` as provided by [julia-emacs](https://github.com/JuliaEditorSupport/julia-emacs), so I assume I leave in those `use-package!` statements.

The only bits I'm not sure about is how enforce a requirement for `vterm`, as that's what snail uses as it's REPL. I added a check in `doctor.el`. Additionally, I'm not quite sure how to spawn a REPL that is detached from a julia source buffer, so I feature-gated the autoload `+julia/open-repl` - I'm not sure if that was the right approach and would appreciate feedback.

This new feature is of course opt-in, and doesn't change any base julia module functionality.

Unrelated to providing the snail feature, I also added the hint to mark folders with julia's Project.toml as projectile projects.