### PR TITLE
fix(latex): respect reftex-cite-format setting

### DIFF
--- a/modules/lang/latex/+ref.el
+++ b/modules/lang/latex/+ref.el
@@ -5,6 +5,11 @@
   :config
   ;; set up completion for citations and references
   (set-company-backend! 'reftex-mode 'company-reftex-labels 'company-reftex-citations)
+  ;; This variable was introduced in AUCTeX 11.90.
+  ;; We need set LaTeX-reftex-cite-format-auto-activate to nil 
+  ;; when setting reftex-cite-format below
+  ;; https://superuser.com/a/1386206
+  (setq LaTeX-reftex-cite-format-auto-activate nil)
   ;; Get ReTeX working with biblatex
   ;; http://tex.stackexchange.com/questions/31966/setting-up-reftex-with-biblatex-citation-commands/31992#31992
   (setq reftex-cite-format


### PR DESCRIPTION
With AUCTeX (version 11.90 and above),  we have to set `LaTeX-reftex-cite-format-auto-activate` to `nil` when setting `reftex-cite-format`.

To see the problem with the current setting, open this test file in emacs and invoke `C-c [` (or `reftex-citation`), the selection menu will be somthing like
```
SELECT A CITATION FORMAT

[^M]   \cite{%l}
[t]    \citet{%l}
[T]    \citet*{%l}
[p]    \citep{%l}
[P]    \citep*{%l}
[e]    \citep[e.g.][]{%l}
[s]    \citep[see][]{%l}
[a]    \citeauthor{%l}
[A]    \citeauthor*{%l}
[y]    \citeyear{%l}
```

Test file:
```latex
\documentclass{article}
\usepackage{natbib}
\begin{document}
\end{document}
```
