### PR TITLE
docs(mu4e): fix msmtp config in readme

### DIFF
--- a/modules/email/mu4e/README.org
+++ b/modules/email/mu4e/README.org
@@ -74,11 +74,12 @@ forwarder such as =msmtp= (recommended).
 If you use =msmtp=, you'll likely want to add the following to your
 =config.el=:
 #+begin_src emacs-lisp
-(setq sendmail-program "/usr/bin/msmtp"
+(after! mu4e
+  (setq sendmail-program (executable-find "msmtp")
         send-mail-function #'smtpmail-send-it
         message-sendmail-f-is-evil t
         message-sendmail-extra-arguments '("--read-envelope-from")
-        message-send-mail-function #'message-send-mail-with-sendmail)
+        message-send-mail-function #'message-send-mail-with-sendmail))
 #+end_src
 
 ** NixOS


### PR DESCRIPTION
- requires being in an (after! mu4e ...) to work
- minor fixes

-------

@tecosaur this fixes the issue I was having