### PR TITLE
tweak(latex): add key bindings for compilation

### DIFF
--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -102,11 +102,15 @@ If no viewers are found, `latex-preview-pane' is used.")
                #'lsp!))
   (map! :localleader
         :map latex-mode-map
-        :desc "View" "v" #'TeX-view)
+        :desc "View"          "v" #'TeX-view
+        :desc "Compile"       "c" #'TeX-command-run-all
+        :desc "Run a command" "m" #'TeX-command-master)
   (map! :after latex
-        :map LaTeX-mode-map
         :localleader
-        :desc "View" "v" #'TeX-view))
+        :map LaTeX-mode-map
+        :desc "View"          "v" #'TeX-view
+        :desc "Compile"       "c" #'TeX-command-run-all
+        :desc "Run a command" "m" #'TeX-command-master))
 
 
 (use-package! tex-fold


### PR DESCRIPTION
This is a minor change.

Doom Emacs was missing key bindings to compile LaTeX documents. This PR adds tow bindings in LaTeX derived modes:
- `SPC m c` for `TeX-command-run-all`, and
- `SPC m m` for `TeX-command-master`.