### PR TITLE
fix(org): no roam buffer for capture buffers

### DIFF
--- a/modules/lang/org/contrib/roam2.el
+++ b/modules/lang/org/contrib/roam2.el
@@ -91,7 +91,8 @@ In case of failure, fail gracefully."
   (add-hook! 'org-roam-find-file-hook :append
     (defun +org-roam-open-with-buffer-maybe-h ()
       (and +org-roam-open-buffer-on-find-file
-           (not org-roam-capture--node) ; don't proc for capture buffers
+           (not org-roam-capture--node) ;; don't proc for roam capture buffers
+           (not org-capture-mode) ;; don't proc for normal capture buffers
            (not (eq 'visible (org-roam-buffer--visibility)))
            (org-roam-buffer-toggle))))
 


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

This pr changes the hook `org-roam-find-file`, so that it checks if the buffer was opened by `org-capture`. 

PS: using `(not (window-parameter nil 'window-side))` instead of `(not org-capture-mode)` would probably work as well, but this line was removed in the transition from roam to roamv2, which is why I'm not sure if this line is still wanted
