### PR TITLE
fix(mu4e): only bind `h` when `workspaces` loaded

### DIFF
--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -193,8 +193,9 @@
   (when (fboundp 'imagemagick-register-types)
     (imagemagick-register-types))
 
-  (map! :map mu4e-main-mode-map
-        :ne "h" #'+workspace/other)
+  (when (featurep! :ui workspaces)
+    (map! :map mu4e-main-mode-map
+          :ne "h" #'+workspace/other))
 
   (map! :map mu4e-headers-mode-map
         :vne "l" #'+mu4e/capture-msg-to-agenda)


### PR DESCRIPTION
Tiny change.

Fixes bug about void function `+workspace/other` when pressing `h` in `mu3e` when workspaces are deactivated.