### PR TITLE
Add `:lang fortran` module

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -129,6 +129,7 @@
        ;;ess               ; emacs speaks statistics
        ;;factor
        ;;faust             ; dsp, but you get to keep your soul
+       ;;fortran           ; in FORTRAN, GOD is REAL (unless declared INTEGER)
        ;;fsharp            ; ML stands for Microsoft's Language
        ;;fstar             ; (dependent) types and (monadic) effects and Z3
        ;;gdscript          ; the language you waited for

--- a/modules/lang/fortran/README.org
+++ b/modules/lang/fortran/README.org
@@ -26,6 +26,7 @@ registry]], and [[https://fortran-lang.discourse.group/][Discourse community]].
 In particular, this module features:
 
 + Support for all major Fortran varieties.
++ Auto-formatting via =fprettier=.
 + Integration with the =fpm= package manager.
 + LSP support via [[https://github.com/hansec/fortran-language-server][fortran-language-server]].
 + Optional support for [[https://www.intel.com/content/www/us/en/developer/tools/oneapi/fortran-compiler.html][Intel Fortran]] (otherwise =gfortran= by default).

--- a/modules/lang/fortran/README.org
+++ b/modules/lang/fortran/README.org
@@ -1,6 +1,6 @@
 #+TITLE:   lang/fortran
 #+DATE:    October 22, 2021
-#+SINCE:   v3.0.0
+#+SINCE:   v3.0.0 (#5676)
 #+STARTUP: inlineimages nofold
 
 * Table of Contents :TOC_3:noexport:

--- a/modules/lang/fortran/README.org
+++ b/modules/lang/fortran/README.org
@@ -9,6 +9,7 @@
   - [[#module-flags][Module Flags]]
   - [[#plugins][Plugins]]
 - [[#prerequisites][Prerequisites]]
+  - [[#arch-linux][Arch Linux]]
 - [[#features][Features]]
 - [[#configuration][Configuration]]
 - [[#troubleshooting][Troubleshooting]]
@@ -32,9 +33,10 @@ In particular, this module features:
 + Optional support for [[https://www.intel.com/content/www/us/en/developer/tools/oneapi/fortran-compiler.html][Intel Fortran]] (otherwise =gfortran= by default).
 
 #+begin_quote
-After a career of writing Fortran on Windows, my now-retired Dad is switching to
-Linux. Imagine my surprise when I learned that off-the-shelf setups for Fortran
-on Linux basically don't exist! Well, until now... Cheers Dad, hope this helps.
+After a career of writing Fortran on Mainframes and Windows machines, my
+now-retired Dad is switching to Linux. Imagine my surprise when I learned that
+off-the-shelf setups for Fortran on Linux basically don't exist! Well, until
+now... Cheers Dad, hope this helps.
 #+end_quote
 
 ** Maintainers
@@ -47,7 +49,24 @@ on Linux basically don't exist! Well, until now... Cheers Dad, hope this helps.
 ** Plugins
 
 * Prerequisites
-This module has no prerequisites.
+
+For minimum functionality, this module requires =gfortran=. For most project
+management tasks you will also need [[https://github.com/fortran-lang/fpm][fpm]], the Fortran Package Manager.
+
+** Arch Linux
+
+=gfortran= is available from the official repositories:
+
+#+begin_example
+sudo pacman -S gcc-fortran
+#+end_example
+
+Whereas =fpm= is available from the AUR and thus must be installed with an
+AUR-compatible tool like [[https://github.com/fosskers/aura][Aura]]:
+
+#+begin_example
+sudo aura -A fortran-fpm
+#+end_example
 
 * Features
 # An in-depth list of features, how to use them, and their dependencies.

--- a/modules/lang/fortran/README.org
+++ b/modules/lang/fortran/README.org
@@ -30,7 +30,6 @@ In particular, this module features:
 + Auto-formatting via =fprettier=.
 + Integration with the =fpm= package manager.
 + LSP support via [[https://github.com/hansec/fortran-language-server][fortran-language-server]].
-+ Optional support for [[https://www.intel.com/content/www/us/en/developer/tools/oneapi/fortran-compiler.html][Intel Fortran]] (otherwise =gfortran= by default).
 
 #+begin_quote
 After a career of writing Fortran on Mainframes and Windows machines, my
@@ -43,7 +42,6 @@ now... Cheers Dad, hope this helps.
 + [[https://github.com/fosskers][@fosskers]] (Author)
 
 ** Module Flags
-+ =+intel= Enable usage of Intel Fortran instead of GNU Fortran.
 + =+lsp= Activate =fortran-language-server= for Fortran projects.
 
 ** Plugins

--- a/modules/lang/fortran/README.org
+++ b/modules/lang/fortran/README.org
@@ -1,0 +1,58 @@
+#+TITLE:   lang/fortran
+#+DATE:    October 22, 2021
+#+SINCE:   v3.0.0
+#+STARTUP: inlineimages nofold
+
+* Table of Contents :TOC_3:noexport:
+- [[#description][Description]]
+  - [[#maintainers][Maintainers]]
+  - [[#module-flags][Module Flags]]
+  - [[#plugins][Plugins]]
+- [[#prerequisites][Prerequisites]]
+- [[#features][Features]]
+- [[#configuration][Configuration]]
+- [[#troubleshooting][Troubleshooting]]
+
+* Description
+
+This module enables a complete, modern development environment for the [[https://fortran-lang.org/][Fortran]]
+language. Initially released in 1956 (a year before Lisp 1.0), Fortran is the
+original high-performance computation language and is still widely used in
+science and academia. Popular versions of the language include Fortran 77 and
+Fortran 90, with further extensions in the 1995 and 2008 varieties. Today,
+Fortran has joined the modern age with its own [[https://github.com/fortran-lang/fpm][package manager]], [[https://fortran-lang.org/packages/][package
+registry]], and [[https://fortran-lang.discourse.group/][Discourse community]].
+
+In particular, this module features:
+
++ Support for all major Fortran varieties.
++ Integration with the =fpm= package manager.
++ LSP support via [[https://github.com/hansec/fortran-language-server][fortran-language-server]].
++ Optional support for [[https://www.intel.com/content/www/us/en/developer/tools/oneapi/fortran-compiler.html][Intel Fortran]] (otherwise =gfortran= by default).
+
+#+begin_quote
+After a career of writing Fortran on Windows, my now-retired Dad is switching to
+Linux. Imagine my surprise when I learned that off-the-shelf setups for Fortran
+on Linux basically don't exist! Well, until now... Cheers Dad, hope this helps.
+#+end_quote
+
+** Maintainers
++ [[https://github.com/fosskers][@fosskers]] (Author)
+
+** Module Flags
++ =+intel= Enable usage of Intel Fortran instead of GNU Fortran.
++ =+lsp= Activate =fortran-language-server= for Fortran projects.
+
+** Plugins
+
+* Prerequisites
+This module has no prerequisites.
+
+* Features
+# An in-depth list of features, how to use them, and their dependencies.
+
+* Configuration
+# How to configure this module, including common problems and how to address them.
+
+* Troubleshooting
+# Common issues and their solution, or places to look for help.

--- a/modules/lang/fortran/autoload.el
+++ b/modules/lang/fortran/autoload.el
@@ -4,13 +4,15 @@
 
 ;;;###autoload
 (defun +fortran/gfortran-compile ()
-  "Compile the current file using gfortran."
+  "Compile the current buffer using gfortran."
   (interactive)
-  (compile (format "gfortran %s %s" (+fortran/fortran-std) buffer-file-name)))
+  (compile (format "gfortran %s %s"
+                   (+fortran/fortran-std)
+                   buffer-file-name)))
 
 ;;;###autoload
 (defun +fortran/gfortran-run ()
-  "Run the current file using gfortran."
+  "Run the current buffer using gfortran."
   (interactive)
   (+fortran/gfortran-compile)
   (let* ((buffer (+fortran/compilation-buffer-name nil))

--- a/modules/lang/fortran/autoload.el
+++ b/modules/lang/fortran/autoload.el
@@ -6,13 +6,21 @@
 (defun +fortran/gfortran-compile ()
   "Compile the current file using gfortran."
   (interactive)
-  (message "Compiling with gfortran."))
+  (compile (format "gfortran %s %s"
+                   (+fortran/fortran-std)
+                   buffer-file-name)))
 
 ;;;###autoload
 (defun +fortran/gfortran-run ()
   "Run the current file using gfortran."
   (interactive)
   (message "Running with gfortran."))
+
+(defun +fortran/fortran-std ()
+  "Which version of Fortran should we target?"
+  (cl-case major-mode
+    (fortran-mode "-std=legacy")
+    (t "")))
 
 ;; --- FPM --- ;;
 

--- a/modules/lang/fortran/autoload.el
+++ b/modules/lang/fortran/autoload.el
@@ -1,0 +1,35 @@
+;;; lang/fortran/autoload.el -*- lexical-binding: t; -*-
+
+;; --- GFORTRAN --- ;;
+
+;;;###autoload
+(defun +fortran/gfortran-compile ()
+  "Compile the current file using gfortran."
+  (interactive)
+  (message "Compiling with gfortran."))
+
+;;;###autoload
+(defun +fortran/gfortran-run ()
+  "Run the current file using gfortran."
+  (interactive)
+  (message "Running with gfortran."))
+
+;; --- FPM --- ;;
+
+;;;###autoload
+(defun +fortran/fpm-build ()
+  "Build the current project using fpm."
+  (interactive)
+  (message "Building with fpm."))
+
+;;;###autoload
+(defun +fortran/fpm-run ()
+  "Run the current project using fpm."
+  (interactive)
+  (message "Running with fpm."))
+
+;;;###autoload
+(defun +fortran/fpm-test ()
+  "Test the current project using fpm."
+  (interactive)
+  (message "Testing with fpm."))

--- a/modules/lang/fortran/autoload.el
+++ b/modules/lang/fortran/autoload.el
@@ -41,3 +41,10 @@
   "Test the current project using fpm."
   (interactive)
   (message "Testing with fpm."))
+
+;; --- MISC. --- ;;
+;;;###autoload
+(defun +fortran/compilation-buffer-name (mode)
+  "The name of the buffer produced by `compile'."
+  (interactive)
+  "*fortran-compilation*")

--- a/modules/lang/fortran/autoload.el
+++ b/modules/lang/fortran/autoload.el
@@ -6,15 +6,20 @@
 (defun +fortran/gfortran-compile ()
   "Compile the current file using gfortran."
   (interactive)
-  (compile (format "gfortran %s %s"
-                   (+fortran/fortran-std)
-                   buffer-file-name)))
+  (compile (format "gfortran %s %s" (+fortran/fortran-std) buffer-file-name)))
 
 ;;;###autoload
 (defun +fortran/gfortran-run ()
   "Run the current file using gfortran."
   (interactive)
-  (message "Running with gfortran."))
+  (+fortran/gfortran-compile)
+  (let* ((buffer (+fortran/compilation-buffer-name nil))
+         (proc (get-buffer-process buffer))
+         (exec (expand-file-name "a.out" ".")))
+    (while (accept-process-output proc))
+    (start-process "gfortran-run" buffer exec)))
+    ;; (comint-exec buffer "gfortran-run" exec nil nil)))
+    ;; (comint-send-string (get-buffer-process buffer) exec)))
 
 (defun +fortran/fortran-std ()
   "Which version of Fortran should we target?"

--- a/modules/lang/fortran/autoload.el
+++ b/modules/lang/fortran/autoload.el
@@ -14,14 +14,11 @@
 (defun +fortran/gfortran-run ()
   "Run the current buffer using gfortran."
   (interactive)
+  (delete-file "./a.out")
   (+fortran/gfortran-compile)
-  (let* ((buffer (+fortran/compilation-buffer-name nil))
-         (proc (get-buffer-process buffer))
-         (exec (expand-file-name "a.out" ".")))
-    (while (accept-process-output proc))
-    (start-process "gfortran-run" buffer exec)))
-    ;; (comint-exec buffer "gfortran-run" exec nil nil)))
-    ;; (comint-send-string (get-buffer-process buffer) exec)))
+  (while (not (file-exists-p "./a.out"))
+    (sleep-for 1))
+  (compile "./a.out"))
 
 (defun +fortran/fortran-std ()
   "Which version of Fortran should we target?"

--- a/modules/lang/fortran/autoload.el
+++ b/modules/lang/fortran/autoload.el
@@ -33,19 +33,19 @@
 (defun +fortran/fpm-build ()
   "Build the current project using fpm."
   (interactive)
-  (message "Building with fpm."))
+  (compile "fpm build"))
 
 ;;;###autoload
 (defun +fortran/fpm-run ()
   "Run the current project using fpm."
   (interactive)
-  (message "Running with fpm."))
+  (compile "fpm run"))
 
 ;;;###autoload
 (defun +fortran/fpm-test ()
   "Test the current project using fpm."
   (interactive)
-  (message "Testing with fpm."))
+  (compile "fpm test"))
 
 ;; --- MISC. --- ;;
 ;;;###autoload

--- a/modules/lang/fortran/config.el
+++ b/modules/lang/fortran/config.el
@@ -5,15 +5,19 @@
 
 (use-package! f90
   :config
+  ;; --- Compilation --- ;;
   ;; Used by `compile' (SPC c c)
-  (setq compile-command "gfortran ")
+  (setq-hook! 'f90-mode-hook
+    compile-command "gfortran "
+    compilation-buffer-name-function #'+fortran/compilation-buffer-name)
+  (set-popup-rule! "^\\*fortran-compilation" :side 'right :size 0.5 :quit t)
 
-  ;; --- LSP Configuration --- ;;
+    ;; --- LSP Configuration --- ;;
   (when (featurep! +lsp)
     (setq lsp-clients-fortls-args '("--enable_code_actions" "--hover_signature"))
     (add-hook 'f90-mode-local-vars-hook #'lsp!))
 
-  ;; --- Keybindings --- ;;
+    ;; --- Keybindings --- ;;
   (map! :map f90-mode-map
         :localleader
         (:prefix ("f" . "fpm")
@@ -36,7 +40,7 @@
   ;; Used by `compile' (SPC c c)
   (setq compile-command "gfortran -std=legacy "
         compilation-buffer-name-function #'+fortran/compilation-buffer-name)
-  (set-popup-rule! "^\\*fortran-compilation" :side 'right :size 0.5 :quit t)
+  ;; (set-popup-rule! "^\\*fortran-compilation" :side 'right :size 0.5 :quit t)
 
   ;; --- LSP --- ;;
   ;; Strangely, the built-in flycheck support seems to give better hints than the LSP.

--- a/modules/lang/fortran/config.el
+++ b/modules/lang/fortran/config.el
@@ -4,6 +4,7 @@
 ;;; Packages
 
 (use-package! f90
+  :defer t
   :config
   ;; --- Compilation --- ;;
   ;; Used by `compile' (SPC c c)
@@ -12,12 +13,12 @@
     compilation-buffer-name-function #'+fortran/compilation-buffer-name)
   (set-popup-rule! "^\\*fortran-compilation" :side 'right :size 0.5 :quit t)
 
-    ;; --- LSP Configuration --- ;;
+  ;; --- LSP Configuration --- ;;
   (when (featurep! +lsp)
     (setq lsp-clients-fortls-args '("--enable_code_actions" "--hover_signature"))
     (add-hook 'f90-mode-local-vars-hook #'lsp!))
 
-    ;; --- Keybindings --- ;;
+  ;; --- Keybindings --- ;;
   (map! :map f90-mode-map
         :localleader
         (:prefix ("f" . "fpm")
@@ -54,4 +55,3 @@
         :localleader
         :desc "compile (gfortran)" "c" #'+fortran/gfortran-compile
         :desc "run (gfortran)"     "r" #'+fortran/gfortran-run))
-

--- a/modules/lang/fortran/config.el
+++ b/modules/lang/fortran/config.el
@@ -1,0 +1,17 @@
+;;; lang/fortran/config.el -*- lexical-binding: t; -*-
+
+;;
+;;; Packages
+
+(use-package! f90
+  :config
+  (message "Hi dad")
+  (when (featurep! +lsp)
+    (setq lsp-clients-fortls-args '("--enable_code_actions" "--hover_signature"))
+    (add-hook 'f90-mode-local-vars-hook #'lsp!)))
+
+(use-package! fortran
+  :mode ("\\.FOR$" . fortran-mode)
+  :config
+  (message "Hi dad (legacy)")
+  (setq flycheck-gfortran-language-standard "legacy"))

--- a/modules/lang/fortran/config.el
+++ b/modules/lang/fortran/config.el
@@ -5,13 +5,36 @@
 
 (use-package! f90
   :config
-  (message "Hi dad")
+  ;; --- LSP Configuration --- ;;
   (when (featurep! +lsp)
     (setq lsp-clients-fortls-args '("--enable_code_actions" "--hover_signature"))
-    (add-hook 'f90-mode-local-vars-hook #'lsp!)))
+    (add-hook 'f90-mode-local-vars-hook #'lsp!))
+
+  ;; --- Keybindings --- ;;
+  (map! :map f90-mode-map
+        :localleader
+        (:prefix ("f" . "fpm")
+         :desc "fpm build" "b" #'+fortran/fpm-build
+         :desc "fpm run"   "r" #'+fortran/fpm-run
+         :desc "fpm test"  "t" #'+fortran/fpm-test)
+        :desc "compile (gfortran)" "c" #'+fortran/gfortran-compile
+        :desc "run (gfortran)"     "r" #'+fortran/gfortran-run))
 
 (use-package! fortran
+  ;; The `.for' extension is automatically recognized by Emacs and invokes
+  ;; `fortran-mode', but not its capital variant `.FOR'. Many old files are
+  ;; named the latter way, so we account for that manually here.
   :mode ("\\.FOR$" . fortran-mode)
   :config
-  (message "Hi dad (legacy)")
-  (setq flycheck-gfortran-language-standard "legacy"))
+  (setq flycheck-gfortran-language-standard "legacy")
+
+  ;; Strangely, the built-in flycheck support seems to give better hints than the LSP.
+  ;; (when (featurep! +lsp)
+  ;;   (setq lsp-clients-fortls-args '("--enable_code_actions" "--hover_signature"))
+  ;;   (add-hook 'fortran-mode-local-vars-hook #'lsp!)))
+
+  ;; --- Keybindings --- ;;
+  (map! :map fortran-mode-map
+        :localleader
+        :desc "compile (gfortran)" "c" #'+fortran/gfortran-compile
+        :desc "run (gfortran)"     "r" #'+fortran/gfortran-run))

--- a/modules/lang/fortran/config.el
+++ b/modules/lang/fortran/config.el
@@ -5,6 +5,9 @@
 
 (use-package! f90
   :config
+  ;; Used by `compile' (SPC c c)
+  (setq compile-command "gfortran ")
+
   ;; --- LSP Configuration --- ;;
   (when (featurep! +lsp)
     (setq lsp-clients-fortls-args '("--enable_code_actions" "--hover_signature"))
@@ -26,7 +29,11 @@
   ;; named the latter way, so we account for that manually here.
   :mode ("\\.FOR$" . fortran-mode)
   :config
+  ;; Or else Flycheck will get very mad.
   (setq flycheck-gfortran-language-standard "legacy")
+
+  ;; Used by `compile' (SPC c c)
+  (setq compile-command "gfortran -std=legacy ")
 
   ;; Strangely, the built-in flycheck support seems to give better hints than the LSP.
   ;; (when (featurep! +lsp)

--- a/modules/lang/fortran/config.el
+++ b/modules/lang/fortran/config.el
@@ -38,9 +38,10 @@
 
   ;; --- Compilation --- ;;
   ;; Used by `compile' (SPC c c)
-  (setq compile-command "gfortran -std=legacy "
-        compilation-buffer-name-function #'+fortran/compilation-buffer-name)
-  ;; (set-popup-rule! "^\\*fortran-compilation" :side 'right :size 0.5 :quit t)
+  (setq-hook! 'fortran-mode-hook ; TODO These work for f90 but not for fortran.
+    compile-command "gfortran -std=legacy "
+    compilation-buffer-name-function #'+fortran/compilation-buffer-name)
+  (set-popup-rule! "^\\*fortran-compilation" :side 'right :size 0.5 :quit t)
 
   ;; --- LSP --- ;;
   ;; Strangely, the built-in flycheck support seems to give better hints than the LSP.
@@ -53,3 +54,4 @@
         :localleader
         :desc "compile (gfortran)" "c" #'+fortran/gfortran-compile
         :desc "run (gfortran)"     "r" #'+fortran/gfortran-run))
+

--- a/modules/lang/fortran/config.el
+++ b/modules/lang/fortran/config.el
@@ -32,9 +32,13 @@
   ;; Or else Flycheck will get very mad.
   (setq flycheck-gfortran-language-standard "legacy")
 
+  ;; --- Compilation --- ;;
   ;; Used by `compile' (SPC c c)
-  (setq compile-command "gfortran -std=legacy ")
+  (setq compile-command "gfortran -std=legacy "
+        compilation-buffer-name-function #'+fortran/compilation-buffer-name)
+  (set-popup-rule! "^\\*fortran-compilation" :side 'right :size 0.5 :quit t)
 
+  ;; --- LSP --- ;;
   ;; Strangely, the built-in flycheck support seems to give better hints than the LSP.
   ;; (when (featurep! +lsp)
   ;;   (setq lsp-clients-fortls-args '("--enable_code_actions" "--hover_signature"))

--- a/modules/lang/fortran/doctor.el
+++ b/modules/lang/fortran/doctor.el
@@ -1,15 +1,11 @@
 ;; -*- lexical-binding: t; no-byte-compile: t; -*-
 ;;; lang/fortran/doctor.el
 
-;; TODO
-;; Check for `gfortran' if not `+intel'.
-
 (assert! (or (not (featurep! +lsp))
              (featurep! :tools lsp))
          "This module requires (:tools lsp)")
 
-(when (and (featurep! +intel)
-           (not (executable-find "gfortran")))
+(when (not (executable-find "gfortran"))
   (warn! "Couldn't find gfortran - compilation will not work."))
 
 (unless (executable-find "fpm")

--- a/modules/lang/fortran/doctor.el
+++ b/modules/lang/fortran/doctor.el
@@ -1,0 +1,22 @@
+;; -*- lexical-binding: t; no-byte-compile: t; -*-
+;;; lang/fortran/doctor.el
+
+;; TODO
+;; Check for `gfortran' if not `+intel'.
+
+(assert! (or (not (featurep! +lsp))
+             (featurep! :tools lsp))
+         "This module requires (:tools lsp)")
+
+(when (and (featurep! +intel)
+           (not (executable-find "gfortran")))
+  (warn! "Couldn't find gfortran - compilation will not work."))
+
+(unless (executable-find "fpm")
+  (warn! "Couldn't find fpm - project building/testing will not work."))
+
+(when (featurep! +lsp)
+  (unless (executable-find "fortls")
+    (warn! "Couldn't find fortls."))
+  (unless (executable-find "fprettify")
+    (warn! "Couldn't find fprettify.")))


### PR DESCRIPTION
This PR adds support for the [Fortran Language](https://fortran-lang.org/), since an off-the-shelf solution mostly doesn't exist if you aren't using Visual Studio on Windows. Critically, this PR brings together all the treats of modernity recently added to the Fortran world; namely a package manager and LSP. It also bridges the gap between `gfortran` and Intel Fortran, since the latter is much loved but hard to integrate into development environments.

#### TODO

- [x] Basic config skeleton
- [x] `+lsp`
- [x] Common Keybindings
- [x] Compilation / Running support
- ~Optional modeline buttons for building/running (`+buttons`?)~
- ~`+intel`~
- [x] `doom doctor` checks
- [x] README clean up

**Note to Self:** Look into `ob-fortran`.