### PR TITLE
Bump format-all package

### DIFF
--- a/modules/editor/format/packages.el
+++ b/modules/editor/format/packages.el
@@ -1,4 +1,4 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; editor/format/packages.el
 
-(package! format-all :pin "47d862d40a088ca089c92cd393c6dca4628f87d3")
+(package! format-all :pin "772beb9acc3152cce10767ebba545c7af52b76e4")


### PR DESCRIPTION
I cannot pull up the convention doc as the site says "Rip and tear..." so I am guessing it is down 🤞 

This updates `format-all` to the latest commit. There has been some fixes to prevent the annoying popup window on syntax error: `Error (before-save-hook): Error running hook "format-all-buffer--from-hook" because: (error Unable to format due to syntax error)` plus added support for other formatters.

