### PR TITLE
bump!: :emacs vc

### DIFF
--- a/modules/emacs/vc/packages.el
+++ b/modules/emacs/vc/packages.el
@@ -5,7 +5,7 @@
 (package! vc-annotate :built-in t)
 (package! smerge-mode :built-in t)
 
-(package! browse-at-remote :pin "e02ad2189c87da33f80bf4967a968772ce3e4431")
+(package! browse-at-remote :pin "cef26f2c063f2473af42d0e126c8613fe2f709e4")
 (package! git-commit :pin "b68a760c9e7694c687adedec7dffab0a5609ea93")
 (package! git-timemachine :pin "8d675750e921a047707fcdc36d84f8439b19a907")
 (package! gitconfig-mode :pin "7678ead3cdbb1692c9728b9730c016283ed97af1")


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [X] It targets the develop branch
  - [X] No other pull requests exist for this issue
  - [X] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [X] Any relevant issues and PRs have been linked to
  - [X] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

BREAKING CHANGE: browse-at-remote-remote-type-domains is replaced by
browse-at-remote-remote-type-regexps. If you have a custom domain
configured replace:

    (add-to-list 'browse-at-remote-remote-type-domains
      ("git.example.com" . "github")

with

    (add-to-list 'browse-at-remote-remote-type-regexp
      ("^git\\.example\\.com$" . "github")

Added support for Gittiles.

