### PR TITLE
feat(clojure): Improve REPL icon modeline for cider

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -97,21 +97,40 @@
   (when (featurep! :ui modeline +light)
     (defvar-local cider-modeline-icon nil)
 
+    (defun +clojure--cider-set-modeline (face label)
+      "Update repl icon on modeline with cider information."
+      (setq cider-modeline-icon (concat
+                                 " "
+                                 (+modeline-format-icon 'faicon "terminal" "" face label -0.0575)
+                                 " "))
+      (add-to-list 'global-mode-string
+                   '(t (:eval cider-modeline-icon))
+                   'append))
+
     (add-hook! '(cider-connected-hook
                  cider-disconnected-hook
                  cider-mode-hook)
-      (defun +clojure--cider-update-modeline ()
+      (defun +clojure--cider-connected-update-modeline ()
         "Update modeline with cider connection state."
         (let* ((connected (cider-connected-p))
-               (face (if connected 'success 'warning))
+               (face (if connected 'warning 'breakpoint-disabled))
                (label (if connected "Cider connected" "Cider disconnected")))
-          (setq cider-modeline-icon (concat
-                                     " "
-                                     (+modeline-format-icon 'faicon "terminal" "" face label -0.0575)
-                                     " "))
-          (add-to-list 'global-mode-string
-                       '(t (:eval cider-modeline-icon))
-                       'append)))))
+          (+clojure--cider-set-modeline face label))))
+
+    (add-hook! '(cider-before-eval-hook)
+      (defun +clojure--cider-before-eval-hook-update-modeline ()
+        "Update modeline with cider state before eval."
+        (+clojure--cider-set-modeline 'warning "Cider evaluating")))
+
+    (add-hook! '(cider-after-eval-done-hook)
+      (defun +clojure--cider-after-eval-done-hook-update-modeline ()
+        "Update modeline with cider state after eval."
+        (+clojure--cider-set-modeline 'success "Cider syncronized")))
+
+    (add-hook! '(cider-file-loaded-hook)
+      (defun +clojure--cider-file-loaded-update-modeline ()
+        "Update modeline with cider file loaded state."
+        (+clojure--cider-set-modeline 'success "Cider syncronized"))))
 
   ;; Ensure that CIDER is used for sessions in org buffers.
   (when (featurep! :lang org)

--- a/modules/lang/clojure/packages.el
+++ b/modules/lang/clojure/packages.el
@@ -16,6 +16,6 @@
 ;;; Core packages
 (package! clojure-mode :pin "e1dc7caee76d117a366f8b8b1c2da7e6400636a8")
 (package! clj-refactor :pin "4cb75bd6a2fcb376455e8b4f3edee509f87b86b8")
-(package! cider :pin "0a9d0ef429e76ee36c34e116c4633c69cea96c67")
+(package! cider :pin "7228402c093a7660a6bee6e4c1c69cce81703013")
 (when (featurep! :checkers syntax)
   (package! flycheck-clj-kondo :pin "a558bda44c4cb65b69fa53df233e8941ebd195c5"))


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [x] No other pull requests exist for this issue
  - [X] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [X] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

This PR use the new cider hooks to improve the REPL icon on modeline. At the moment we just show the REPL icon as yellow if cider not connected and green if connected, with this PR we add a new intermediate state of REPL in sync:

Now, If the REPL is not connected we show the icon:
![image](https://user-images.githubusercontent.com/7820865/140235997-b9116058-8b5f-413c-921b-788d9c044bf7.png)

If the REPL is connected but nothing was evaluated or cider is still evaluating any code, we show:
![image](https://user-images.githubusercontent.com/7820865/140236004-9e8413e2-c22a-44ec-ad71-0569e01ffda4.png)

If cider is in sync/not evaluating anything, we show:
![image](https://user-images.githubusercontent.com/7820865/140236028-7e36f8a3-6109-400d-88dd-16444865831e.png)

This is a follow up of https://github.com/clojure-emacs/cider/pull/3084 and https://github.com/clojure-emacs/cider/pull/3089

Another gif showing the new feature:
![cider-modeline-eval](https://user-images.githubusercontent.com/7820865/140000528-77936735-7bb0-4f38-8205-6514ab754d94.gif)
