### PR TITLE
Improve `:editor parinfer`

### DIFF
--- a/modules/editor/parinfer/README.org
+++ b/modules/editor/parinfer/README.org
@@ -1,25 +1,55 @@
 #+TITLE:   editor/parinfer
 #+DATE:    June 9, 2018
 #+SINCE:   v2.1
-#+STARTUP: inlineimages
+#+STARTUP: inlineimages nofold
 
-* Table of Contents :TOC:
+* Table of Contents :TOC_3:noexport:
 - [[#description][Description]]
+  - [[#maintainers][Maintainers]]
   - [[#module-flags][Module Flags]]
-  - [[#packages][Packages]]
+  - [[#plugins][Plugins]]
+- [[#prerequisites][Prerequisites]]
+- [[#features][Features]]
+  - [[#keybindings][Keybindings]]
+- [[#configuration][Configuration]]
+- [[#troubleshooting][Troubleshooting]]
 
 * Description
-Parinfer is a proof-of-concept editor mode for Lisp programming languages. It
-will infer some changes to keep Parens and Indentation inline with one another.
 
-https://raw.githubusercontent.com/DogLooksGood/parinfer-mode/a7c041454e05ec2b88333a73e72debaa671ed596/images/demo.gif
+Parinfer is a minor mode that aids the writing of Lisp code. It automatically
+infers parenthesis matching and indentation alignment, keeping your code
+balanced and beautiful.
 
-More information can be found about it [[https://shaunlebron.github.io/parinfer/][in the project's documentation]].
+Note that the original =parinfer-mode= has been deprecated and superceded by
+=parinfer-rust-mode=, which has much better performance.
+
+** Maintainers
+
+This module has no dedicated maintainers.
 
 ** Module Flags
-+ =+rust= Use [[github:justinbarclay/parinfer-rust-mode][parinfer-rust-mode]] instead of the now deprecated [[github:DogLooksGood/parinfer-mode][parinfer-mode]].
-  This depends on Emacs being compiled with the option `--with-modules`. The
-  pre-built library is only available for Linux, Windows and MacOS.
 
-** Packages
-+ [[https://github.com/DogLooksGood/parinfer-mode][parinfer]]
+This module provides no flags.
+
+** Plugins
+
++ [[https://github.com/justinbarclay/parinfer-rust-mode][parinfer-rust-mode]]
+
+* Prerequisites
+
+This module has no prerequisites.
+
+* Features
+
+** Keybindings
+
+| Binding           | Description                               |
+|-------------------+-------------------------------------------|
+| ~<localleader> m p~ | Toggle between different inference modes. |
+| ~<localleader> m P~ | Temporarily disable parinfer.             |
+
+* Configuration
+# How to configure this module, including common problems and how to address them.
+
+* Troubleshooting
+# Common issues and their solution, or places to look for help.

--- a/modules/editor/parinfer/config.el
+++ b/modules/editor/parinfer/config.el
@@ -22,8 +22,7 @@
         :i "<tab>"     #'parinfer-smart-tab:dwim-right-or-complete
         :i "<backtab>" #'parinfer-smart-tab:dwim-left
         :localleader
-        "m" #'parinfer-toggle-mode))
-
+        "p" #'parinfer-toggle-mode))
 
 (use-package! parinfer-rust-mode
   :when (featurep! +rust)
@@ -45,5 +44,5 @@
   :config
   (map! :map parinfer-rust-mode-map
         :localleader
-        "m" #'parinfer-rust-switch-mode
-        "M" #'parinfer-rust-toggle-disable))
+        "p" #'parinfer-rust-switch-mode
+        "P" #'parinfer-rust-toggle-disable))

--- a/modules/editor/parinfer/config.el
+++ b/modules/editor/parinfer/config.el
@@ -1,31 +1,6 @@
 ;;; editor/parinfer/config.el -*- lexical-binding: t; -*-
 
-(use-package! parinfer
-  :unless (featurep! +rust)
-  :hook ((emacs-lisp-mode
-          clojure-mode
-          scheme-mode
-          lisp-mode
-          racket-mode
-          hy-mode) . parinfer-mode)
-  :init
-  (setq parinfer-extensions
-        '(defaults
-          pretty-parens
-          smart-tab
-          smart-yank))
-  (when (featurep! :editor evil +everywhere)
-    (push 'evil parinfer-extensions))
-  :config
-  (map! :map parinfer-mode-map
-        "\"" nil  ; smartparens handles this
-        :i "<tab>"     #'parinfer-smart-tab:dwim-right-or-complete
-        :i "<backtab>" #'parinfer-smart-tab:dwim-left
-        :localleader
-        "p" #'parinfer-toggle-mode))
-
 (use-package! parinfer-rust-mode
-  :when (featurep! +rust)
   :when (bound-and-true-p module-file-suffix)
   :hook ((emacs-lisp-mode
           clojure-mode

--- a/modules/editor/parinfer/doctor.el
+++ b/modules/editor/parinfer/doctor.el
@@ -3,8 +3,5 @@
 (unless (fboundp 'module-load)
   (warn! "Your emacs wasn't built with dynamic modules support. `parinfer-rust-mode' won't work"))
 (when (and (eq system-type 'berkeley-unix)
-           (not (file-readable-p (concat user-emacs-directory
-                                         ".local/etc/parinfer-rust/libparinfer_rust.so"))))
-  (warn! (concat "Could not read " user-emacs-directory
-                 ".local/etc/parinfer-rust/libparinfer_rust.so. "
-                 "`parinfer-rust-mode' won't work")))
+           (not (file-readable-p parinfer-rust-library)))
+  (warn! (concat "Could not read " parinfer-rust-library ". `parinfer-rust-mode' won't work")))

--- a/modules/editor/parinfer/doctor.el
+++ b/modules/editor/parinfer/doctor.el
@@ -1,11 +1,10 @@
 ;;; editor/parinfer/doctor.el -*- lexical-binding: t; -*-
 
-(when (featurep! +rust)
-  (unless (fboundp 'module-load)
-    (warn! "Your emacs wasn't built with dynamic modules support. `parinfer-rust-mode' won't work"))
-  (when (and (eq system-type 'berkeley-unix)
-             (not (file-readable-p (concat user-emacs-directory
-                                           ".local/etc/parinfer-rust/libparinfer_rust.so"))))
-    (warn! (concat "Could not read " user-emacs-directory
-                   ".local/etc/parinfer-rust/libparinfer_rust.so. "
-                   "`parinfer-rust-mode' won't work"))))
+(unless (fboundp 'module-load)
+  (warn! "Your emacs wasn't built with dynamic modules support. `parinfer-rust-mode' won't work"))
+(when (and (eq system-type 'berkeley-unix)
+           (not (file-readable-p (concat user-emacs-directory
+                                         ".local/etc/parinfer-rust/libparinfer_rust.so"))))
+  (warn! (concat "Could not read " user-emacs-directory
+                 ".local/etc/parinfer-rust/libparinfer_rust.so. "
+                 "`parinfer-rust-mode' won't work")))

--- a/modules/editor/parinfer/packages.el
+++ b/modules/editor/parinfer/packages.el
@@ -1,18 +1,4 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; editor/parinfer/packages.el
 
-(if (featurep! +rust)
-    (package! parinfer-rust-mode :pin "c2c1bbec6cc7dad4f546868aa07609b8d58a78f8")
-  (when (featurep! :editor evil)
-    ;; Parinfer uses `evil-define-key' without loading evil, so if evil is
-    ;; installed *after* parinfer, parinfer will throw up void-function errors.
-    ;; because evil-define-key (a macro) wasn't expanded at compile-time. So we
-    ;; make sure evil is installed before parinfer...
-    (package! evil)
-    ;; ...and that it can see `evil-define-key' if evil was installed in a
-    ;; separate session:
-    (autoload 'evil-define-key "evil-core" nil nil 'macro))
-
-  (package! parinfer
-    :recipe (:host github :repo "emacsattic/parinfer")
-    :pin "8659c99a9475ee34af683fdf8f272728c6bebb3a"))
+(package! parinfer-rust-mode :pin "c2c1bbec6cc7dad4f546868aa07609b8d58a78f8")


### PR DESCRIPTION
As brought up initially in the Discord, this PR modernizes the `parinfer` module by:

- [x] Unbreaking the expected binding of `macrostep-expand` to `SPC m m`.
- [x] Removing the deprecated `parinfer-mode` in favour of the Rust variant (current invoked by `+rust`).
- [x] Modernizing the module README

**Note:** This is a fairly breaking change, as it actually assumes that the user's Emacs was compiled with `--with-modules`. However, given that Doom requires Emacs 27 at minimum and that the major distributions likely ship with an Emacs built with `--with-modules` (I haven't checked), should we be concerned?