### PR TITLE
fix(emacs-lisp): quiet doc lints in org src blocks

### DIFF
--- a/modules/lang/emacs-lisp/autoload.el
+++ b/modules/lang/emacs-lisp/autoload.el
@@ -244,6 +244,7 @@ verbosity when editing a file in `doom-private-dir' or `doom-emacs-dir'."
   (when (and (bound-and-true-p flycheck-mode)
              (eq major-mode 'emacs-lisp-mode)
              (or (not default-directory)
+                 (null (buffer-file-name (buffer-base-buffer)))
                  (cl-find-if (doom-partial #'file-in-directory-p default-directory)
                              +emacs-lisp-disable-flycheck-in-dirs)))
     (add-to-list 'flycheck-disabled-checkers 'emacs-lisp-checkdoc)


### PR DESCRIPTION
Previously, OrgMode src blocks that contained Emacs Lisp were not given special treatment by flycheck, and were thus were given obtrusive warnings that only usually apply to Lisp being written as part of an Emacs package.

This PR adds a detection mechanism for these Elisp src blocks that allows the flycheck warnings to be disabled, as in one's Doom config.