### PR TITLE
fix(popup,undo): make undo-tree visualizer work with our popup manager

### DIFF
--- a/modules/emacs/undo/config.el
+++ b/modules/emacs/undo/config.el
@@ -80,6 +80,15 @@
       :filter-return #'undo-tree-make-history-save-file-name
       (concat file ".zst")))
 
+  ;; Make these functions respect the value of `undo-tree-visualizer-diff'
+  (defun +keep-undo-tree-visualizer-diff-a (fn &rest args)
+    (let (old-undo-tree-visualizer-dif undo-tree-visualizer-diff)
+      (apply fn args)
+      (setq undo-tree-visualizer-diff old-undo-tree-visualizer-dif)))
+
+  (advice-add #'undo-tree-visualizer-show-diff :around #'+keep-undo-tree-visualizer-diff-a)
+  (advice-add #'undo-tree-visualizer-hide-diff :around #'+keep-undo-tree-visualizer-diff-a)
+
   ;; Strip text properties from undo-tree data to stave off bloat. File size
   ;; isn't the concern here; undo cache files bloat easily, which can cause
   ;; freezing, crashes, GC-induced stuttering or delays when opening files.

--- a/modules/ui/popup/+hacks.el
+++ b/modules/ui/popup/+hacks.el
@@ -362,10 +362,8 @@ Ugh, such an ugly hack."
 (defadvice! +popup--use-popup-window-for-undo-tree-visualizer-a (fn &rest args)
   "TODO"
   :around #'undo-tree-visualize
-  (if undo-tree-visualizer-diff
-      (apply fn args)
-    (letf! ((#'switch-to-buffer-other-window #'pop-to-buffer))
-      (apply fn args))))
+   (letf! ((#'switch-to-buffer-other-window #'pop-to-buffer))
+      (apply fn args)))
 
 ;;;###package wgrep
 (progn


### PR DESCRIPTION
Fixes #5317

`undo-tree-visualizer-{show/hide}-diff` changes the value of `undo-tree-visualizer-diff`, so even if it is set to `t` (as default in doom), when the user quits the visualizer (by pressing `q`), this variable is set to `nil` (in `undo-tree-visualizer-hide-diff`).
An unexpected behavior is that first the visualizer is shown in a side window, and the second time it is invoked, it is shown in a popup.

This forces `undo-tree` visualizer always show in popup, and makes it respect the value of `undo-tree-visualizer-diff`.

