### PR TITLE
fix: wrong number of arguments when calling (dtrt-indent-mode)

### DIFF
--- a/core/core-editor.el
+++ b/core/core-editor.el
@@ -499,7 +499,7 @@ files, so this replace calls to `pp' with the much faster `prin1'."
   (push '(t tab-width) dtrt-indent-hook-generic-mapping-list)
 
   (defvar dtrt-indent-run-after-smie)
-  (defadvice! doom--fix-broken-smie-modes-a (fn arg)
+  (defadvice! doom--fix-broken-smie-modes-a (fn &optional arg)
     "Some smie modes throw errors when trying to guess their indentation, like
 `nim-mode'. This prevents them from leaving Emacs in a broken state."
     :around #'dtrt-indent-mode


### PR DESCRIPTION
`doom--fix-broken-smie-modes-a` forces `dtrt-indent-mode` to expect exactly one argument so an error will be raised when the latter is turned on without arguments programmatically in lisp.


