### PR TITLE
fix(biblio): do not load org mode eagerly.

### DIFF
--- a/modules/tools/biblio/config.el
+++ b/modules/tools/biblio/config.el
@@ -54,6 +54,7 @@
 ;;;; Third-party
 
 (use-package! citar-org
+  :no-require
   :when (featurep! :lang org +roam2)
   :config
   ;; Include property drawer metadata for 'org-roam' v2.


### PR DESCRIPTION
-------

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [X] It targets the develop branch
  - [X] No other pull requests exist for this issue
  - [X] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [X] Any relevant issues and PRs have been linked to
  - [X] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

Due to unconditional loading configuration for `citar-org` package, `org` is also being loaded eagerly.
Especially, causes a warning message from doom, like

``` text
‘org’ was already loaded by the time lang/org loaded, this may cause issues
```