### PR TITLE
Add `:input bidi` module

### DIFF
--- a/docs/modules.org
+++ b/docs/modules.org
@@ -89,6 +89,7 @@ Modules that reconfigure or augment packages or features built into Emacs.
 + wanderlust =+gmail= - TODO
 
 * :input
++ [[file:../modules/input/bidi/README.org][bidi]] - (tfel ot) thgir etirw uoy gnipleh
 + [[file:../modules/input/chinese/README.org][chinese]] - TODO
 + [[file:../modules/input/japanese/README.org][japanese]] - TODO
 + [[file:../modules/input/layout/README.org][layout]] =+azerty +bepo= - TODO

--- a/init.example.el
+++ b/init.example.el
@@ -15,6 +15,7 @@
 ;;      directory (for easy access to its source code).
 
 (doom! :input
+       ;;bidi              ; (tfel ot) thgir etirw uoy gnipleh
        ;;chinese
        ;;japanese
        ;;layout            ; auie,ctsrnm is the superior home row

--- a/modules/input/bidi/README.org
+++ b/modules/input/bidi/README.org
@@ -11,12 +11,19 @@
 - [[#prerequisites][Prerequisites]]
 - [[#features][Features]]
 - [[#configuration][Configuration]]
+  - [[#using-bidi-mode][Using =+bidi-mode=]]
+  - [[#input-methods][Input Methods]]
+  - [[#fonts][Fonts]]
+  - [[#change-dictionary-language-on-bidi-buffers][Change Dictionary Language On Bidi Buffers]]
+  - [[#automatic-input-mode-switching][Automatic input mode switching]]
 - [[#troubleshooting][Troubleshooting]]
 
 * Description
 
 This module improves support for bidi (bidirectional text). It should be enabled
-if you regularly write in languages that write right-to-left.
+if you regularly write in languages that write right-to-left. It also provides
+some added configuration instructions in the README, since a lot of it is user
+specific.
 
 ** Maintainers
 + [[https://github.com/iyefrat][@iyefrat]]
@@ -32,10 +39,69 @@ This module provides no plugins.
 This module has no prerequisites.
 
 * Features
-# An in-depth list of features, how to use them, and their dependencies.
+This module provides =+bidi-mode=, a minor mode that improves the display of RTL
+text by right-aligning lines that start with an RTL language, on a per-line
+basis. Since exact use cases vary, turning on this mode is left to the user.
 
 * Configuration
-# How to configure this module, including common problems and how to address them.
+** Using =+bidi-mode=
+=+bidi-mode= is a local minor mode, meaning it has to be turned on a per-buffer
+basis.
+
+If you only need it for specific purposes, e.g. editing LaTeX
+documents, you probably want to enable it through a hook:
+
+#+begin_src emacs-lisp
+(add-hook 'TeX-mode-hook #'+bidi-mode)
+#+end_src
+
+This is also useful for adding specific functionality for when =+bidi-mode= is on.
+
+** Input Methods
+If you need bidi support, it's likely that you want to easily switch between
+English and your favorite RTL language. In order to be able to do this without
+losing access to all of the keybindings require English letters, you should use
+[[https://www.gnu.org/software/emacs/manual/html_node/emacs/Input-Methods.html][input methods]] to switch languages instead of changing the system keyboard
+language. If you use a non-qwerty layout, you will need extra configuration to
+keep the input method consistent, see [[https://github.com/ymarco/doom-emacs-config/blob/2d655adb6a35c5cd3afcba24e76327f5444cf774/dvorak-config.el#L3-L18][here]] for an example for dvorak.
+
+Toggling the input method bound to =C-\=. It prompts you to choose an input
+method the first time you do this in a session, but you bypass this by setting
+the default input method:
+
+#+begin_src emacs-lisp
+(setq default-input-method "hebrew")
+#+end_src
+
+** Fonts
+You may want to set a different font for the characters in your favorite
+RTL language, this is highly recommended in Hebrew since the default font Emacs
+uses is terrible. You can do this by changing the default font for specific
+Unicode blocks. For example:
+
+#+begin_src emacs-lisp
+(set-fontset-font t 'hebrew (font-spec :family "DejaVu Sans"))
+#+end_src
+
+Note that the Unicode block for your language might not have the same name as
+your language, e.g. Urdu characters are under the Arabic Unicode block. See the
+documentation of =set-fontset-font= for more information.
+
+** Change Dictionary Language On Bidi Buffers
+If you are only using =+bidi-mode= in specific buffers, you might want to
+automatically change the dictionary language there. For example:
+
+#+begin_src emacs-lisp
+(add-hook! '+bidi-mode-hook
+  (if +bidi-mode
+      (ispell-change-dictionary "hebrew")
+    (ispell-change-dictionary "default")))
+#+end_src
+
+** Automatic input mode switching
+You may want to Emacs to try and guess when you want it to switch input methods.
+See [[https://github.com/ymarco/doom-emacs-config/blob/2d655adb6a35c5cd3afcba24e76327f5444cf774/hebrew-latex-config.el#L7-L21][here]] and [[https://github.com/ymarco/doom-emacs-config/blob/2d655adb6a35c5cd3afcba24e76327f5444cf774/hebrew-latex-config.el#L99-L102][here]] for an example of how to get Emacs to switch to hebrew when
+entering insert mode after a hebrew character, in LaTeX buffers.
 
 * Troubleshooting
 # Common issues and their solution, or places to look for help.

--- a/modules/input/bidi/README.org
+++ b/modules/input/bidi/README.org
@@ -87,8 +87,12 @@ uses is terrible. You can do this by changing the default font for specific
 Unicode blocks. For example:
 
 #+begin_src emacs-lisp
-(set-fontset-font t 'hebrew (font-spec :family "DejaVu Sans"))
+(add-hook 'after-setting-font-hook
+          (lambda () (set-fontset-font t 'hebrew (font-spec :family "DejaVu Sans"))))
 #+end_src
+
+The hook is needed because otherwise refreshing the font with =SPC h r f= will
+undo =set-fontset-font=.
 
 Note that the Unicode block for your language might not have the same name as
 your language, e.g. Urdu characters are under the Arabic Unicode block. See the

--- a/modules/input/bidi/README.org
+++ b/modules/input/bidi/README.org
@@ -46,6 +46,11 @@ This module provides ~+bidi-mode~, a minor mode that improves the display of RTL
 text by right-aligning lines that start with an RTL language, on a per-line
 basis. Since exact use cases vary, turning on this mode is left to the user.
 
+It also provides easy font configuration for Hebrew and Arabic-derived scripts
+(Arabic, Persian, Urdu, etc.) in ~+bidi-hebrew-font~ and ~+bidi-arabic-font~.
+See [[Fonts]] for more information. If you use an RTL language that isn't covered by
+these characters, open an issue requesting support for it.
+
 * Configuration
 ** Using ~+bidi-mode~
 ~+bidi-mode~ is a local minor mode, meaning it has to be turned on a per-buffer

--- a/modules/input/bidi/README.org
+++ b/modules/input/bidi/README.org
@@ -81,22 +81,27 @@ the default input method:
 #+end_src
 
 ** Fonts
-You may want to set a different font for the characters in your favorite
-RTL language, this is highly recommended in Hebrew since the default font Emacs
-uses is terrible. You can do this by changing the default font for specific
-Unicode blocks. For example:
+Many good English fonts do not have great coverage for RTL languages, especially
+for Hebrew and monospace fonts. To this end, we provide ~+bidi-hebrew-font~ and
+~+bidi-arabic-font~ as an easy way to override the default fonts but only for
+Hebrew and Arabic characters. They are set by default to =DejaVu Sans=, since
+it has pretty decent looking Hebrew and Arabic characters.
+
+Note, that if you are writing in an Arabic-derived script, such as Persian,
+Urdu, or Pashto, you may want to change ~+bidi-arabic-font~ to one specific to
+your language, especially if you want your script to be written in the Nastaliq
+style.
+
+If you use an RTL language the script of which isn't covered by the =hebrew= or
+=arabic= unicode blocks, you can set a font override manually. For example:
 
 #+begin_src emacs-lisp
 (add-hook 'after-setting-font-hook
-          (lambda () (set-fontset-font t 'hebrew (font-spec :family "DejaVu Sans"))))
+          (lambda () (set-fontset-font t 'syriac (font-spec :family "DejaVu Sans"))))
 #+end_src
 
-The hook is needed because otherwise refreshing the font with =SPC h r f= will
-undo =set-fontset-font=.
-
-Note that the Unicode block for your language might not have the same name as
-your language, e.g. Urdu characters are under the Arabic Unicode block. See the
-documentation of =set-fontset-font= for more information.
+Make sure to use the correct unicode block name, see the documentation of
+~set-fontset-font~ for more details.
 
 ** Change Dictionary Language On Bidi Buffers
 If you are only using =+bidi-mode= in specific buffers, you might want to

--- a/modules/input/bidi/README.org
+++ b/modules/input/bidi/README.org
@@ -14,6 +14,7 @@
   - [[#using-bidi-mode][Using =+bidi-mode=]]
   - [[#input-methods][Input Methods]]
   - [[#fonts][Fonts]]
+    - [[#smart-fontify][Smart Fontify]]
   - [[#change-dictionary-language-on-bidi-buffers][Change Dictionary Language On Bidi Buffers]]
   - [[#automatic-input-mode-switching][Automatic input mode switching]]
 - [[#troubleshooting][Troubleshooting]]
@@ -102,6 +103,16 @@ If you use an RTL language the script of which isn't covered by the =hebrew= or
 
 Make sure to use the correct unicode block name, see the documentation of
 ~set-fontset-font~ for more details.
+
+*** Smart Fontify
+Since good bidi fonts are often not monospace (as is the default =DejaVu Sans=),
+It usually looks better to have the surrounding spaces and punctuation in the
+use the bidi font as well. This is the default behaviour, but you can turn this
+off by setting:
+
+#+begin_src emacs-lisp
+(setq +bidi-want-smart-fontify nil)
+#+end_src
 
 ** Change Dictionary Language On Bidi Buffers
 If you are only using =+bidi-mode= in specific buffers, you might want to

--- a/modules/input/bidi/README.org
+++ b/modules/input/bidi/README.org
@@ -11,7 +11,7 @@
 - [[#prerequisites][Prerequisites]]
 - [[#features][Features]]
 - [[#configuration][Configuration]]
-  - [[#using-bidi-mode][Using =+bidi-mode=]]
+  - [[#using-bidi-mode][Using ~+bidi-mode~]]
   - [[#force-rtl-text-alignment][Force RTL text alignment]]
   - [[#input-methods][Input Methods]]
   - [[#fonts][Fonts]]
@@ -42,16 +42,16 @@ This module provides no plugins.
 This module has no prerequisites.
 
 * Features
-This module provides =+bidi-mode=, a minor mode that improves the display of RTL
+This module provides ~+bidi-mode~, a minor mode that improves the display of RTL
 text by right-aligning lines that start with an RTL language, on a per-line
 basis. Since exact use cases vary, turning on this mode is left to the user.
 
 * Configuration
-** Using =+bidi-mode=
-=+bidi-mode= is a local minor mode, meaning it has to be turned on a per-buffer
+** Using ~+bidi-mode~
+~+bidi-mode~ is a local minor mode, meaning it has to be turned on a per-buffer
 basis.
 
-If you want to have it on for all buffers, use =+bidi-global-mode=:
+If you want to have it on for all buffers, use ~+bidi-global-mode~:
 
 #+begin_src emacs-lisp
 ;; ~/.doom.d/config.el
@@ -65,12 +65,12 @@ documents, you probably want to enable it through a hook:
 (add-hook 'TeX-mode-hook #'+bidi-mode)
 #+end_src
 
-This is also useful for adding specific functionality for when =+bidi-mode= is on.
+This is also useful for adding specific functionality for when ~+bidi-mode~ is on.
 
 ** Force RTL text alignment
-By default, =+bidi-mode= will align paragraphs by the first character with
+By default, ~+bidi-mode~ will align paragraphs by the first character with
 strong directionality. If you want to force all paragraphs to be aligned
-right-to-left when =+bidi-mode= is on, add the following to your config:
+right-to-left when ~+bidi-mode~ is on, add the following to your config:
 
 #+begin_src emacs-lisp
 (setq +bidi-paragraph-direction 'right-to-left)
@@ -126,7 +126,7 @@ off by setting:
 #+end_src
 
 ** Change Dictionary Language On Bidi Buffers
-If you are only using =+bidi-mode= in specific buffers, you might want to
+If you are only using ~+bidi-mode~ in specific buffers, you might want to
 automatically change the dictionary language there. For example:
 
 #+begin_src emacs-lisp

--- a/modules/input/bidi/README.org
+++ b/modules/input/bidi/README.org
@@ -18,6 +18,7 @@
   - [[#change-dictionary-language-on-bidi-buffers][Change Dictionary Language On Bidi Buffers]]
   - [[#automatic-input-mode-switching][Automatic input mode switching]]
 - [[#troubleshooting][Troubleshooting]]
+  - [[#nastaliq-font-display-bug][Nastaliq font display bug]]
 
 * Description
 
@@ -131,4 +132,7 @@ See [[https://github.com/ymarco/doom-emacs-config/blob/2d655adb6a35c5cd3afcba24e
 entering insert mode after a hebrew character, in LaTeX buffers.
 
 * Troubleshooting
-# Common issues and their solution, or places to look for help.
+
+** Nastaliq font display bug
+If Emacs is having trouble properly displaying a Nastaliq font, try using one of
+[[https://urdufonts.net/fonts/jameel-noori-nastaleeq-regular][these]] [[https://urdufonts.net/fonts/alvi-nastaleeq-regular][two]] fonts for ~+bidi-arabic-font~.

--- a/modules/input/bidi/README.org
+++ b/modules/input/bidi/README.org
@@ -48,6 +48,13 @@ basis. Since exact use cases vary, turning on this mode is left to the user.
 =+bidi-mode= is a local minor mode, meaning it has to be turned on a per-buffer
 basis.
 
+If you want to have it on for all buffers, use =+bidi-global-mode=:
+
+#+begin_src emacs-lisp
+;; ~/.doom.d/config.el
+(+bidi-global-mode 1)
+#+end_src
+
 If you only need it for specific purposes, e.g. editing LaTeX
 documents, you probably want to enable it through a hook:
 

--- a/modules/input/bidi/README.org
+++ b/modules/input/bidi/README.org
@@ -81,6 +81,9 @@ right-to-left when ~+bidi-mode~ is on, add the following to your config:
 (setq +bidi-paragraph-direction 'right-to-left)
 #+end_src
 
+*Warning:* do not do this if you are using ~+bidi-global-mode~, it will mess up
+all of the buffers in Emacs that use English, including things like the =M-x= buffer.
+
 ** Input Methods
 If you need bidi support, it's likely that you want to easily switch between
 English and your favorite RTL language. In order to be able to do this without

--- a/modules/input/bidi/README.org
+++ b/modules/input/bidi/README.org
@@ -12,6 +12,7 @@
 - [[#features][Features]]
 - [[#configuration][Configuration]]
   - [[#using-bidi-mode][Using =+bidi-mode=]]
+  - [[#force-rtl-text-alignment][Force RTL text alignment]]
   - [[#input-methods][Input Methods]]
   - [[#fonts][Fonts]]
     - [[#smart-fontify][Smart Fontify]]
@@ -65,6 +66,15 @@ documents, you probably want to enable it through a hook:
 #+end_src
 
 This is also useful for adding specific functionality for when =+bidi-mode= is on.
+
+** Force RTL text alignment
+By default, =+bidi-mode= will align paragraphs by the first character with
+strong directionality. If you want to force all paragraphs to be aligned
+right-to-left when =+bidi-mode= is on, add the following to your config:
+
+#+begin_src emacs-lisp
+(setq +bidi-paragraph-direction 'right-to-left)
+#+end_src
 
 ** Input Methods
 If you need bidi support, it's likely that you want to easily switch between

--- a/modules/input/bidi/README.org
+++ b/modules/input/bidi/README.org
@@ -1,0 +1,41 @@
+#+TITLE:   input/bidi
+#+DATE:    September 28, 2021
+#+SINCE:   v3.0.0
+#+STARTUP: inlineimages nofold
+
+* Table of Contents :TOC_3:noexport:
+- [[#description][Description]]
+  - [[#maintainers][Maintainers]]
+  - [[#module-flags][Module Flags]]
+  - [[#plugins][Plugins]]
+- [[#prerequisites][Prerequisites]]
+- [[#features][Features]]
+- [[#configuration][Configuration]]
+- [[#troubleshooting][Troubleshooting]]
+
+* Description
+
+This module improves support for bidi (bidirectional text). It should be enabled
+if you regularly write in languages that write right-to-left.
+
+** Maintainers
++ [[https://github.com/iyefrat][@iyefrat]]
++ [[https://github.com/ymarco][@ymarco]]
+
+** Module Flags
+This module provides no flags.
+
+** Plugins
+This module provides no plugins.
+
+* Prerequisites
+This module has no prerequisites.
+
+* Features
+# An in-depth list of features, how to use them, and their dependencies.
+
+* Configuration
+# How to configure this module, including common problems and how to address them.
+
+* Troubleshooting
+# Common issues and their solution, or places to look for help.

--- a/modules/input/bidi/config.el
+++ b/modules/input/bidi/config.el
@@ -3,6 +3,20 @@
 (defvar +bidi-mode-map (make-sparse-keymap)
   "Keymap for `+bidi-mode'.")
 
+(defvar +bidi-hebrew-font (font-spec :family "DejaVu Sans")
+  "Overriding font for hebrew script.
+Must be a `font-spec', see `doom-font' for examples.
+
+WARNING: if you specify a size for this font it will hard-lock any usage of this
+font to that size. It's rarely a good idea to do so!")
+
+(defvar +bidi-arabic-font (font-spec :family "DejaVu Sans")
+  "Overriding font for arabic and arabic-derived scripts.
+Must be a `font-spec', see `doom-font' for examples.
+
+WARNING: if you specify a size for this font it will hard-lock any usage of this
+font to that size. It's rarely a good idea to do so!")
+
 ;;;###autoload
 (define-minor-mode +bidi-mode
   "Minor mode for using bidirectional text in a buffer.
@@ -23,3 +37,8 @@ easier."
           bidi-inhibit-bpa t)))
 
 (define-globalized-minor-mode +bidi-global-mode +bidi-mode +bidi-mode)
+
+(add-hook! 'after-setting-font-hook
+  (defun +bidi-set-fonts-h ()
+    (set-fontset-font t 'hebrew +bidi-hebrew-font)
+    (set-fontset-font t 'arabic +bidi-arabic-font)))

--- a/modules/input/bidi/config.el
+++ b/modules/input/bidi/config.el
@@ -21,3 +21,5 @@ easier."
           bidi-paragraph-separate-re nil
           bidi-paragraph-start-re nil
           bidi-inhibit-bpa t)))
+
+(define-globalized-minor-mode +bidi-global-mode +bidi-mode +bidi-mode)

--- a/modules/input/bidi/config.el
+++ b/modules/input/bidi/config.el
@@ -78,4 +78,6 @@ easier."
 (add-hook! 'after-setting-font-hook
   (defun +bidi-set-fonts-h ()
     (set-fontset-font t 'hebrew +bidi-hebrew-font)
-    (set-fontset-font t 'arabic +bidi-arabic-font)))
+    (set-fontset-font t 'arabic +bidi-arabic-font)
+    (set-face-font '+bidi-arabic-face +bidi-arabic-font)
+    (set-face-font '+bidi-hebrew-face +bidi-hebrew-font)))

--- a/modules/input/bidi/config.el
+++ b/modules/input/bidi/config.el
@@ -1,0 +1,23 @@
+;;; input/bidi/config.el -*- lexical-binding: t; -*-
+
+(defvar +bidi-mode-map (make-sparse-keymap)
+  "Keymap for `+bidi-mode'.")
+
+;;;###autoload
+(define-minor-mode +bidi-mode
+  "Minor mode for using bidirectional text in a buffer.
+
+Note that the whole buffer doesn't have to contain any
+bidirectional text at all, this mode just makes bidi editing
+easier."
+  :keymap +bidi-mode-map
+  (if +bidi-mode
+      (progn
+        (setq bidi-paragraph-direction nil   ; Do treat +Bidi as right-to-left
+              bidi-paragraph-separate-re "^" ; No need for empty lines to switch alignment
+              bidi-paragraph-start-re "^"    ; ^
+              bidi-inhibit-bpa nil))         ; Better bidi paren logic
+    (setq bidi-paragraph-direction 'left-to-right
+          bidi-paragraph-separate-re nil
+          bidi-paragraph-start-re nil
+          bidi-inhibit-bpa t)))

--- a/modules/input/bidi/config.el
+++ b/modules/input/bidi/config.el
@@ -41,6 +41,14 @@ when `+bidi-mode' is on."
   "`font-lock' keywords matching spaces and punctuation after RTL characters.
 See the variable `font-lock-keywords' for information on the format.")
 
+(defcustom +bidi-paragraph-direction nil
+  "The value of `bidi-paragragh-direction' when `+bidi-mode' is on.
+See the `bidi-paragraph-direction' for more info.'"
+  :type '(choice
+          (const :tag "Left to Right" left-to-right)
+          (const :tag "Right to Left" right-to-left)
+          (const :tag "Dynamic, according to paragraph text" nil)))
+
 ;;;###autoload
 (define-minor-mode +bidi-mode
   "Minor mode for using bidirectional text in a buffer.
@@ -51,7 +59,7 @@ easier."
   :keymap +bidi-mode-map
   (if +bidi-mode
       (progn
-        (setq bidi-paragraph-direction nil   ; Do treat +Bidi as right-to-left
+        (setq bidi-paragraph-direction +bidi-paragraph-direction   ; Better paragraph alignment
               bidi-paragraph-separate-re "^" ; No need for empty lines to switch alignment
               bidi-paragraph-start-re "^"    ; ^
               bidi-inhibit-bpa nil)          ; Better bidi paren logic

--- a/modules/input/bidi/config.el
+++ b/modules/input/bidi/config.el
@@ -43,7 +43,9 @@ See the variable `font-lock-keywords' for information on the format.")
 
 (defcustom +bidi-paragraph-direction nil
   "The value of `bidi-paragragh-direction' when `+bidi-mode' is on.
-See the `bidi-paragraph-direction' for more info.'"
+See the `bidi-paragraph-direction' for more info.
+
+Warning: do not change this if you are using `+bidi-global-mode'.'"
   :type '(choice
           (const :tag "Left to Right" left-to-right)
           (const :tag "Right to Left" right-to-left)


### PR DESCRIPTION
This pull requests adds better support for bidirectional and rtl text. It provides:
- a buffer-local `+bidi-mode` that undoes doom's anti-bidi optimizations, and sets the bidi initial alignment algorithm to start from scratch each line, so there is no need for empty lines to separate paragraphs.
- a global variant `+bidi-global-mode` if people just want it on all the time (off for read-only buffers due to fontification shenanigans)
- `+bidi-(hebrew|arabic)-font` (and faces) for easily setting a better font for these languages
- `+bidi-want-smart-fontify` uses for using said fonts on spaces and punctuation after RTL characters, since in hebrew at least there are almost no good monospace fonts
- instructions in the readme on further customization users probably want to make that can't be universalized in the module (such as language specific fonts)
- `+bidi-paragraph-direction` to customize what `bidi-paragraph-direction` is set to when `+bidi-mode` is on. (should not be used with `+bidi-global-mode`).
- There is currently an issue with the way evil handles arrow key movement (which imo should be visual rather than logical, the way Emacs does it). This is something that I'll fix upstream.

since and date tags will be corrected once the module is approved