### PR TITLE
fix(evil): handle edge cases of embrace

### DIFF
--- a/modules/editor/evil/autoload/embrace.el
+++ b/modules/editor/evil/autoload/embrace.el
@@ -17,10 +17,11 @@
   (let ((char (read-char "\\")))
     (if (eq char 27)
         (cons "" "")
-      (let ((pair (+evil--embrace-get-pair (string char)))
-            (text (if (sp-point-in-string) "\\\\%s" "\\%s")))
-        (cons (format text (car pair))
-              (format text (cdr pair)))))))
+      (let* ((pair (+evil--embrace-get-pair (string char)))
+             (escape (if (sp-point-in-string) "\\\\" "\\"))
+             (escape (format "\\1%s" (regexp-quote escape))))
+        (cons (replace-regexp-in-string "^\\( *\\)" escape (car pair))
+              (replace-regexp-in-string "^\\( *\\)" escape (cdr pair)))))))
 
 ;;;###autoload
 (defun +evil--embrace-latex ()


### PR DESCRIPTION
If the surround key is `\(`, the text should be surrounded as
`\( text \)`. The same for `\[` and `\{`.

Currently, when the surround key is `\(`, `+evil--embrace-escaped` returns `"\( " . "\ )"`, which changes the text to `\( text\ )` (notice a whitespace before `\` and `)`).