### PR TITLE
Recall `mu4e--start` interactively inside `+mu4e-lock-start`

### DIFF
--- a/modules/email/mu4e/autoload/mu-lock.el
+++ b/modules/email/mu4e/autoload/mu-lock.el
@@ -54,7 +54,7 @@ Else, write to this process' PID to the lock file"
     (write-region (number-to-string (emacs-pid)) nil +mu4e-lock-file)
     (delete-file +mu4e-lock-request-file)
     (call-process "touch" nil nil nil +mu4e-lock-request-file)
-    (funcall orig-fun callback)
+    (funcall-interactively orig-fun callback)
     (setq +mu4e-lock--request-watcher
           (file-notify-add-watch +mu4e-lock-request-file
                                  '(change)


### PR DESCRIPTION
This seems to fix #5689

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

`mu4e--start` should be called interactively, as it is done in `=mu4e`.
It fixes a problem when sometimes `mu4e` does not open its main view.
