### PR TITLE
fix(lookup): xref 1.3.0 removed var xref--marker-ring

### DIFF
--- a/modules/tools/lookup/autoload/lookup.el
+++ b/modules/tools/lookup/autoload/lookup.el
@@ -188,15 +188,16 @@ This can be passed nil as its second argument to unset handlers for MODES. e.g.
                         (xref-find-backend)
                         identifier)))
     (when xrefs
-      (let ((marker-ring (ring-copy xref--marker-ring)))
+      (let* ((jumped nil)
+             (xref-after-jump-hook
+              (cons (lambda () (setq jumped t))
+                    xref-after-jump-hook)))
         (funcall (or show-fn #'xref--show-defs)
                  (lambda () xrefs)
                  nil)
         (if (cdr xrefs)
             'deferred
-          ;; xref will modify its marker stack when it finds a result to jump to.
-          ;; Use that to determine success.
-          (not (equal xref--marker-ring marker-ring)))))))
+          jumped)))))
 
 (defun +lookup-dictionary-definition-backend-fn (identifier)
   "Look up dictionary definition for IDENTIFIER."


### PR DESCRIPTION
Fixes #5737 

This is not a mode specific issue but is actually caused by changes to _xref_. _Xref_ was changed in the emacs repo about a month ago. I have already created a patch for a mode that needed to adjust to _xref_'s internal changes.

[xref's recent history](https://github.com/emacs-mirror/emacs/commits/master/lisp/progmodes/xref.el)

Xref started many backwards incompatible changes in the name of performance. The marker ring no longer exists as a variable. `+lookup--xref-show` will silently fail every time.

Switches to using `xref-after-jump-hook` to test whether _xref_ actually jumped to a definition. The hook is part of the exposed interface and should hopefully not change in the near future.
