### PR TITLE
feat(notmuch): only tag new messages w/ afew 

### DIFF
--- a/modules/email/notmuch/config.el
+++ b/modules/email/notmuch/config.el
@@ -19,8 +19,8 @@ More specifically, this accepts one of the following symbols (see
 OR a shell command string such as
 
   \"path/to/some/shell-script.sh\"
-  \"offlineimap && notmuch new && afew -a -t\"
-  \"mbsync %s -a && notmuch new && afew -a -t\"")
+  \"offlineimap && notmuch new && afew -n -t\"
+  \"mbsync %s -a && notmuch new && afew -n -t\"")
 
 (defvar +notmuch-mail-folder "~/.mail/account.gmail"
   "Where your email folder is located (for use with gmailieer).")
@@ -88,7 +88,7 @@ OR a shell command string such as
                notmuch-tree-mode-hook
                notmuch-search-mode-hook)
              #'hide-mode-line-mode)
- 
+
   (map! :localleader
         :map (notmuch-hello-mode-map notmuch-search-mode-map notmuch-tree-mode-map notmuch-show-mode-map)
         :desc "Compose email"   "c" #'+notmuch/compose


### PR DESCRIPTION
Tagging all messages can cause very heavy load and is not necessary.
Just indexing new messages is quicker and lighter.
If one needs to tag all messages again it is still possible to do so manually.

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [x] No other pull requests exist for this issue
  - [x] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [x] Any relevant issues and PRs have been linked to
  - [x] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

Changes `afew -a -t` to `afew -n -t` which is an equivalent of `afew --new --tag`.