### PR TITLE
docs(python): setting lsp PATH for python

### DIFF
--- a/modules/lang/python/README.org
+++ b/modules/lang/python/README.org
@@ -84,6 +84,11 @@ manager or manually:
 + *mspyls* can be installed by typing =M-x lsp-install-server RET mspyls=.
 + *pyright* can be installed with ~pip install pyright~ or ~npm i -g pyright~.
 
+Take a note that if you had installed LSP in the virtual env, you have to add
+it to your path (use ~config.el~ for this). For example:
+
+~(add-to-list 'exec-path "/home/ac/_work/venvs/doom/bin")~
+
 * Features
 This module supports LSP. It requires installation of [[https://pypi.org/project/python-language-server/][Python Language
 Server]], [[https://github.com/Microsoft/python-language-server][Microsoft Language Server]], or [[https://github.com/microsoft/pyright][pyright]], see [[Language Server Protocol Support][LSP Support]].


### PR DESCRIPTION
The commit adds information about setting PATH for lsp.

It is not so clear, especially for beginners that if you install lsp
in the virtualenv you will have a trouble with running it.

The current order of pyenv-activate and lsp starting does not allow user
to use lsp installed to a project venv so the simplest way I found is
a modification of the PATH.
