### PR TITLE
fix: +default/discover-projects not reading depth

### DIFF
--- a/modules/config/default/autoload/files.el
+++ b/modules/config/default/autoload/files.el
@@ -52,7 +52,7 @@ If prefix ARG is non-nil, prompt for the search path."
         (dolist (dir projectile-project-search-path)
           (cl-destructuring-bind (dir . depth) (if (consp dir) dir (cons dir nil))
             (if (not (file-accessible-directory-p dir))
-                (message "%S was inaccessible and couldn't searched" dir)
+                (message "%S was inaccessible and couldn't be searched" dir)
               (projectile-discover-projects-in-directory dir depth))))))))
 
 ;;;###autoload

--- a/modules/config/default/autoload/files.el
+++ b/modules/config/default/autoload/files.el
@@ -50,9 +50,10 @@ If prefix ARG is non-nil, prompt for the search path."
                  (funcall projectile-add-known-project project-root)
                  (message "Added %S to known project roots" project-root)))
         (dolist (dir projectile-project-search-path)
-          (if (not (file-accessible-directory-p dir))
-              (message "%S was inaccessible and couldn't searched" dir)
-            (projectile-discover-projects-in-directory dir)))))))
+          (cl-destructuring-bind (dir . depth) (if (consp dir) dir (cons dir nil))
+            (if (not (file-accessible-directory-p dir))
+                (message "%S was inaccessible and couldn't searched" dir)
+              (projectile-discover-projects-in-directory dir depth))))))))
 
 ;;;###autoload
 (defun +default/dired (arg)


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [x] No other pull requests exist for this issue
  - [x] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [x] Any relevant issues and PRs have been linked to
  - [x] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

Fix `+default/discover-projects` to read the depth in `projectile-project-search-path`.