### PR TITLE
Replace mentions of `ob-rust` with `ob-rustic`

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -1452,7 +1452,7 @@ running ~doom sync~ to sync your config).
 You don't need ~org-babel-do-load-languages~. Doom lazy loads babel packages
 based on the language name in ~#+BEGIN_SRC~ blocks needed. As long as the babel
 plugin is installed and the plugin is named after its language (e.g.
-~#+BEGIN_SRC rust~ will load ~ob-rust~), you don't need to do anything else.
+~#+BEGIN_SRC rust~ will load ~ob-rustic~), you don't need to do anything else.
 
 There may be some special cases, however. Doom tries to handle a couple of them
 (e.g. with ob-jupyter, ob-ipython and ob-async). If you are experiencing errors

--- a/modules/lang/org/README.org
+++ b/modules/lang/org/README.org
@@ -104,7 +104,7 @@ https://www.mfoot.com/blog/2015/11/22/literate-emacs-configuration-with-org-mode
 + =:lang rst=
   + [[https://github.com/msnoigrs/ox-rst][ox-rst]]
 + =:lang rust=
-  + [[https://github.com/micanzhang/ob-rust][ob-rust]]
+  + [[https://github.com/brotzeit/rustic#org-babel][ob-rustic]]
 + =:lang scala=
   + [[https://github.com/zwild/ob-ammonite][ob-ammonite]]
 + =:editor evil=


### PR DESCRIPTION
A quick tweak. I noticed today that Doom doesn't actually use `ob-rust` anymore, although the docs still mentioned it.