### PR TITLE
fix(dart): remove hardcoded path to flutter SDK

### DIFF
--- a/modules/lang/dart/config.el
+++ b/modules/lang/dart/config.el
@@ -4,9 +4,6 @@
   :when (featurep! +lsp)
   :hook (dart-mode-local-vars . lsp!)
   :config
-  (when (and (featurep! +flutter) IS-LINUX)
-    (when-let (path (doom-glob "/opt/flutter/bin/cache/dart-sdk"))
-      (setq flutter-sdk-path (car path))))
   (set-ligatures! '(dart-mode)
     ;; Functional
     :def "Function"


### PR DESCRIPTION
This is unnecesary since hover search flutter in the path

Emacs says that file does not exists when I try to run any flutter command and I can't override `flutter-sdk-path` on the config file.
Removing these lines everything works fine