### PR TITLE
docs(javascript): fix tide-rename-symbol binding

### DIFF
--- a/modules/lang/javascript/README.org
+++ b/modules/lang/javascript/README.org
@@ -81,7 +81,7 @@ The =:completion company= module uses =company-prescient= to sort completion by
 |-------------------------+------------------+------------------------|
 | ~tide-restart-server~   | =SPC m R=        | Restart tide server    |
 | ~tide-reformat~         | =SPC m f=        | Reformat region        |
-| ~tide-rename-symbol~    | =SPC m r s=      | Rename symbol at point |
+| ~tide-rename-symbol~    | =SPC m r r s=    | Rename symbol at point |
 | ~tide-organize-imports~ | =SPC m r o i=    | Organize imports       |
 *** Refactoring (js2-refactor-mode)
 | command                                           | key / ex command | description                                                                                                        |


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

Fix the keybinding for `tide-rename-symbol` in the documentation - a single letter was missing.