### PR TITLE
fix(notmuch): window is not a valid window error on sync end

### DIFF
--- a/modules/email/notmuch/autoload.el
+++ b/modules/email/notmuch/autoload.el
@@ -60,20 +60,17 @@
   "Sync notmuch emails with server."
   (interactive)
   (with-current-buffer (compile (+notmuch-get-sync-command))
-    (let ((w (get-buffer-window (current-buffer))))
-      (select-window w)
-      (add-hook
-       'compilation-finish-functions
-       (lambda (buf status)
-         (if (equal status "finished\n")
-             (progn
-               (delete-window w)
-               (kill-buffer buf)
-               (notmuch-refresh-all-buffers)
-               (message "Notmuch sync successful"))
-           (user-error "Failed to sync notmuch data")))
-       nil
-       'local))))
+    (add-hook
+     'compilation-finish-functions
+     (lambda (buf status)
+       (if (equal status "finished\n")
+           (progn
+             (kill-buffer buf)
+             (notmuch-refresh-all-buffers)
+             (message "Notmuch sync successful"))
+         (user-error "Failed to sync notmuch data")))
+     nil
+     'local)))
 
 ;;;###autoload
 (defun +notmuch/search-delete ()


### PR DESCRIPTION
Tidy notmuch update process
-------

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [X] It targets the develop branch
  - [X] No other pull requests exist for this issue
  - [X] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [X] Any relevant issues and PRs have been linked to
  - [X] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

Notmuch sync process is done asynchronously, but if the user switch to other buffer before update process, it complains like

```
error in process sentinel: #<window 98> is not a valid window
```

This commit simplifies cleanup process after mail syncing, and still maintain its functionality.