### PR TITLE
fix(mu4e): do not set coding-system-for-read globally

### DIFF
--- a/modules/email/mu4e/autoload/mu-lock.el
+++ b/modules/email/mu4e/autoload/mu-lock.el
@@ -16,9 +16,9 @@
   "Get info on the PID refered to in `+mu4e-lock-file' in the form (pid . process-attributes)
  If the file or process do not exist, the lock file is deleted an nil returned."
   (when (file-exists-p +mu4e-lock-file)
-    (let* ((pid (string-to-number
+    (let* ((coding-system-for-read 'utf-8)
+           (pid (string-to-number
                  (with-temp-buffer
-                   (setq coding-system-for-read 'utf-8)
                    (insert-file-contents +mu4e-lock-file)
                    (buffer-string))))
            (process (process-attributes pid)))


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

Fixes #5788 <!-- remove if not applicable -->

In the function `+mu4e-lock-pid-info` in `mu-lock.el`, the variable `coding-system-for-read` is set globally which is against its documentation's recommendation and can cause issues as described in #5788. Setting the value in the `let*` statement instead through `setq` fixes this issue for me.