### PR TITLE
fix & bump (company-box): make company-box works with daemon emacs

### DIFF
--- a/modules/completion/company/config.el
+++ b/modules/completion/company/config.el
@@ -95,7 +95,7 @@
 
 (use-package! company-box
   :when (featurep! +childframe)
-  :hook (company-mode . company-box-mode)
+  :hook (doom-init-ui . company-box-mode)
   :config
   (setq company-box-show-single-candidate t
         company-box-backends-colors nil

--- a/modules/completion/company/packages.el
+++ b/modules/completion/company/packages.el
@@ -4,4 +4,4 @@
 (package! company :pin "d77184094b9a45b204813d824918e1ec2aac8504")
 (package! company-dict :pin "cd7b8394f6014c57897f65d335d6b2bd65dab1f4")
 (when (featurep! +childframe)
-  (package! company-box :pin "c8a867163b15586cc9ed4accb992094308e54a9a"))
+  (package! company-box :pin "156f65cfbf690ed84e0e84f90277d665d873ff24"))


### PR DESCRIPTION
When starting emacs as a daemon `company-box` does not display the icons.

`company-mode-hook` is called too early, so I changed the hook `doom-init-ui`.

The PR also bump to the latest commit of `company-box` that fixes a bug introduced in the pinned version.
