### PR TITLE
fix(latex): run AUCTeX folding after font locking

### DIFF
--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -115,9 +115,11 @@ If no viewers are found, `latex-preview-pane' is used.")
 
 (use-package! tex-fold
   :when (featurep! +fold)
-  :hook (TeX-mode . TeX-fold-buffer)
+  :hook (TeX-mode . +latex-TeX-fold-buffer-h)
   :hook (TeX-mode . TeX-fold-mode)
   :config
+  (defun +latex-TeX-fold-buffer-h ()
+    (run-with-idle-timer 0 nil 'TeX-fold-buffer))
   ;; Fold after all auctex macro insertions
   (advice-add #'TeX-insert-macro :after #'+latex-fold-last-macro-a)
   ;; Fold after cdlatex macro insertions


### PR DESCRIPTION
This guarantees that `TeX-fold-buffer` is run after the style hooks and not before. Otherwise, it looks like they may reset/erase font-lock stuff you have set up.

Currently, `TeX-fold-buffer` sometimes is applied before font locking hooks, causing incomplete folding (usually wrong colorization). 
