### PR TITLE
Scoop install instructions: `scoop bucket add` requires git to work

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -394,10 +394,11 @@ choco install fd llvm
 #+END_SRC
 
 Scoop will work too, but because Emacs is a GUI application you'll need to
-enable the 'extras' Scoop bucket:
+enable the 'extras' Scoop bucket, and =scoop bucket add= requires git:
 #+BEGIN_SRC sh
+scoop install git
 scoop bucket add extras
-scoop install git emacs ripgrep
+scoop install emacs ripgrep
 # Optional dependencies
 scoop install fd llvm
 #+END_SRC


### PR DESCRIPTION
Following current installation instructions for Windows with scoop gave me this:

    PS C:\Users\teodorlu> scoop bucket add extras
    Git is required for buckets. Run 'scoop install git' and try again.

Installing git before running `scoop bucket add extras` worked fine.

The text in the docs can probably be improved, feel free to make suggestions.