### PR TITLE
markdown: evil normal: map <RET> to markdown-do

### DIFF
--- a/modules/lang/markdown/config.el
+++ b/modules/lang/markdown/config.el
@@ -127,6 +127,7 @@ capture, the end position, and the output buffer.")
   (map! :map evil-markdown-mode-map
         :n "TAB" #'markdown-cycle
         :n [backtab] #'markdown-shifttab
+        :n "<RET>" #'markdown-do
         :i "M-*" #'markdown-insert-list-item
         :i "M-b" #'markdown-insert-bold
         :i "M-i" #'markdown-insert-italic

--- a/modules/lang/markdown/packages.el
+++ b/modules/lang/markdown/packages.el
@@ -1,7 +1,7 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; lang/markdown/packages.el
 
-(package! markdown-mode :pin "862ae8addd29bf6affca1a35fd0176cb0c1392da")
+(package! markdown-mode :pin "c3c2f0d473a3f8ca8c4ffb2ecc094d5c3541769f")
 (package! markdown-toc :pin "3d724e518a897343b5ede0b976d6fb46c46bcc01")
 (package! edit-indirect :pin "bdc8f542fe8430ba55f9a24a7910639d4c434422")
 


### PR DESCRIPTION
this does two things:

- Maps `<RET>` to markdown-do (same as spacemacs)
- Updates markdown-mode, to get https://github.com/jrblevin/markdown-mode/pull/666 which enables following `[markdown](links)` and `[[wiki|links]]` with markdown-do