### PR TITLE
Mu4e: improve message checks at send

### DIFF
--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -165,6 +165,21 @@
   (when (fboundp 'make-xwidget)
     (add-to-list 'mu4e-view-actions '("xwidgets view" . mu4e-action-view-with-xwidget)))
 
+  ;; Detect empty subjects, and give users an opotunity to fill something in
+  (defun +mu4e-check-for-subject ()
+    "Check that a subject is present, and prompt for a subject if not."
+    (save-excursion
+      (goto-char (point-min))
+      (search-forward "--text follows this line--")
+      (re-search-backward "^Subject:") ; this should be present no matter what
+      (let ((subject (string-trim (substring (thing-at-point 'line) 8))))
+        (when (string-empty-p subject)
+          (end-of-line)
+          (insert (read-string "Subject (optional): "))
+          (message "Sending...")))))
+
+  (add-hook 'message-send-hook #'+mu4e-check-for-subject)
+
   ;; The header view needs a certain amount of horizontal space to
   ;; actually show you all the information you want to see
   ;; so if the header view is entered from a narrow frame,

--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -321,7 +321,13 @@ Ignores all arguments and returns nil."
         org-msg-default-alternatives '((new . (utf-8 html))
                                        (reply-to-text . (utf-8))
                                        (reply-to-html . (utf-8 html)))
-        org-msg-convert-citation t)
+        org-msg-convert-citation t
+        ;; The default attachment matcher gives too many false positives,
+        ;; it's better to be more conservative. See https://regex101.com/r/EtaiSP/4.
+        org-msg-attached-file-reference
+        "see[ \t\n]\\(?:the[ \t\n]\\)?\\(?:\\w+[ \t\n]\\)\\{0,3\\}\\(?:attached\\|enclosed\\)\\|\
+(\\(?:attached\\|enclosed\\))\\|\
+\\(?:attached\\|enclosed\\)[ \t\n]\\(?:for\\|is\\)[ \t\n]")
 
   (defvar +org-msg-currently-exporting nil
     "Helper variable to indicate whether org-msg is currently exporting the org buffer to HTML.


### PR DESCRIPTION
Just two little QOL improvements here.

- `org-msg` checks for attachments using an overly simply regex, there are too many false positives. So, let's tighten that up a bit.
- Accidentally sending an email without a subject isn't nice. So, we add a hook to confirm that the user really wants to do this, and if not enter their desired subject line.