### PR TITLE
dev(doctor): add error message for Emacs dev versions

### DIFF
--- a/core/cli/doctor.el
+++ b/core/cli/doctor.el
@@ -50,6 +50,17 @@ in."
   (print! (start "Checking your Emacs version..."))
   (print-group!
    (cond
+    ((string= ".50" (substring emacs-version -3))
+     (error! "Emacs development version detected (%s)" emacs-version)
+     ;; There are 2 newlines between each item to fight against
+     ;; the (fill-region) call in `doom--output-autofill'
+     (explain! "Doom supports this version, but you are using a development version of Emacs! "
+               "Be prepared for possibly weekly breakages that\n\n"
+               "\t- you will have to investigate yourself,\n\n"
+               "\t- might appear, or be solved, on any Emacs update,\n\n"
+               "\t- might depend subtly on upstream packages updates\n\n"
+               "You might need to unpin packages to get a fix for a specific commit of Emacs, "
+               "and you should be ready to downgrade Emacs if something is just not fixable."))
     (EMACS28+
      (warn! "Emacs %s detected" emacs-version)
      (explain! "Doom supports this version, but you are living on the edge! "


### PR DESCRIPTION
The message simply test for the "not-a-version-yet" patch number and
displays an explanation to prepare users for raised error frequency and
having a backup version of Emacs if they do not want to deal with issues.

(Of course, feel free to discard it if it's too much).

Rendered (yes, I struggled with autofill :( ) :

![image](https://user-images.githubusercontent.com/10496163/142594234-0c8260fa-d3d8-429e-846f-2fa5744f0dbe.png)
