### PR TITLE
fix: flymake--diag-buffer is now flymake--diag-locus

### DIFF
--- a/modules/tools/lsp/autoload/flycheck-eglot.el
+++ b/modules/tools/lsp/autoload/flycheck-eglot.el
@@ -67,4 +67,10 @@ CALLBACK is the function that we need to call when we are done, on all the error
       ;; errors
       (flycheck-buffer-deferred))))
 
+(after! flymake
+  (when (and
+         (not (fboundp 'flymake--diag-buffer))
+         (fboundp 'flymake--diag-locus))
+    (defalias 'flymake--diag-buffer 'flymake--diag-locus)))
+
 ;;; flycheck-eglot.el ends here


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

Fixes #5644 <!-- remove if not applicable -->

This PR only renames `flymake--diag-buffer` as `flymake--diag-locus` in `modules/tools/lsp/autoload/flycheck-eglot.el`.
