### PR TITLE
fix: remap xref-go-* to better-jumper

### DIFF
--- a/core/core-editor.el
+++ b/core/core-editor.el
@@ -432,6 +432,8 @@ files, so this replace calls to `pp' with the much faster `prin1'."
   (global-set-key [remap evil-jump-forward]  #'better-jumper-jump-forward)
   (global-set-key [remap evil-jump-backward] #'better-jumper-jump-backward)
   (global-set-key [remap xref-pop-marker-stack] #'better-jumper-jump-backward)
+  (global-set-key [remap xref-go-back] #'better-jumper-jump-backward)
+  (global-set-key [remap xref-go-forward] #'better-jumper-jump-forward)
   :config
   (defun doom-set-jump-a (fn &rest args)
     "Set a jump point and ensure fn doesn't set any new jump points."


### PR DESCRIPTION
Emacs 29.x introduces xref-go-{back,forward}. xref-pop-marker-stack is
now obsolete.

Fix: #5813
Signed-off-by: Clément Guidi <clementguidi@gmail.com>
