### PR TITLE
fix(zen): robust visual adjustment upon text scaling

### DIFF
--- a/modules/ui/zen/config.el
+++ b/modules/ui/zen/config.el
@@ -46,7 +46,7 @@
         (window-divider-mode +1))))
 
   ;; Adjust margins when text size is changed
-  (advice-add #'text-scale-adjust :after #'visual-fill-column-adjust))
+  (add-hook 'text-scale-mode-hook #'visual-fill-column-adjust))
 
 
 (use-package! mixed-pitch


### PR DESCRIPTION
Visual adjustment upon text scale change
-------

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [X] It targets the develop branch
  - [X] No other pull requests exist for this issue
  - [X] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [X] Any relevant issues and PRs have been linked to
  - [X] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

Using `advice-add` to `text-scale-mode` only covers text scaling done
by `text-scale-adjust`. Typically users rely more on `C-+` or `C--`,
which doesn't use `text-scale-adjust` function under the hood.

Hooking to `text-scale-mode` renders more reliable, and broad coverage.
