### PR TITLE
bump: :tools magit

### DIFF
--- a/modules/tools/magit/packages.el
+++ b/modules/tools/magit/packages.el
@@ -3,7 +3,7 @@
 
 (when (package! magit :pin "1e40d0021790707f6e88debda04f6b14d9429586")
   (when (featurep! +forge)
-    (package! forge :pin "6e8ab6c67e3bac1d4e464e64a6b39971814f25cb"))
+    (package! forge :pin "f97bc47e9e2a2a6300dd267bdd67a88254f65aa7"))
   (package! magit-gitflow :pin "cc41b561ec6eea947fe9a176349fb4f771ed865b")
   (package! magit-todos :pin "60152d5c4e4b73e72e15f23ca16e8cc7734906bc")
   (package! github-review :pin "341b7a1352e4ee1f1119756360ac0714abbaf460"))


### PR DESCRIPTION
magit/forge@6e8ab6c67e3b -> magit/forge@6e8ab6c67e3bf97bc47e9e2a

To fix https://github.com/magit/forge/issues/414