### PR TITLE
fix(biblio): bibtex-actions category is now bib-reference

### DIFF
--- a/modules/tools/biblio/config.el
+++ b/modules/tools/biblio/config.el
@@ -19,4 +19,4 @@
   :after embark
   :defer t
   :config
-  (add-to-list 'embark-keymap-alist '(bibtex . bibtex-actions-map)))
+  (add-to-list 'embark-keymap-alist '(bib-reference . bibtex-actions-map)))


### PR DESCRIPTION
As of [this change to bibtex-actions](https://github.com/bdarcus/bibtex-actions/pull/222), the `embark` category for bibtex-actions is now `bib-reference` instead of `bibtex`. This PR updates the relevant config for the `biblio` module when `vertico` is also enabled.

Without this change, `embark-act` (bound to `C-;` in minibuffers) incorrectly uses the generic action map instead of the bibtex-specific one provided by bibtex-actions.