### PR TITLE
Revert "Add set -euo pipefail to sh-mode file template"

### DIFF
--- a/modules/editor/file-templates/templates/sh-mode/__
+++ b/modules/editor/file-templates/templates/sh-mode/__
@@ -1,4 +1,3 @@
 #!/usr/bin/env `(if (equal (file-name-extension buffer-file-name) "zsh") "zsh" "bash")`
-set -euo pipefail
 
 $0


### PR DESCRIPTION
This reverts commit ce2fee138a7eef2d01e67e555654bba934623297.

As of https://github.com/hlissner/doom-emacs/pull/2906 `set -euo pipefail` is added to any newly created `.sh` script. This snippet made my bash behave strangely after I used doom emacs to create a new `.bashrc` file.
Examples of what happens when `.bashrc` starts with the snippet:
```
cd Doc<tab> -> terminal crash without error message, despite Documents existing.
cat Documents -> terminal crash without error message. This command makes no sense since Documents is a directory, but it normally outputs the error message "cat: Documents: Is a directory"
```
This had me confused for a while and I thought my OS was at fault before I realized what was going on. I'm sure this snippet is reasonable in most cases, but since it's added automatically I would expect it to never cause issues like this.
Thank you for doom emacs!