### PR TITLE
Fix +mu4e/attach-files for ranger/deer mode

### DIFF
--- a/modules/email/mu4e/autoload/email.el
+++ b/modules/email/mu4e/autoload/email.el
@@ -257,7 +257,7 @@ When otherwise called, open a dired buffer and enable `dired-mu4e-attach-ctrl-c-
          (with-current-buffer (dired location)
            (setq-local dired-mail-buffer mail-buffer)
            (dired-mu4e-attach-ctrl-c-ctrl-c 1)))))
-    ('dired-mode
+    ((or 'dired-mode 'ranger-mode 'deer-mode)
      (unless (and files-to-attach (/= 1 files-to-attach))
        (setq files-to-attach
              (delq nil


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

Simple change to the function +mu4e/attach-files so that this function works within deer and ranger mode buffers not just dired. Seems like this would be the intended behavior to interface with the ranger plugin to the dired module. 