### PR TITLE
tweak(eshell): C-l binding to clear scrollback

### DIFF
--- a/modules/term/eshell/config.el
+++ b/modules/term/eshell/config.el
@@ -147,7 +147,7 @@ You should use `set-eshell-alias!' to change this.")
         [remap evil-window-split]   #'+eshell/split-below
         [remap evil-window-vsplit]  #'+eshell/split-right
         ;; To emulate terminal keybinds
-        "C-l"   #'eshell/clear
+        "C-l"   (cmd! (eshell/clear-scrollback) (eshell-emit-prompt))
         (:localleader
          "b" #'eshell-insert-buffer-name
          "e" #'eshell-insert-envvar


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [x] No other pull requests exist for this issue
  - [x] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [x] Any relevant issues and PRs have been linked to
  - [x] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

Currently eshell has a `clear` alias which maps to `eshell/clear-scrollback`. It also has a <kbd>C-l</kbd> binding for calling `eshell/clear`, which doesn't call the alias. This PR makes <kbd>C-l</kbd> call `eshell/clear-scrollback` for consistency with the alias.