### PR TITLE
fix(org): correct renamed variable

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -298,7 +298,7 @@ Also adds support for a `:sync' parameter to override `:async'."
                ;; Since Doom adds its most expensive hooks to
                ;; MAJOR-MODE-local-vars-hook, we can savely inhibit those.
                (lambda ()
-                 (let ((doom-inhibit-local-var-hooks t))
+                 (let ((doom-inhibit-major-mode-post-hooks t))
                    (funcall initialize)))
              initialize)
            args))


### PR DESCRIPTION
`doom-inhibit-local-var-hooks` was renamed to `doom-inhibit-major-mode-post-hooks`.