### PR TITLE
Use persp-set-keymap-prefix instead of setq

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -5,7 +5,7 @@
       doom-localleader-alt-key "C-c l")
 
 ;; persp-mode and projectile in different prefixes
-(setq persp-keymap-prefix (kbd "C-c w"))
+(setq! persp-keymap-prefix (kbd "C-c w"))
 (after! projectile
   (define-key projectile-mode-map (kbd "C-c p") 'projectile-command-map))
 


### PR DESCRIPTION
this is to change the default keymap of persp-mode correctly and avoid
weird bugs

- https://github.com/Bad-ptr/persp-mode.el/blob/298df111f081b5925f0aa0126a1b8d334117e0a2/persp-mode.el#L1002-L1017
- https://www.reddit.com/r/DoomEmacs/comments/qgn814/adding_a_specific_package_as_a_module/?utm_source=share&utm_medium=web2x&context=3
- https://github.com/merrickluo/lsp-tailwindcss/issues/22

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [x] No other pull requests exist for this issue
  - [x] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] Any relevant issues and PRs have been linked to
  - [x] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

Under [some circumstances](https://www.reddit.com/r/DoomEmacs/comments/qgn814/adding_a_specific_package_as_a_module/?utm_source=share&utm_medium=web2x&context=3) `:config (default +bindings)` will fail to rebind the keymap of persp-mode which in turn breaks some bindings for projectile, to prevent this bug from happening, using a function [provided by persp-mode](https://github.com/Bad-ptr/persp-mode.el/blob/298df111f081b5925f0aa0126a1b8d334117e0a2/persp-mode.el#L1002-L1017) to change the keymap is required.

Using [`setq` to change a `defcustom`](https://emacs.stackexchange.com/questions/44220/how-to-overwrite-a-defcustom-of-a-package-within-the-initfile#comment68327_44223) shouldn't be done anyway.