### PR TITLE
Remove 'bash strict mode' from sh template.

### DIFF
--- a/modules/editor/file-templates/templates/sh-mode/__
+++ b/modules/editor/file-templates/templates/sh-mode/__
@@ -1,4 +1,3 @@
 #!/usr/bin/env `(if (equal (file-name-extension buffer-file-name) "zsh") "zsh" "bash")`
-set -euo pipefail
 
 $0


### PR DESCRIPTION
There are good reasons not to include

    set -euo pipefail

in shell scripts. A summary and more references may be found here,
https://lists.gnu.org/archive/html/help-bash/2020-04/msg00049.html

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->