### PR TITLE
fix(snippets): yas-expand error when yas-choose-value

### DIFF
--- a/modules/editor/snippets/autoload/snippets.el
+++ b/modules/editor/snippets/autoload/snippets.el
@@ -20,7 +20,9 @@ If there are conflicting keys across the two camps, the built-in ones are
 ignored. This makes it easy to override built-in snippets with private ones."
   (when (eq this-command 'yas-expand)
     (let* ((gc-cons-threshold most-positive-fixnum)
-           (choices (cl-remove-duplicates choices :test #'+snippets--remove-p)))
+           (choices (condition-case _
+                        (cl-remove-duplicates choices :test #'+snippets--remove-p)
+                      (wrong-type-argument choices))))
       (if (cdr choices)
           (cl-loop for fn in (cdr (memq '+snippets-prompt-private yas-prompt-functions))
                    if (funcall fn prompt choices display-fn)


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [X] It targets the develop branch
  - [X] No other pull requests exist for this issue
  - [X] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [X] Any relevant issues and PRs have been linked to
  - [X] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

`+snippets-prompt-private` is being overzealous that intercepts the candidates triggered by `yas-choose-value`.

For example, triggering `jupyter` in org mode, renders
#+begin_src jupyter-Wrong type argument: yas--template, "python" :session  :async yes

#+end_src