### PR TITLE
feat(org): add binding for `org-clone-subtree-with-time-shift`

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -924,6 +924,7 @@ between the two."
         (:prefix ("s" . "tree/subtree")
          "a" #'org-toggle-archive-tag
          "b" #'org-tree-to-indirect-buffer
+         "c" #'org-clone-subtree-with-time-shift
          "d" #'org-cut-subtree
          "h" #'org-promote-subtree
          "j" #'org-move-subtree-down


### PR DESCRIPTION
Adds an additional org binding, useful for repeated tasks with minor variations in time or name.