### PR TITLE
fix(:lang/common-lisp): check inferior-lisp-program like "ros -Q run"

### DIFF
--- a/modules/lang/common-lisp/config.el
+++ b/modules/lang/common-lisp/config.el
@@ -73,7 +73,7 @@
       "Attempt to auto-start sly when opening a lisp buffer."
       (cond ((or (doom-temp-buffer-p (current-buffer))
                  (sly-connected-p)))
-            ((executable-find inferior-lisp-program)
+            ((executable-find (car (split-string inferior-lisp-program)))
              (let ((sly-auto-start 'always))
                (sly-auto-start)
                (add-hook 'kill-buffer-hook #'+common-lisp--cleanup-sly-maybe-h nil t)))


### PR DESCRIPTION
After I set inferior-lisp-program to "ros -Q run", I see "WARNING: Couldn't find `inferior-lisp-program' (ros -Q run)" when load a ros file.

I see fix code at common-lisp/doctor.el, and I think the same check in config.el should be fix too.