### PR TITLE
improve `:app rss` module

### DIFF
--- a/modules/app/rss/README.org
+++ b/modules/app/rss/README.org
@@ -30,6 +30,7 @@ This module has no dedicated maintainers.
 
 ** Plugins
 + [[https://github.com/skeeto/elfeed][elfeed]]
++ [[https://github.com/algernon/elfeed-goodies][elfeed-goodies]] 
 + =+org=
   + [[https://github.com/remyhonig/elfeed-org][elfeed-org]]
 
@@ -72,20 +73,21 @@ When using ~+org~ flag then configuration is easier. You can use ~org-mode~ to c
 
 ** Keybindings
 + General
-  | Key     | Mode               | Description            |
-  |---------+--------------------+------------------------|
-  | =S-RET= | Elfeed-search-mode | Open link into browser |
-  | =RET=   | Elfeed-search-mode | Open item              |
-  | =s=     | Elfeed-search-mode | Filter                 |
-  | =C-j=   | Elfeed-show-mode   | Move to next item      |
-  | =C-k=   | Elfeed-show-mode   | Move to previous item  |
+  | Key     | Mode               | Description                    |
+  |---------+--------------------+--------------------------------|
+  | =S-RET= | Elfeed-search-mode | Open link into browser         |
+  | =RET=   | Elfeed-search-mode | Open item                      |
+  | =s=     | Elfeed-search-mode | Filter                         |
+  | =C-j=   | Elfeed-show-mode   | Move to next item              |
+  | =C-k=   | Elfeed-show-mode   | Move to previous item          |
 
 + If ~:editor evil +everywhere~
   | Key | Description                 |
   |-----+-----------------------------|
   | q   | elfeed-kill-buffer          |
   | r   | elfeed-search-update--force |
- 
+  | g c | Copy link of current entry  |
+
 ** News filtering
 + Time filtering
   + ~@2-days-ago~ Past two days

--- a/modules/app/rss/autoload.el
+++ b/modules/app/rss/autoload.el
@@ -54,7 +54,14 @@
     (forward-line -1)
     (call-interactively '+rss/open)))
 
-
+;;;###autoload
+(defun +rss/copy-link ()
+  "Copy current link to clipboard."
+  (interactive)
+  (let ((link (elfeed-entry-link elfeed-show-entry)))
+    (when link
+      (kill-new link)
+      (message "Copied %s to clipboard" link))))
 ;;
 ;; Hooks
 

--- a/modules/app/rss/config.el
+++ b/modules/app/rss/config.el
@@ -80,3 +80,8 @@ easier to scroll through.")
         (dolist (file (cl-remove-if #'file-exists-p files))
           (message "elfeed-org: ignoring %S because it can't be read" file))
         (setq rmh-elfeed-org-files (cl-remove-if-not #'file-exists-p files))))))
+
+(use-package! elfeed-goodies
+  :after elfeed
+  :config
+  (elfeed-goodies/setup))

--- a/modules/app/rss/config.el
+++ b/modules/app/rss/config.el
@@ -58,7 +58,11 @@ easier to scroll through.")
     (evil-define-key 'normal elfeed-search-mode-map
       "q" #'elfeed-kill-buffer
       "r" #'elfeed-search-update--force
-      (kbd "M-RET") #'elfeed-search-browse-url)))
+      (kbd "M-RET") #'elfeed-search-browse-url)
+    (map! (:map elfeed-show-mode-map
+       :n "gc" nil
+       :n "gc" #'+rss/copy-link))))
+
 
 
 (use-package! elfeed-org

--- a/modules/app/rss/packages.el
+++ b/modules/app/rss/packages.el
@@ -2,5 +2,6 @@
 ;;; app/rss/packages.el
 
 (package! elfeed :pin "162d7d545ed41c27967d108c04aa31f5a61c8e16")
+(package! elfeed-goodies :pin "95b4ea632fbd5960927952ec8f3394eb88da4752")
 (when (featurep! +org)
   (package! elfeed-org :pin "268efdd0121fa61f63b722c30e0951c5d31224a4"))


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [X] It targets the develop branch
  - [X] No other pull requests exist for this issue
  - [X] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [X] Any relevant issues and PRs have been linked to
  - [X] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

This PR makes minor improvements to `:app rss` by adding
- the `+rss/copy-link` command and binding it to `g c` 
  This is similar to the `elfeed-search-browse-url` command but copys the link
  instead of sending it to the web browser 
- integrates `elfeed-goodies` which provides a better and more configurable UI