### PR TITLE
fix(org): show outline path on refile to current file

### DIFF
--- a/modules/lang/org/autoload/org-refile.el
+++ b/modules/lang/org/autoload/org-refile.el
@@ -8,7 +8,7 @@
 If prefix ARG, copy instead of move."
   (interactive "P")
   (let ((org-refile-targets `((,file :maxlevel . 10)))
-        (org-refile-use-outline-path nil)
+        (org-refile-use-outline-path t)
         (org-refile-keep arg)
         current-prefix-arg)
     (call-interactively #'org-refile)))


### PR DESCRIPTION
  MEETS THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [x] No other pull requests exist for this issue
  - [x] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [x] Any relevant issues and PRs have been linked to
  - [x] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

Summary:

Before this change, the refile to current file command would result in a list of headings in current file. 

In case of duplicate names, it was hard to tell which heading referred to which.

With org-refile-use-outline-path set to t, now you should see a baths to each heading in a file.

I can easily replace this function in my local config, but I think this change should be the default.
