### PR TITLE
fix(vc): +vc/browse-at-remote fails in TRAMP buffers.

### DIFF
--- a/modules/emacs/vc/autoload/vc.el
+++ b/modules/emacs/vc/autoload/vc.el
@@ -13,7 +13,8 @@
 If prefix ARG, negate the default value of `browse-at-remote-prefer-symbolic'."
   (interactive "P")
   (require 'browse-at-remote)
-  (let ((browse-at-remote-prefer-symbolic
+  (let ((vc-ignore-dir-regexp locate-dominating-stop-dir-regexp)
+        (browse-at-remote-prefer-symbolic
          (if arg
              (not browse-at-remote-prefer-symbolic)
            browse-at-remote-prefer-symbolic)))
@@ -25,7 +26,8 @@ If prefix ARG, negate the default value of `browse-at-remote-prefer-symbolic'."
 If prefix ARG, negate the default value of `browse-at-remote-prefer-symbolic'."
   (interactive "P")
   (require 'browse-at-remote)
-  (let ((browse-at-remote-prefer-symbolic
+  (let ((vc-ignore-dir-regexp locate-dominating-stop-dir-regexp)
+        (browse-at-remote-prefer-symbolic
          (if arg
              (not browse-at-remote-prefer-symbolic)
            browse-at-remote-prefer-symbolic)))


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [X] It targets the develop branch
  - [X] No other pull requests exist for this issue
  - [X] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [X] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

Fixing vc/browse-at-remote in files opened via SSH on remote servers.

**browse-at-remote** uses **vc-git-root** to find git root project.  **vc-git-root** ignores directories matching **vc-ignore-dir-regexp**. **vc-ignore-dir-regexp** is set to ignore TRAMP buffers to speedup projectile. Which means vc-git-root can't find git root in TRAMP buffers.

Temporary revert **vc-ignore-dir-regexp** to default value (which doesn't ignore TRAMP buffers) 

Fixes #5660