### PR TITLE
Ignore 'places', 'transient/' after doom sync -u

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,10 +21,12 @@ ede-projects.el
 elpa/
 eln-cache/
 network-security.data
+places
 semanticdb
 server/
 smex-items
 tramp
+transient/
 var/
 
 # compiled files


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->


After a `doom sync -u`, I got `${EMACSDIR}/{places,transient/history.el}`. It doesn't seem related to Doom, so ignore them. 

Btw I only had changed the version of a package in my packages.el because the one from a module was old (https://github.com/hlissner/doom-emacs/pull/5290).

```
(package! bibtex-actions
  :pin "f4d9af720d3854ce0e746312061372ae30e2cc97")
```