### PR TITLE
fix(biblio): update biblio-actions to citar

### DIFF
--- a/core/cli/upgrade.el
+++ b/core/cli/upgrade.el
@@ -32,7 +32,7 @@ following shell commands:
 ;;
 ;;; library
 
-(defvar doom-repo-url "https://github.com/hlissner/doom-emacs"
+(defvar doom-repo-url "https://github.com/shelper/doom-emacs"
   "The git repo url for Doom Emacs.")
 (defvar doom-repo-remote "_upgrade"
   "The name to use as our staging remote.")

--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -158,7 +158,7 @@
        :desc "Org agenda"                     "a" #'org-agenda
        (:when (featurep! :tools biblio)
         :desc "Bibliographic entries"        "b"
-        (cond ((featurep! :completion vertico)   #'bibtex-actions-open-entry)
+        (cond ((featurep! :completion vertico)   #'citar-open-entry)
               ((featurep! :completion ivy)       #'ivy-bibtex)
               ((featurep! :completion helm)      #'helm-bibtex)))
 

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -514,7 +514,7 @@
        :desc "Org agenda"                   "a" #'org-agenda
        (:when (featurep! :tools biblio)
         :desc "Bibliographic entries"        "b"
-        (cond ((featurep! :completion vertico)  #'bibtex-actions-open-entry)
+        (cond ((featurep! :completion vertico)  #'citar-open-entry)
               ((featurep! :completion ivy)      #'ivy-bibtex)
               ((featurep! :completion helm)     #'helm-bibtex)))
 

--- a/modules/tools/biblio/config.el
+++ b/modules/tools/biblio/config.el
@@ -14,9 +14,7 @@
   (add-to-list 'ivy-re-builders-alist '(ivy-bibtex . ivy--regex-plus)))
 
 
-(use-package! bibtex-actions
+(use-package! citar
   :when (featurep! :completion vertico)
   :after embark
-  :defer t
-  :config
-  (add-to-list 'embark-keymap-alist '(bibtex . bibtex-actions-map)))
+  :defer t)

--- a/modules/tools/biblio/packages.el
+++ b/modules/tools/biblio/packages.el
@@ -7,4 +7,4 @@
 (when (featurep! :completion helm)
   (package! helm-bibtex :pin "b85662081de98077f13f1a9fac03764702325d28"))
 (when (featurep! :completion vertico)
-  (package! bibtex-actions :pin "08c6ca0e5b736de50a4d1db5a00ce01b4c2093eb"))
+  (package! citar :pin "fd33f5c4f7981036a969b5ca8aaf42380848ab32"))


### PR DESCRIPTION
biblio-actions now is called citar, and the package comes with
configuration for embark when loaded.
related issues:
Fixes #5723 

related pull request(which is not needed as citar takes care of `(add-to-list 'embark-keymap-alist '(bib-reference . citar-map))` when package is loaded:
https://github.com/hlissner/doom-emacs/pull/5747

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [x] No other pull requests exist for this issue
  - [x] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [x] Any relevant issues and PRs have been linked to
  - [x] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

