### PR TITLE
fix: unset default-input-method in early-init.el

### DIFF
--- a/early-init.el
+++ b/early-init.el
@@ -59,6 +59,9 @@
 ;; more than this to make UTF-8 the default coding system:
 (set-language-environment "UTF-8")
 
+;; set-language-enviornment sets default-input-method, which is unwanted
+(setq default-input-method nil)
+
 ;; Ensure Doom is running out of this file's directory
 (setq user-emacs-directory (file-name-directory load-file-name))
 


### PR DESCRIPTION
set-language-environment sets default-input-method, which is unwanted.

Fix: #5046

-------

@ineu @dukebarman please confirm on your end that this fixes the issue. It unsets the default input method, but I never had the locale autodetection thing, so I'm not sure if that's still a problem.