### PR TITLE
fix(dired): ranger-travel bug

### DIFF
--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -102,6 +102,26 @@ we have to clean it up ourselves."
       (with-current-buffer (window-buffer ranger-preview-window)
         (local-unset-key [mouse-1]))))
 
+  (defadvice! +dired--ranger-travel-a ()
+    "Temprorary fix for this function until ralesi/ranger.el#236 gets merged."
+    :override #'ranger-travel
+    (interactive)
+    (let ((prompt "Travel: "))
+      (cond
+       ((bound-and-true-p helm-mode)
+        (ranger-find-file (helm-read-file-name prompt)))
+       ((bound-and-true-p ivy-mode)
+        (ivy-read prompt 'read-file-name-internal
+                  :matcher #'counsel--find-file-matcher
+                  :action
+                  (lambda (x)
+                    (with-ivy-window
+                     (ranger-find-file (expand-file-name x default-directory))))))
+       ((bound-and-true-p ido-mode)
+        (ranger-find-file (ido-read-file-name prompt)))
+       (t
+        (ranger-find-file (read-file-name prompt))))))
+
   (setq ranger-cleanup-on-disable t
         ranger-excluded-extensions '("mkv" "iso" "mp4")
         ranger-deer-show-details t


### PR DESCRIPTION
Overrides ranger-travel to have better mode detection for which
completion framework to use, and default to emacs built-ins instead of
ido.

In theory this should be a temporary fix until ralesi/ranger.el#236 gets
merged, but the maintenance status of ranger.el is not clear.

Fix #5509
Ref ralesi/ranger.el#236