### PR TITLE
tweak(elfeed): Move elfeed-goodies behind +goodies flag

### DIFF
--- a/modules/app/rss/README.org
+++ b/modules/app/rss/README.org
@@ -30,7 +30,8 @@ This module has no dedicated maintainers.
 
 ** Plugins
 + [[https://github.com/skeeto/elfeed][elfeed]]
-+ [[https://github.com/algernon/elfeed-goodies][elfeed-goodies]] 
++ =+goodies=
+  + [[https://github.com/algernon/elfeed-goodies][elfeed-goodies]]
 + =+org=
   + [[https://github.com/remyhonig/elfeed-org][elfeed-org]]
 

--- a/modules/app/rss/config.el
+++ b/modules/app/rss/config.el
@@ -82,6 +82,7 @@ easier to scroll through.")
         (setq rmh-elfeed-org-files (cl-remove-if-not #'file-exists-p files))))))
 
 (use-package! elfeed-goodies
+  :when (featurep! +goodies)
   :after elfeed
   :config
   (elfeed-goodies/setup))

--- a/modules/app/rss/packages.el
+++ b/modules/app/rss/packages.el
@@ -2,6 +2,7 @@
 ;;; app/rss/packages.el
 
 (package! elfeed :pin "162d7d545ed41c27967d108c04aa31f5a61c8e16")
-(package! elfeed-goodies :pin "95b4ea632fbd5960927952ec8f3394eb88da4752")
+(when (featurep! +goodies)
+  (package! elfeed-goodies :pin "95b4ea632fbd5960927952ec8f3394eb88da4752"))
 (when (featurep! +org)
   (package! elfeed-org :pin "268efdd0121fa61f63b722c30e0951c5d31224a4"))


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->


Elfeed-goodies package does not provide much functionality besides visual flair. Some people (like myself) find spartan stock elfeed interface more appealing/preferable compared to eye-candy. But, extra visual flair behind an easy flag (+pretty) should be enough to satisfy both camps.
