### PR TITLE
display dired-icons with colors

### DIFF
--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -119,6 +119,9 @@ we have to clean it up ourselves."
   ;;      wdired-mode.
   (defvar +wdired-icons-enabled -1)
 
+  ;; display icons with colors
+  (setq all-the-icons-dired-monochrome nil)
+
   (defadvice! +dired-disable-icons-in-wdired-mode-a (&rest _)
     :before #'wdired-change-to-wdired-mode
     (setq-local +wdired-icons-enabled (if all-the-icons-dired-mode 1 -1))


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

Module `(dired +icons)` currently display icons in monochrome (i.e black & white). 
This PR aims to provide a better default UI with colored dired icons. 
