### PR TITLE
Fix extra trailing brace after haskell comment

### DIFF
--- a/modules/config/default/config.el
+++ b/modules/config/default/config.el
@@ -205,7 +205,7 @@
       (map! :map markdown-mode-map
             :ig "*" (general-predicate-dispatch nil
                       (looking-at-p "\\*\\* *")
-                      (cmd! (forward-char 2)))))))
+                      (cmd! (forward-char 2)))))
 
     ;; Removes haskell-mode trailing braces
 
@@ -216,7 +216,7 @@
         (sp-local-pair "{-@" "@-}" :actions :rem)
         (sp-local-pair "{-" "-")
         (sp-local-pair "{-#" "#-")
-        (sp-local-pair "{-@" "@-")))
+        (sp-local-pair "{-@" "@-")))))
 
 
 ;;

--- a/modules/config/default/config.el
+++ b/modules/config/default/config.el
@@ -207,6 +207,17 @@
                       (looking-at-p "\\*\\* *")
                       (cmd! (forward-char 2)))))))
 
+    ;; Removes haskell-mode trailing braces
+
+    (after! haskell-mode
+      (sp-with-modes '(haskell-mode haskell-interactive-mode)
+        (sp-local-pair "{-" "-}" :actions :rem)
+        (sp-local-pair "{-#" "#-}" :actions :rem)
+        (sp-local-pair "{-@" "@-}" :actions :rem)
+        (sp-local-pair "{-" "-")
+        (sp-local-pair "{-#" "#-")
+        (sp-local-pair "{-@" "@-")))
+
 
 ;;
 ;;; Keybinding fixes


### PR DESCRIPTION
Fixes  #5448

I've added a condition to the smartparens braces expansion, not including "{" if we're in `haskell-mode`.
I'm not much of an elisp user, so it may be very wrong. I would be very happy to make it better if anyone has a suggestion :-)
