### PR TITLE
docs(javascript): fix code rendering on GitHub

### DIFF
--- a/modules/lang/javascript/README.org
+++ b/modules/lang/javascript/README.org
@@ -12,7 +12,7 @@
   - [[#arch-linux][Arch Linux]]
   - [[#opensuse][openSUSE]]
 - [[#troubleshooting][Troubleshooting]]
-  - [[#tide-sort-completions-by-kind-isnt-respected][~tide-sort-completions-by-kind~ isn't respected]]
+  - [[#tide-sort-completions-by-kind-isnt-respected][ ~tide-sort-completions-by-kind~ isn't respected]]
 - [[#appendix][Appendix]]
   - [[#commands][Commands]]
 


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

An extra space is needed for the `~code~` markup to be correctly rendered on GitHub.