### PR TITLE
fix(mu4e): minor errors with org-msg LaTeX eqns

### DIFF
--- a/modules/email/mu4e/autoload/advice.el
+++ b/modules/email/mu4e/autoload/advice.el
@@ -55,78 +55,78 @@ clicked."
                          (/ 1.0 (plist-get org-format-latex-options :scale))))))
 
 ;;;###autoload
-  (defun +org-html-latex-fragment-scaled-a (latex-fragment _contents info)
-    "Transcode a LATEX-FRAGMENT object from Org to HTML.
+(defun +org-html-latex-fragment-scaled-a (latex-fragment _contents info)
+  "Transcode a LATEX-FRAGMENT object from Org to HTML.
 CONTENTS is nil.  INFO is a plist holding contextual information.
 
 This differs from `org-html-latex-fragment' in that it uses the LaTeX fragment
 as a meaningful alt value, applies a class to indicate what sort of fragment it is
 (latex-fragment-inline or latex-fragment-block), and (on Linux) scales the image to
 account for the value of :scale in `org-format-latex-options'."
-    (let ((latex-frag (org-element-property :value latex-fragment))
-          (processing-type (plist-get info :with-latex)))
-      (cond
-       ((memq processing-type '(t mathjax))
-        (org-html-format-latex latex-frag 'mathjax info))
-       ((eq processing-type 'html)
-        (org-html-format-latex latex-frag 'html info))
-       ((assq processing-type org-preview-latex-process-alist)
-        (let ((formula-link
-               (org-html-format-latex latex-frag processing-type info)))
-          (when (and formula-link (string-match "file:\\([^]]*\\)" formula-link))
-            (let* ((source (org-export-file-uri (match-string 1 formula-link)))
-                   (attributes (append (list :alt latex-frag
-                                             :class
-                                             (concat "latex-fragment-"
-                                                     (if (equal "\\(" (substring latex-frag 0 2))
-                                                         "inline" "block")))
-                                       (when (memq processing-type '(dvipng convert))
-                                         (+org-msg-img-scale-css source)))))
-              (org-html--format-image source attributes info)))))
-       (t latex-frag))))
+  (let ((latex-frag (org-element-property :value latex-fragment))
+        (processing-type (plist-get info :with-latex)))
+    (cond
+     ((memq processing-type '(t mathjax))
+      (org-html-format-latex latex-frag 'mathjax info))
+     ((eq processing-type 'html)
+      (org-html-format-latex latex-frag 'html info))
+     ((assq processing-type org-preview-latex-process-alist)
+      (let ((formula-link
+             (org-html-format-latex latex-frag processing-type info)))
+        (when (and formula-link (string-match "file:\\([^]]*\\)" formula-link))
+          (let* ((source (org-export-file-uri (match-string 1 formula-link)))
+                 (attributes (append (list :alt latex-frag
+                                           :class
+                                           (concat "latex-fragment-"
+                                                   (if (equal "\\(" (substring latex-frag 0 2))
+                                                       "inline" "block")))
+                                     (when (memq processing-type '(dvipng convert))
+                                       (+org-msg-img-scale-css source)))))
+            (org-html--format-image source attributes info)))))
+     (t latex-frag))))
 
 ;;;###autoload
-  (defun +org-html-latex-environment-scaled-a (latex-environment _contents info)
-    "Transcode a LATEX-ENVIRONMENT element from Org to HTML.
+(defun +org-html-latex-environment-scaled-a (latex-environment _contents info)
+  "Transcode a LATEX-ENVIRONMENT element from Org to HTML.
 CONTENTS is nil.  INFO is a plist holding contextual information.
 
 This differs from `org-html-latex-environment' in that (on Linux) it
 scales the image to account for the value of :scale in `org-format-latex-options'."
-    (let ((processing-type (plist-get info :with-latex))
-          (latex-frag (org-remove-indentation
-                       (org-element-property :value latex-environment)))
-          (attributes (org-export-read-attribute :attr_html latex-environment))
-          (label (and (org-element-property :name latex-environment)
-                      (org-export-get-reference latex-environment info)))
-          (caption (and (org-html--latex-environment-numbered-p latex-environment)
-                        (number-to-string
-                         (org-export-get-ordinal
-                          latex-environment info nil
-                          (lambda (l _)
-                            (and (org-html--math-environment-p l)
-                                 (org-html--latex-environment-numbered-p l))))))))
-      (plist-put attributes :class "latex-environment")
-      (cond
-       ((memq processing-type '(t mathjax))
-        (org-html-format-latex
-         (if (org-string-nw-p label)
-             (replace-regexp-in-string "\\`.*"
-                                       (format "\\&\n\\\\label{%s}" label)
-                                       latex-frag)
-           latex-frag)
-         'mathjax info))
-       ((assq processing-type org-preview-latex-process-alist)
-        (let ((formula-link
-               (org-html-format-latex
-                (org-html--unlabel-latex-environment latex-frag)
-                processing-type info)))
-          (when (and formula-link (string-match "file:\\([^]]*\\)" formula-link))
-            (let ((source (org-export-file-uri (match-string 1 formula-link))))
-              (org-html--wrap-latex-environment
-               (org-html--format-image source
-                                       (append attributes
-                                               (when (memq processing-type '(dvipng convert))
-                                                 (+org-msg-img-scale-css source)))
-                                       info)
-               info caption label)))))
-       (t (org-html--wrap-latex-environment latex-frag info caption label)))))
+  (let ((processing-type (plist-get info :with-latex))
+        (latex-frag (org-remove-indentation
+                     (org-element-property :value latex-environment)))
+        (attributes (org-export-read-attribute :attr_html latex-environment))
+        (label (and (org-element-property :name latex-environment)
+                    (org-export-get-reference latex-environment info)))
+        (caption (and (org-html--latex-environment-numbered-p latex-environment)
+                      (number-to-string
+                       (org-export-get-ordinal
+                        latex-environment info nil
+                        (lambda (l _)
+                          (and (org-html--math-environment-p l)
+                               (org-html--latex-environment-numbered-p l))))))))
+    (plist-put attributes :class "latex-environment")
+    (cond
+     ((memq processing-type '(t mathjax))
+      (org-html-format-latex
+       (if (org-string-nw-p label)
+           (replace-regexp-in-string "\\`.*"
+                                     (format "\\&\n\\\\label{%s}" label)
+                                     latex-frag)
+         latex-frag)
+       'mathjax info))
+     ((assq processing-type org-preview-latex-process-alist)
+      (let ((formula-link
+             (org-html-format-latex
+              (org-html--unlabel-latex-environment latex-frag)
+              processing-type info)))
+        (when (and formula-link (string-match "file:\\([^]]*\\)" formula-link))
+          (let ((source (org-export-file-uri (match-string 1 formula-link))))
+            (org-html--wrap-latex-environment
+             (org-html--format-image source
+                                     (append attributes
+                                             (when (memq processing-type '(dvipng convert))
+                                               (+org-msg-img-scale-css source)))
+                                     info)
+             info caption label)))))
+     (t (org-html--wrap-latex-environment latex-frag info caption label)))))

--- a/modules/email/mu4e/autoload/advice.el
+++ b/modules/email/mu4e/autoload/advice.el
@@ -39,9 +39,9 @@ clicked."
   "For a given IMG-URI, use imagemagick to find its width."
   (if +org-msg-currently-exporting
       (when (and (not IS-WINDOWS)) ; relies on posix path
-        (let ((with-call (and (executable-find "identify")
-                              (doom-call-process "identify" "-format" "%w"
-                                                 (substring img-uri 7))))) ; 7=(length "file://")
+        (let ((width-call (and (executable-find "identify")
+                               (doom-call-process "identify" "-format" "%w"
+                                                  (substring img-uri 7))))) ; 7=(length "file://")
           (unless width-call
             (setq width-call (doom-call-process "file" (substring img-uri 7)))
             (setcdr width-call (replace-regexp-in-string "^.*image data, \\([0-9]+\\).*$" "\\1" (cdr width-call)))
@@ -74,14 +74,14 @@ account for the value of :scale in `org-format-latex-options'."
         (let ((formula-link
                (org-html-format-latex latex-frag processing-type info)))
           (when (and formula-link (string-match "file:\\([^]]*\\)" formula-link))
-            (let ((source (org-export-file-uri (match-string 1 formula-link)))
-                  (attributes (append (list :alt latex-frag
-                                            :class
-                                            (concat "latex-fragment-"
-                                                    (if (equal "\\(" (substring latex-frag 0 2))
-                                                        "inline" "block")))
-                                      (when (memq processing-type '(dvipng convert))
-                                        (+org-msg-img-scale-css source)))))
+            (let* ((source (org-export-file-uri (match-string 1 formula-link)))
+                   (attributes (append (list :alt latex-frag
+                                             :class
+                                             (concat "latex-fragment-"
+                                                     (if (equal "\\(" (substring latex-frag 0 2))
+                                                         "inline" "block")))
+                                       (when (memq processing-type '(dvipng convert))
+                                         (+org-msg-img-scale-css source)))))
               (org-html--format-image source attributes info)))))
        (t latex-frag))))
 


### PR DESCRIPTION
A typo and a missing `*` break the creation and insertion of LaTeX images. This PR is literally just two characters being changed + indent changes. I did notice that the indentation was a bit off though in the file, so I've added a second commit which is just me running `= a G` on the file.

Closes #5416.
