### PR TITLE
docs(config): replace broken wiki reference in default module

### DIFF
--- a/modules/config/default/README.org
+++ b/modules/config/default/README.org
@@ -12,8 +12,8 @@ The defaults module is intended as a "reasonable-defaults" module, but also as a
 reference for your own private modules. You'll find [[https://github.com/hlissner/doom-emacs-private][my private module in a
 separate repo]].
 
-Refer to the [[https://github.com/hlissner/doom-emacs/wiki/Customization][Customization page]] on the wiki for details on starting your own
-private module.
+Refer to the "Configure → Writing your own modules" section of the [[file:../../../docs/getting_started.org][Getting
+Started]] documentation for details on starting your own private module.
 #+end_quote
 
 * Table of Contents :TOC:


### PR DESCRIPTION
There is no wiki available (anymore?), but there is documentation on how to write your own module in the docs inside the repository, so reference them instead.