### PR TITLE
fix(notmuch) incorrect type used for window

### DIFF
--- a/modules/email/notmuch/autoload.el
+++ b/modules/email/notmuch/autoload.el
@@ -8,9 +8,9 @@
       (progn
         (when (featurep! :ui workspaces)
           (+workspace-switch "*MAIL*" t))
-        (if-let* ((buf (cl-find-if (lambda (it) (string-match-p "^\\*notmuch" (buffer-name (window-buffer it))))
+        (if-let* ((win (cl-find-if (lambda (it) (string-match-p "^\\*notmuch" (buffer-name (window-buffer it))))
                                    (doom-visible-windows))))
-            (select-window (get-buffer-window buf))
+            (select-window win)
           (funcall +notmuch-home-function))
         (when (featurep! :ui workspaces)
           (+workspace/display)))


### PR DESCRIPTION
`if-let*` returns a window type, not a buffer which would cause a `Wrong type argument: stringp, #<window 3 on *doom*>` when trying to access notmuch via `=notmuch` while it is already open in a workspace.
