### PR TITLE
feat(notmuch): allow notmuch module without (:ui workspaces)

### DIFF
--- a/modules/email/notmuch/autoload.el
+++ b/modules/email/notmuch/autoload.el
@@ -4,16 +4,16 @@
 (defun =notmuch ()
   "Activate (or switch to) `notmuch' in its workspace."
   (interactive)
-  (unless (featurep! :ui workspaces)
-    (user-error ":ui workspaces is required, but disabled"))
   (condition-case-unless-debug e
       (progn
-        (+workspace-switch "*MAIL*" t)
+        (when (featurep! :ui workspaces)
+          (+workspace-switch "*MAIL*" t))
         (if-let* ((buf (cl-find-if (lambda (it) (string-match-p "^\\*notmuch" (buffer-name (window-buffer it))))
                                    (doom-visible-windows))))
             (select-window (get-buffer-window buf))
           (funcall +notmuch-home-function))
-        (+workspace/display))
+        (when (featurep! :ui workspaces)
+          (+workspace/display)))
     ('error
      (+notmuch/quit)
      (signal (car e) (cdr e)))))
@@ -28,7 +28,8 @@
   (interactive)
   ;; (+popup/close (get-buffer-window "*notmuch-hello*"))
   (doom-kill-matching-buffers "^\\*notmuch")
-  (+workspace/delete "*MAIL*"))
+  (when (featurep! :ui workspaces)
+    (+workspace/delete "*MAIL*")))
 
 (defun +notmuch-get-sync-command ()
   "Return a shell command string to synchronize your notmuch mmail with."


### PR DESCRIPTION
Remove the dependency of (:ui workspaces) from the notmuch module

The notmuch module had a hard-dep on the (:ui workspaces) module which was unnecessary; these (very simple) changes fix that.
(I'm calling it a "feat" since it introduces new behavior (debatable))
