### PR TITLE
quick fix(mu4e): incorrect access of from addr slot

### DIFF
--- a/modules/email/mu4e/autoload/email.el
+++ b/modules/email/mu4e/autoload/email.el
@@ -199,7 +199,7 @@ is tomorrow.  With two prefixes, select the deadline."
                               "[[mu4e:msgid:"
                               (plist-get msg :message-id) "]["
                               (truncate-string-to-width
-                               (or (caar from) (cadr from)) 25 nil nil t)
+                               (or (caar from) (cdar from)) 25 nil nil t)
                               " - "
                               (truncate-string-to-width
                                (plist-get msg :subject) 40 nil nil t)


### PR DESCRIPTION
Within +mu4e/capture-msg-to-agenda, the from address is stored in the
cdar not the cadr.

Unfortunately, I think I just made a typo in the original implementation, oh well — it comes up rarely but this should fix it.