### PR TITLE
tweak(web): add nxml mode to LSP enabled modes

### DIFF
--- a/modules/lang/web/+html.el
+++ b/modules/lang/web/+html.el
@@ -165,5 +165,6 @@
 
 (when (featurep! +lsp)
   (add-hook! '(html-mode-local-vars-hook
-               web-mode-local-vars-hook)
+               web-mode-local-vars-hook
+               nxml-mode-local-vars-hook)
              #'lsp!))


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [X] It targets the develop branch
  - [X] No other pull requests exist for this issue
  - [X] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [X] Any relevant issues and PRs have been linked to
  - [X] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

Since lsp-mode supports XML (see
https://emacs-lsp.github.io/lsp-mode/page/lsp-xml/), it makes sense to
add nxml-mode to the list of automatically enabled lsp mode clients.