### PR TITLE
Prevent "origin already exists" bug

### DIFF
--- a/bin/doom
+++ b/bin/doom
@@ -1,5 +1,6 @@
 #!/usr/bin/env sh
 :; set -e # -*- mode: emacs-lisp; lexical-binding: t -*-
+:; unset GIT_CONFIG  # BUG some GIT_CONFIG values cause "origin already exists" error
 :; case "$EMACS" in *term*) EMACS=emacs ;; *) EMACS="${EMACS:-emacs}" ;; esac
 :; $EMACS --version >/dev/null 2>&1 || { >&2 echo "Can't find emacs in your PATH"; exit 1; }
 :; $EMACS --no-site-file --script "$0" -- "$@" || __DOOMCODE=$?


### PR DESCRIPTION
There is this annoying bug that nobody can solve on discord. "origin already exists" error from git on ANY `doom` call.

```
      x The package manager threw an error
      x Last 25 lines of straight's error log:
        $ cd /home/user/.config/emacs/.local/straight/repos/melpa/
        $ git rev-parse HEAD
        dc9ec7c99477746b1bddc97231a8f5ee37322d11
        [Return code: 0]
        $ cd /home/user/.config/emacs/.local/straight/repos/melpa/
        $ git config --get remote.origin.url
        [Return code: 1]
        $ cd /home/user/.config/emacs/.local/straight/repos/melpa/
        $ git remote add origin https\://github.com/melpa/melpa.git
        error: remote origin already exists.
        [Return code: 3]
      ! Extended backtrace logged to .config/emacs/.local/doom.error.log
```

Having `GIT_CONFIG` set to a sketchy value like `/home/user/.config/git/config` causes this.
Since this happens ONLY in Doom, I make this PR here.

None of the proposed solutions works unless `GIT_CONFIG` is unset. Trust me, I'm a noob, true, but I've dealt with this over an 8 months period. This is literally the only solution that I could find.
I cannot be bothered to look up the issues/Discord but I'm sure I'm not the only one who faced this.

Here are some of the solutions that don't work:
- Delete `.local`
- Delete `.local/*/{straight,melpa}`
- Manually remove `origin` in problematic repos (straight and melpa basically and some more)
- Rename `origin`
- Reinstall Git