### PR TITLE
refactor(notmuch): parameterize delete/spam tags

### DIFF
--- a/modules/email/notmuch/autoload.el
+++ b/modules/email/notmuch/autoload.el
@@ -76,32 +76,32 @@
 ;;;###autoload
 (defun +notmuch/search-delete ()
   (interactive)
-  (notmuch-search-add-tag (list "+trash" "-inbox" "-unread"))
+  (notmuch-search-add-tag +notmuch-delete-tags)
   (notmuch-tree-next-message))
 
 ;;;###autoload
 (defun +notmuch/tree-delete ()
   (interactive)
-  (notmuch-tree-add-tag (list "+trash" "-inbox" "-unread"))
+  (notmuch-tree-add-tag +notmuch-delete-tags)
   (notmuch-tree-next-message))
 
 ;;;###autoload
 (defun +notmuch/show-delete ()
   "Mark email for deletion in notmuch-show"
   (interactive)
-  (notmuch-show-add-tag (list "+trash" "-inbox" "-unread"))
+  (notmuch-show-add-tag +notmuch-delete-tags)
   (notmuch-show-next-thread-show))
 
 ;;;###autoload
 (defun +notmuch/search-spam ()
   (interactive)
-  (notmuch-search-add-tag (list "+spam" "-inbox" "-unread"))
+  (notmuch-search-add-tag +notmuch-spam-tags)
   (notmuch-search-next-thread))
 
 ;;;###autoload
 (defun +notmuch/tree-spam ()
   (interactive)
-  (notmuch-tree-add-tag (list "+spam" "-inbox" "-unread"))
+  (notmuch-tree-add-tag +notmuch-spam-tags)
   (notmuch-tree-next-message))
 
 ;;;###autoload

--- a/modules/email/notmuch/config.el
+++ b/modules/email/notmuch/config.el
@@ -25,6 +25,16 @@ OR a shell command string such as
 (defvar +notmuch-mail-folder "~/.mail/account.gmail"
   "Where your email folder is located (for use with gmailieer).")
 
+(defvar +notmuch-delete-tags '("+trash" "-inbox" "-unread")
+  "Tags applied to mark email for deletion.
+
+When replacing the +trash tag by a different tag such as
++deleted, you will need to update the notmuch-saved-searches
+variable accordingly.")
+
+(defvar +notmuch-spam-tags '("+spam" "-inbox" "-unread")
+  "Tags applied to mark email as spam.")
+
 
 ;;
 ;;; Packages


### PR DESCRIPTION
Introduce `+notmuch-delete-tags` and `+notmuch-spam-tags` variables instead of hardcoding the tags. The default values are set to the previously hardcoded values and the change does thus not break any existing users.