### PR TITLE
nit: log recipe repo git output at "debug"

### DIFF
--- a/core/cli/packages.el
+++ b/core/cli/packages.el
@@ -134,7 +134,7 @@ list remains lean."
                       (doom--abbrev-commit ref)
                       (doom--abbrev-commit newref))
               (unless (string-empty-p output)
-                (print-group! (print! (info "%s" output))))))))))
+                (print-group! (print! (debug "%s" output))))))))))
     (setq straight--recipe-lookup-cache (make-hash-table :test #'eq)
           doom--cli-updated-recipes t)))
 


### PR DESCRIPTION
This quiets down `doom sync -u` from this:

```
    > Updating recipe repos...
      ✓ melpa updated (cdd8115 -> 4424e06)
        - $ cd /Users/offby1/.emacs.d/.local/straight/repos/melpa/
        $ git config --get remote.origin.url

        https://github.com/melpa/melpa.git

        [Return code: 0]

        $ cd /Users/offby1/.emacs.d/.local/straight/repos/melpa/
        $ git fetch origin
```

to this:

```
    > Updating recipe repos...
      ✓ melpa updated (cdd8115 -> 4424e06)
```

at least, in the common case.

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [X] It targets the develop branch
  - [X] No other pull requests exist for this issue
  - [X] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [X] Any relevant issues and PRs have been linked to
  - [X] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->
