### PR TITLE
nit: init.example.el: wording, sort

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -1,7 +1,7 @@
 ;;; init.el -*- lexical-binding: t; -*-
 
-;; This file controls what Doom modules are enabled and what order they load
-;; in. Remember to run 'doom sync' after modifying it!
+;; This file controls which Doom modules are enabled and their load order.
+;; Remember to run 'doom sync' after modifications!
 
 ;; NOTE Press 'SPC h d h' (or 'C-h d h' for non-vim users) to access Doom's
 ;;      documentation. There you'll find a "Module Index" link where you'll find
@@ -118,8 +118,8 @@
        ;;coq               ; proofs-as-programs
        ;;crystal           ; ruby at the speed of c
        ;;csharp            ; unity, .NET, and mono shenanigans
-       ;;data              ; config/data formats
        ;;(dart +flutter)   ; paint ui and not much else
+       ;;data              ; config/data formats
        ;;dhall
        ;;elixir            ; erlang done right
        ;;elm               ; care for a cup of TEA?
@@ -135,9 +135,9 @@
        ;;(haskell +lsp)    ; a language that's lazier than I am
        ;;hy                ; readability of scheme w/ speed of python
        ;;idris             ; a language you can depend on
-       ;;json              ; At least it ain't XML
        ;;(java +meghanada) ; the poster child for carpal tunnel syndrome
        ;;javascript        ; all(hope(abandon(ye(who(enter(here))))))
+       ;;json              ; At least it ain't XML
        ;;julia             ; a better, faster MATLAB
        ;;kotlin            ; a better, slicker Java(Script)
        ;;latex             ; writing papers in Emacs has never been so fun


### PR DESCRIPTION
Minor change.

I added `biblio`, because it was missing.

I sorted two other entries.

I changed the wording of the first sentence. Please let me know if you don't wnat this change, but it sounds better to me.