### PR TITLE
feat(doom-quit): hide some messages with +friendly

### DIFF
--- a/docs/modules.org
+++ b/docs/modules.org
@@ -202,7 +202,7 @@ Aesthetic modules that affect the Emacs interface or user experience.
 + [[file:../modules/ui/deft/README.org][deft]] - TODO
 + [[file:../modules/ui/doom/README.org][doom]] - TODO
 + [[file:../modules/ui/doom-dashboard/README.org][doom-dashboard]] - TODO
-+ [[file:../modules/ui/doom-quit/README.org][doom-quit]] - TODO
++ [[file:../modules/ui/doom-quit/README.org][doom-quit]] =+friendly= - TODO
 + [[file:../modules/ui/emoji/README.org][emoji]] =+ascii +github +unicode= - Adds emoji support to Emacs
 + [[file:../modules/ui/hl-todo/README.org][hl-todo]] - TODO
 + [[file:../modules/ui/hydra/README.org][hydra]] - TODO

--- a/init.example.el
+++ b/init.example.el
@@ -30,7 +30,7 @@
        ;;deft              ; notational velocity for Emacs
        doom              ; what makes DOOM look the way it does
        doom-dashboard    ; a nifty splash screen for Emacs
-       doom-quit         ; DOOM quit-message prompts when you quit Emacs
+       (doom-quit +friendly) ; DOOM quit-message prompts when you quit Emacs
        ;;(emoji +unicode)  ; 🙂
        hl-todo           ; highlight TODO/FIXME/NOTE/DEPRECATED/HACK/REVIEW
        ;;hydra

--- a/modules/ui/doom-quit/README.org
+++ b/modules/ui/doom-quit/README.org
@@ -17,7 +17,7 @@ A silly module that prompts you with messages when you try to quit, like DOOM
 did. Some quotes are from Doom's quit-message list. Others are random, nerdy
 references that no decent human being has any business recognising.
 ** Module Flags
-This module provides no flags
++ =+friendly= Hides some of the default ~+doom-quit-messages~.
 ** Plugins
 This module uses no Plugins
 * Prerequisites

--- a/modules/ui/doom-quit/config.el
+++ b/modules/ui/doom-quit/config.el
@@ -6,27 +6,33 @@
     "Let's beat it -- This is turning into a bloodbath!"
     "I wouldn't leave if I were you. DOS is much worse."
     "Don't leave yet -- There's a demon around that corner!"
-    "Ya know, next time you come in here I'm gonna toast ya."
-    "Go ahead and leave. See if I care."
     "Are you sure you want to quit this great editor?"
     ;; from Portal
     "Thank you for participating in this Aperture Science computer-aided enrichment activity."
     "You can't fire me, I quit!"
-    "I don't know what you think you are doing, but I don't like it. I want you to stop."
-    "This isn't brave. It's murder. What did I ever do to you?"
     "I'm the man who's going to burn your house down! With the lemons!"
     "Okay, look. We've both said a lot of things you're going to regret..."
     ;; Custom
     "(setq nothing t everything 'permitted)"
-    "Emacs will remember that."
     "Emacs, Emacs never changes."
     "Hey! Hey, M-x listen!"
     "It's not like I'll miss you or anything, b-baka!"
     "Wake up, Mr. Stallman. Wake up and smell the ashes."
-    "You are *not* prepared!"
     "Please don't go. The drones need you. They look up to you.")
   "A list of quit messages, picked randomly by `+doom-quit'. Taken from
 http://doom.wikia.com/wiki/Quit_messages and elsewhere.")
+
+(unless (featurep! +friendly)
+  (appendq! +doom-quit-messages
+            '(;; from Doom 1
+              "Ya know, next time you come in here I'm gonna toast ya."
+              "Go ahead and leave. See if I care."
+              ;; from Portal
+              "I don't know what you think you are doing, but I don't like it. I want you to stop."
+              "This isn't brave. It's murder. What did I ever do to you?"
+              ;; Custom
+              "Emacs will remember that."
+              "You are *not* prepared!")))
 
 (defun +doom-quit-fn (&rest _)
   (doom-quit-p


### PR DESCRIPTION
I feel that some of the default `doom-quit` messages are a little offputting for those who aren't aware of the references. I think doom emacs is an amazing framework and I wouldn't want any newcomers to be turned off by some of the more aggressive messages when they already may be feeling overwhelmed by learning (doom) emacs. I also understand others may like these messages, so I've come up with the following compromise:

1. Add `+friendly` flag to `doom-quit`. When `+friendly` is enabled, hide some of the quit messages.
2. Add `+friendly` to the default `init.el`.

Current doom users will be unaffected but may opt-in with the flag, while newcomers will have `+friendly` enabled by default and must opt-out.
