### PR TITLE
feat(web): add tailwind lsp support

### DIFF
--- a/modules/lang/web/+tailwind.el
+++ b/modules/lang/web/+tailwind.el
@@ -4,11 +4,10 @@
   :when (and (featurep! +lsp) (featurep! +tailwind))
   :after lsp-mode
   :init
-  (setq lsp-tailwindcss-add-on-mode t
-        lsp-tailwindcss-emmet-completions (featurep 'emmet-mode))
+  (setq lsp-tailwindcss-add-on-mode t)
   :config
-  (delq! 'typescript-mode lsp-tailwindcss-major-modes)
-  (add-to-list 'lsp-tailwindcss-major-modes 'typescript-tsx-mode))
+  (setq lsp-tailwindcss-major-modes '(web-mode css-mode rjsx-mode typescript-tsx-mode)
+        lsp-tailwindcss-emmet-completions (featurep 'emmet-mode)))
 
 (set-docsets! '(web-mode css-mode rjsx-mode typescript-tsx-mode)
   :add "Tailwind_CSS")

--- a/modules/lang/web/+tailwind.el
+++ b/modules/lang/web/+tailwind.el
@@ -9,3 +9,6 @@
   :config
   (delq! 'typescript-mode lsp-tailwindcss-major-modes)
   (add-to-list 'lsp-tailwindcss-major-modes 'typescript-tsx-mode))
+
+(set-docsets! '(web-mode css-mode rjsx-mode typescript-tsx-mode)
+  :add "Tailwind_CSS")

--- a/modules/lang/web/+tailwind.el
+++ b/modules/lang/web/+tailwind.el
@@ -7,4 +7,5 @@
   (setq lsp-tailwindcss-add-on-mode t
         lsp-tailwindcss-emmet-completions (featurep 'emmet-mode))
   :config
+  (delq! 'typescript-mode lsp-tailwindcss-major-modes)
   (add-to-list 'lsp-tailwindcss-major-modes 'typescript-tsx-mode))

--- a/modules/lang/web/+tailwind.el
+++ b/modules/lang/web/+tailwind.el
@@ -1,0 +1,9 @@
+;;; lang/web/+tailwind.el -*- lexical-binding: t; -*-
+
+(use-package! lsp-tailwindcss
+  :when (and (featurep! +lsp) (featurep! +tailwind))
+  :after lsp-mode
+  :init
+  (setq lsp-tailwindcss-emmet-completions (featurep 'emmet-mode))
+  :config
+  (add-to-list 'lsp-tailwindcss-major-modes 'typescript-tsx-mode))

--- a/modules/lang/web/+tailwind.el
+++ b/modules/lang/web/+tailwind.el
@@ -4,6 +4,7 @@
   :when (and (featurep! +lsp) (featurep! +tailwind))
   :after lsp-mode
   :init
-  (setq lsp-tailwindcss-emmet-completions (featurep 'emmet-mode))
+  (setq lsp-tailwindcss-add-on-mode t
+        lsp-tailwindcss-emmet-completions (featurep 'emmet-mode))
   :config
   (add-to-list 'lsp-tailwindcss-major-modes 'typescript-tsx-mode))

--- a/modules/lang/web/config.el
+++ b/modules/lang/web/config.el
@@ -2,7 +2,8 @@
 
 (load! "+html")
 (load! "+css")
-(load! "+tailwind")
+(when (featurep! +tailwind)
+  (load! "+tailwind"))
 
 
 (use-package! emmet-mode

--- a/modules/lang/web/config.el
+++ b/modules/lang/web/config.el
@@ -2,6 +2,7 @@
 
 (load! "+html")
 (load! "+css")
+(load! "+tailwind")
 
 
 (use-package! emmet-mode

--- a/modules/lang/web/packages.el
+++ b/modules/lang/web/packages.el
@@ -14,6 +14,10 @@
 (package! css-mode :built-in t)
 (package! less-css-mode :built-in t :pin "c7fa3d56d83206b28657f2e56439dc62280a2bf2")
 
+;; LSP
+(when (and (featurep! +lsp) (featurep! +tailwind))
+  (package! lsp-tailwindcss :pin "bfcae3f53a500b712f503f5a16d25502a480a892"))
+
 (package! sass-mode :pin "247a0d4b509f10b28e4687cd8763492bca03599b")
 (package! stylus-mode :pin "111460b056838854e470a6383041a99f843b93ee")
 (package! sws-mode :pin "111460b056838854e470a6383041a99f843b93ee")


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [x] No other pull requests exist for this issue
  - [x] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [x] Any relevant issues and PRs have been linked to
  - [x] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

Add [TailwindCSS](https://tailwindcss.com) LSP support.

Using [lsp-tailwindcss](https://github.com/merrickluo/lsp-tailwindcss), which uses [@tailwindcss/language-server](https://www.npmjs.com/package/@tailwindcss/language-server). It works as an add-on LSP and can work other LSP servers together.

I'm wondering if it's preferable to include this feature in `:lang web` because it also affects `rjsx-mode`, `typescript-tsx-mode`.

**TODOs**

- [x] ~Remove` `typescript-mode` from `lsp-tailwindcss-major-modes`~
- [x] ~Add` `Tailwind_CSS` to the docset lists.~
- [ ] Supress warning: `Warning (lsp-mode): Unknown request method: @/tailwindCSS/getDocumentSymbols`
  → I'm still investigating. It's perhaps lsp-mode's issue.
- [x] ~Check if there's a way to preview the color of Tailwind color classes in company-box~
  There's no way to set color per completion candidate. We can preview the colors in document by enabling lsp-mode's  `textDocument/documentColor` feature. But it's explicitly disabled in Doom Emacs, so I left it as it was.
- [x] `lsp-tailwindcss--activate-p` in upstream may slow down other LSP initializations because it performs file reads before checking the major mode.
  Code: https://github.com/merrickluo/lsp-tailwindcss/blob/master/lsp-tailwindcss.el#L215-L223
  PR: https://github.com/merrickluo/lsp-tailwindcss/pull/25
  → Merged!