### PR TITLE
fix: ol-notmuch moved from org-contrib to new repo

### DIFF
--- a/modules/email/notmuch/config.el
+++ b/modules/email/notmuch/config.el
@@ -117,6 +117,9 @@ variable accordingly.")
   :after (org notmuch)
   :config (setq org-mime-library 'mml))
 
+(use-package! ol-notmuch
+  :when (featurep! +org)
+  :after (org notmuch))
 
 (use-package! counsel-notmuch
   :when (featurep! :completion ivy)

--- a/modules/email/notmuch/packages.el
+++ b/modules/email/notmuch/packages.el
@@ -20,7 +20,8 @@
   :pin "63413a5563450bdedee4c077f2f998578e75083a")
 
 (when (featurep! +org)
-  (package! org-mime :pin "eb21c02ba8f97fe69c14dc657a7883b982664649"))
+  (package! org-mime :pin "eb21c02ba8f97fe69c14dc657a7883b982664649")
+  (package! ol-notmuch :pin "126fb446d8fa9e54cf21103afaf506fd81273c02"))
 (when (featurep! :completion ivy)
   (package! counsel-notmuch :pin "a4a1562935e4180c42524c51609d1283e9be0688"))
 (when (featurep! :completion helm)


### PR DESCRIPTION
[org-contrib](https://git.sr.ht/~bzg/org-contrib) is moving a number of files to separate repositories, including ol-notmuch.el. ol-notmuch.el is set up by default in the notmuch module, but was no longer installed by default, resulting in a `Problems while trying to load feature ‘ol-notmuch’` message when opening the org-agenda.

The new repo location is referenced in the file at org-contrib: https://git.sr.ht/~bzg/org-contrib/tree/e14dfea5/item/lisp/ol-notmuch.el#L8