### PR TITLE
refactor(latex): nitpick, table d'hôte

### DIFF
--- a/modules/lang/latex/+fontification.el
+++ b/modules/lang/latex/+fontification.el
@@ -1,11 +1,11 @@
 ;;; lang/latex/+fontification.el -*- lexical-binding: t; -*-
 
-;; Fontification taken from https://tex.stackexchange.com/a/86119/81279
+;; Fontification taken from https://tex.stackexchange.com/a/86119/81279.
 (setq font-latex-match-reference-keywords
-      '(;; biblatex
+      '(;; BibLaTeX.
         ("printbibliography" "[{")
         ("addbibresource" "[{")
-        ;; Standard commands
+        ;; Standard commands.
         ("cite" "[{")
         ("citep" "[{")
         ("citet" "[{")
@@ -14,7 +14,7 @@
         ("Parencite" "[{")
         ("footcite" "[{")
         ("footcitetext" "[{")
-        ;; Style-specific commands
+        ;; Style-specific commands.
         ("textcite" "[{")
         ("Textcite" "[{")
         ("smartcite" "[{")
@@ -22,7 +22,7 @@
         ("cite*" "[{")
         ("parencite*" "[{")
         ("supercite" "[{")
-        ;; Qualified citation lists
+        ;; Qualified citation lists.
         ("cites" "[{")
         ("Cites" "[{")
         ("parencites" "[{")
@@ -34,14 +34,14 @@
         ("textcites" "[{")
         ("Textcites" "[{")
         ("supercites" "[{")
-        ;; Style-independent commands
+        ;; Style-independent commands.
         ("autocite" "[{")
         ("Autocite" "[{")
         ("autocite*" "[{")
         ("Autocite*" "[{")
         ("autocites" "[{")
         ("Autocites" "[{")
-        ;; Text commands
+        ;; Text commands.
         ("citeauthor" "[{")
         ("Citeauthor" "[{")
         ("citetitle" "[{")
@@ -49,9 +49,9 @@
         ("citeyear" "[{")
         ("citedate" "[{")
         ("citeurl" "[{")
-        ;; Special commands
+        ;; Special commands.
         ("fullcite" "[{")
-        ;; cleveref
+        ;; Cleveref.
         ("cref" "{")
         ("Cref" "{")
         ("cpageref" "{")
@@ -63,22 +63,22 @@
         ("labelcref" "{")))
 
 (setq font-latex-match-textual-keywords
-      '(;; biblatex brackets
+      '(;; BibLaTeX brackets.
         ("parentext" "{")
         ("brackettext" "{")
         ("hybridblockquote" "[{")
-        ;; Auxiliary Commands
+        ;; Auxiliary commands.
         ("textelp" "{")
         ("textelp*" "{")
         ("textins" "{")
         ("textins*" "{")
-        ;; subcaption
+        ;; Subcaption.
         ("subcaption" "[{")))
 
 (setq font-latex-match-variable-keywords
-      '(;; amsmath
+      '(;; Amsmath.
         ("numberwithin" "{")
-        ;; enumitem
+        ;; Enumitem.
         ("setlist" "[{")
         ("setlist*" "[{")
         ("newlist" "{")

--- a/modules/lang/latex/+ref.el
+++ b/modules/lang/latex/+ref.el
@@ -3,10 +3,10 @@
 (use-package! reftex
   :hook (LaTeX-mode . reftex-mode)
   :config
-  ;; set up completion for citations and references
+  ;; Set up completion for citations and references.
   (set-company-backend! 'reftex-mode 'company-reftex-labels 'company-reftex-citations)
-  ;; Get ReTeX working with biblatex
-  ;; http://tex.stackexchange.com/questions/31966/setting-up-reftex-with-biblatex-citation-commands/31992#31992
+  ;; Get RefTeX working with BibLaTeX, see
+  ;; http://tex.stackexchange.com/questions/31966/setting-up-reftex-with-biblatex-citation-commands/31992#31992.
   (setq reftex-cite-format
         '((?a . "\\autocite[]{%l}")
           (?b . "\\blockcquote[]{%l}{}")
@@ -31,7 +31,7 @@
           :e "q"   #'kill-buffer-and-window
           :e "ESC" #'kill-buffer-and-window)))
 
-;; set up mode for bib files
+;; Set up mode for bib files.
 (after! bibtex
   (setq bibtex-dialect 'biblatex
         bibtex-align-at-equal-sign t

--- a/modules/lang/latex/+viewers.el
+++ b/modules/lang/latex/+viewers.el
@@ -1,6 +1,6 @@
 ;;; lang/latex/+viewers.el -*- lexical-binding: t; -*-
 
-;; fall back pdf previewing to latex-preview-pane
+;; Fall back PDF previewing to `latex-preview-pane-mode'.
 (add-to-list 'TeX-view-program-selection '(output-pdf "preview-pane") 'append)
 (add-to-list 'TeX-view-program-list '("preview-pane" latex-preview-pane-mode))
 
@@ -25,7 +25,7 @@
     (`okular
      (when (executable-find "okular")
        ;; Configure Okular as viewer. Including a bug fix
-       ;; (https://bugs.kde.org/show_bug.cgi?id=373855)
+       ;; (https://bugs.kde.org/show_bug.cgi?id=373855).
        (add-to-list 'TeX-view-program-list '("Okular" ("okular --noraise --unique file:%o" (mode-io-correlate "#src:%n%a"))))
        (add-to-list 'TeX-view-program-selection '(output-pdf "Okular"))))
 
@@ -41,16 +41,16 @@
      (when (featurep! :tools pdf)
        (add-to-list 'TeX-view-program-selection '(output-pdf "PDF Tools"))
        (when IS-MAC
-         ;; PDF Tools isn't in `TeX-view-program-list-builtin' on macs
+         ;; PDF Tools isn't in `TeX-view-program-list-builtin' on macs.
          (add-to-list 'TeX-view-program-list '("PDF Tools" TeX-pdf-tools-sync-view)))
-       ;; Update PDF buffers after successful LaTeX runs
+       ;; Update PDF buffers after successful LaTeX runs.
        (add-hook 'TeX-after-compilation-finished-functions #'TeX-revert-document-buffer)))))
 
 
 (after! latex-preview-pane
   (setq latex-preview-pane-multifile-mode 'auctex)
 
-  ;; TODO PR this to maintained fork. Original project appears abandoned
+  ;; TODO: PR this to maintained fork by arifer48. The original project appears abandoned.
   (defadvice! +latex--dont-reopen-preview-pane-a (fn &rest args)
     "Once the preview pane has been closed it should not be reopened."
     :around #'latex-preview-pane-update

--- a/modules/lang/latex/autoload.el
+++ b/modules/lang/latex/autoload.el
@@ -50,8 +50,8 @@ function uses."
   "Advice to auto-fold LaTeX macros after functions that
 typically insert macros."
   ;; A simpler approach would be to just fold the whole line, but if point was
-  ;; inside a macro that would would kick it out. So instead we fold the last
-  ;; macro before point, hoping its the one newly inserted.
+  ;; inside a macro that would kick it out. So instead we fold the last macro
+  ;; before point, hoping its the one newly inserted.
   (TeX-fold-region (save-excursion
                      (search-backward "\\" (line-beginning-position) t)
                      (point))

--- a/modules/lang/latex/config.el
+++ b/modules/lang/latex/config.el
@@ -3,7 +3,7 @@
 (defconst +latex-indent-item-continuation-offset 'align
   "Level to indent continuation of enumeration-type environments.
 
-i.e. This affects \\item, \\enumerate, and \\description.
+I.e., this affects \\item, \\enumerate, and \\description.
 
 Set this to `align' for:
 
@@ -13,7 +13,7 @@ Set this to `align' for:
 Set to `auto' for continuation lines to be offset by `LaTeX-indent-line':
 
   \\item lines aligned
-    like this, assuming LaTeX-indent-line == 2
+    like this, assuming `LaTeX-indent-line' == 2
 
 Any other fixed integer will be added to `LaTeX-item-indent' and the current
 indentation level.
@@ -24,16 +24,16 @@ You'll need to adjust `LaTeX-item-indent' to control indentation of \\item
 itself.")
 
 (defvar +latex-enable-unicode-math nil
-  "If non-nil, use `company-math-symbols-unicode' backend in LaTeX-mode,
-enabling unicode symbols in math regions. This requires the unicode-math latex
+  "If non-nil, use `company-math-symbols-unicode' backend in `LaTeX-mode',
+enabling unicode symbols in math regions. This requires the unicode-math LaTeX
 package to be installed.")
 
 (defvar +latex-viewers '(skim evince sumatrapdf zathura okular pdf-tools)
-  "A list of enabled latex viewers to use, in this order. If they don't exist,
+  "A list of enabled LaTeX viewers to use, in this order. If they don't exist,
 they will be ignored. Recognized viewers are skim, evince, sumatrapdf, zathura,
 okular and pdf-tools.
 
-If no viewers are found, `latex-preview-pane' is used.")
+If no viewer is found, `latex-preview-pane-mode' is used.")
 
 ;;
 (defvar +latex--company-backends nil)
@@ -46,44 +46,46 @@ If no viewers are found, `latex-preview-pane' is used.")
 
 (setq TeX-parse-self t ; parse on load
       TeX-auto-save t  ; parse on save
-      ;; use hidden dirs for auctex files
+      ;; Use hidden directories for AUCTeX files.
       TeX-auto-local ".auctex-auto"
       TeX-style-local ".auctex-style"
       TeX-source-correlate-mode t
       TeX-source-correlate-method 'synctex
-      ;; don't start the emacs server when correlating sources
+      ;; Don't start the Emacs server when correlating sources.
       TeX-source-correlate-start-server nil
-      ;; automatically insert braces after sub/superscript in math mode
+      ;; Automatically insert braces after sub/superscript in `LaTeX-math-mode'.
       TeX-electric-sub-and-superscript t
-      ;; just save, dont ask me before each compilation
+      ;; Just save, don't ask before each compilation.
       TeX-save-query nil)
 
 
 (after! tex
-  ;; fontify common latex commands
+  ;; Fontify common LaTeX commands.
   (load! "+fontification")
-  ;; select viewer
+  ;; Select viewer.
   (load! "+viewers")
-  ;; do not prompt for master
+  ;; Do not prompt for a master file.
   (setq-default TeX-master t)
-  ;; set-up chktex
+  ;; Set-up chktex.
   (setcar (cdr (assoc "Check" TeX-command-list)) "chktex -v6 -H %s")
   (setq-hook! 'TeX-mode-hook
-    ;; tell emacs how to parse tex files
+    ;; Tell Emacs how to parse TeX files.
     ispell-parser 'tex
-    ;; Don't auto-fill in math blocks
+    ;; Don't auto-fill in math blocks.
     fill-nobreak-predicate (cons #'texmathp fill-nobreak-predicate))
-  ;; Enable word wrapping
+  ;; Enable word wrapping.
   (add-hook 'TeX-mode-hook #'visual-line-mode)
-  ;; Enable rainbow mode after applying styles to the buffer
+  ;; Enable `rainbow-mode' after applying styles to the buffer.
   (add-hook 'TeX-update-style-hook #'rainbow-delimiters-mode)
-  ;; display output of latex commands in popup
+  ;; Display output of LaTeX commands in a popup.
   (set-popup-rules! '((" output\\*$" :size 15)
                       ("^\\*TeX \\(?:Help\\|errors\\)"
                        :size 0.3 :select t :ttl nil)))
   (after! smartparens-latex
+    ;; We have to use lower case modes here, because `smartparens-mode' uses
+    ;; the same during configuration.
     (let ((modes '(tex-mode plain-tex-mode latex-mode LaTeX-mode)))
-      ;; All these excess pairs dramatically slow down typing in latex buffers,
+      ;; All these excess pairs dramatically slow down typing in LaTeX buffers,
       ;; so we remove them. Let snippets do their job.
       (dolist (open '("\\left(" "\\left[" "\\left\\{" "\\left|"
                       "\\bigl(" "\\biggl(" "\\Bigl(" "\\Biggl(" "\\bigl["
@@ -92,10 +94,10 @@ If no viewers are found, `latex-preview-pane' is used.")
                       "\\lfloor" "\\lceil" "\\langle"
                       "\\lVert" "\\lvert" "`"))
         (sp-local-pair modes open nil :actions :rem))
-      ;; And tweak these so that users can decide whether they want use latex
-      ;; quotes or not, via `+latex-enable-plain-double-quotes'
+      ;; And tweak these so that users can decide whether they want use LaTeX
+      ;; quotes or not, via `+latex-enable-plain-double-quotes'.
       (sp-local-pair modes "``" nil :unless '(:add sp-in-math-p))))
-  ;; Hook lsp if enabled
+  ;; Hook LSP, if enabled.
   (when (featurep! +lsp)
     (add-hook! '(tex-mode-local-vars-hook
                  latex-mode-local-vars-hook)
@@ -120,12 +122,12 @@ If no viewers are found, `latex-preview-pane' is used.")
   :config
   (defun +latex-TeX-fold-buffer-h ()
     (run-with-idle-timer 0 nil 'TeX-fold-buffer))
-  ;; Fold after all auctex macro insertions
+  ;; Fold after all AUCTeX macro insertions.
   (advice-add #'TeX-insert-macro :after #'+latex-fold-last-macro-a)
-  ;; Fold after cdlatex macro insertions
+  ;; Fold after CDLaTeX macro insertions.
   (advice-add #'cdlatex-math-symbol :after #'+latex-fold-last-macro-a)
   (advice-add #'cdlatex-math-modify :after #'+latex-fold-last-macro-a)
-  ;; Fold after snippets
+  ;; Fold after snippets.
   (when (featurep! :editor snippets)
     (add-hook! 'TeX-fold-mode-hook
       (defun +latex-fold-snippet-contents-h ()
@@ -154,7 +156,8 @@ Math faces should stay fixed by the mixed-pitch blacklist, this is mostly for
 
 
 (after! latex
-  (setq LaTeX-section-hook ; Add the toc entry to the sectioning hooks.
+  ;; Add the TOC entry to the sectioning hooks.
+  (setq LaTeX-section-hook
         '(LaTeX-section-heading
           LaTeX-section-title
           LaTeX-section-toc
@@ -165,14 +168,14 @@ Math faces should stay fixed by the mixed-pitch blacklist, this is mostly for
   (when +latex--company-backends
     (set-company-backend! 'latex-mode +latex--company-backends))
 
-  ;; Provide proper indentation for LaTeX "itemize","enumerate", and
+  ;; Provide proper indentation for LaTeX "itemize", "enumerate", and
   ;; "description" environments. See
-  ;; http://emacs.stackexchange.com/questions/3083/how-to-indent-items-in-latex-auctex-itemize-environments
-  ;; Set `+latex-indent-item-continuation-offset' to 0 to disable this
+  ;; http://emacs.stackexchange.com/questions/3083/how-to-indent-items-in-latex-auctex-itemize-environments.
+  ;; Set `+latex-indent-item-continuation-offset' to 0 to disable this.
   (dolist (env '("itemize" "enumerate" "description"))
     (add-to-list 'LaTeX-indent-environment-list `(,env +latex-indent-item-fn)))
 
-  ;; Fix #1849: allow fill-paragraph in itemize/enumerate
+  ;; Fix #1849: allow fill-paragraph in itemize/enumerate.
   (defadvice! +latex--re-indent-itemize-and-enumerate-a (fn &rest args)
     :around #'LaTeX-fill-region-as-para-do
     (let ((LaTeX-indent-environment-list
@@ -194,7 +197,7 @@ Math faces should stay fixed by the mixed-pitch blacklist, this is mostly for
   (setq-default preview-scale 1.4
                 preview-scale-function
                 (lambda () (* (/ 10.0 (preview-document-pt)) preview-scale)))
-  ;; Don't cache preamble, it creates issues with synctex. Let users enable
+  ;; Don't cache preamble, it creates issues with SyncTeX. Let users enable
   ;; caching if they have compilation times that long.
   (setq preview-auto-cache-preamble nil)
   (map! :map LaTeX-mode-map
@@ -208,31 +211,31 @@ Math faces should stay fixed by the mixed-pitch blacklist, this is mostly for
   :hook (LaTeX-mode . cdlatex-mode)
   :hook (org-mode . org-cdlatex-mode)
   :config
-  ;; Use \( ... \) instead of $ ... $
+  ;; Use \( ... \) instead of $ ... $.
   (setq cdlatex-use-dollar-to-ensure-math nil)
-  ;; Disabling keys that have overlapping functionality with other parts of Doom
+  ;; Disabling keys that have overlapping functionality with other parts of Doom.
   (map! :map cdlatex-mode-map
-        ;; smartparens takes care of inserting closing delimiters, and if you
-        ;; don't use smartparens you probably won't want these also.
+        ;; Smartparens takes care of inserting closing delimiters, and if you
+        ;; don't use smartparens you probably don't want these either.
         "$" nil
         "(" nil
         "{" nil
         "[" nil
         "|" nil
         "<" nil
-        ;; TAB is used for cdlatex's snippets and navigation. But we have
-        ;; yasnippet for that.
+        ;; TAB is used for CDLaTeX's snippets and navigation. But we have
+        ;; Yasnippet for that.
         (:when (featurep! :editor snippets)
           "TAB" nil)
         ;; AUCTeX takes care of auto-inserting {} on _^ if you want, with
-        ;; `TeX-electric-sub-and-superscript'
+        ;; `TeX-electric-sub-and-superscript'.
         "^" nil
         "_" nil
-        ;; AUCTeX already provides this with `LaTeX-insert-item'
+        ;; AUCTeX already provides this with `LaTeX-insert-item'.
         [(control return)] nil))
 
 
-;; Nicely indent lines that have wrapped when visual line mode is activated
+;; Nicely indent lines that have wrapped when visual line mode is activated.
 (use-package! adaptive-wrap
   :hook (LaTeX-mode . adaptive-wrap-prefix-mode)
   :init (setq-default adaptive-wrap-extra-indent 0))
@@ -242,12 +245,12 @@ Math faces should stay fixed by the mixed-pitch blacklist, this is mostly for
   :when (featurep! +latexmk)
   :after latex
   :init
-  ;; Pass the -pdf flag when TeX-PDF-mode is active
+  ;; Pass the -pdf flag when TeX-PDF-mode is active.
   (setq auctex-latexmk-inherit-TeX-PDF-mode t)
-  ;; Set LatexMk as the default
+  ;; Set LatexMk as the default.
   (setq-hook! LaTeX-mode TeX-command-default "LatexMk")
   :config
-  ;; Add latexmk as a TeX target
+  ;; Add LatexMk as a TeX target.
   (auctex-latexmk-setup))
 
 
@@ -271,5 +274,5 @@ Math faces should stay fixed by the mixed-pitch blacklist, this is mostly for
   (add-to-list '+latex--company-backends #'+latex-symbols-company-backend nil #'eq))
 
 
-;; bibtex + reftex
+;; BibTeX + RefTeX.
 (load! "+ref")

--- a/modules/lang/latex/packages.el
+++ b/modules/lang/latex/packages.el
@@ -7,7 +7,7 @@
 (when (featurep! :editor evil +everywhere)
   (package! evil-tex :pin "aa0ddf8e768a24cda6d50d07f04c8e7813a2dccd"))
 
-;; Optional module features:
+;; Optional module features.
 
 (when (featurep! +latexmk)
   (package! auctex-latexmk :pin "4d353522650d7685acbf1d38f7dbc504f734bd84"))
@@ -15,7 +15,7 @@
 (when (featurep! +cdlatex)
   (package! cdlatex :pin "f215b70c5cb02bbc43f5a7d5c8e5e3460ff82428"))
 
-;; Features according to other user selected options
+;; Features according to other user selected options.
 
 (when (featurep! :completion company)
   (package! company-auctex :pin "9400a2ec7459dde8cbf1a5d50dfee4e300ed7e18")


### PR DESCRIPTION
See #5621, actual changes to code have been removed.

This is a huge set of pedantic changes, none them affecting actual code.

Mostly, I tried to:
- use consistent names; e.g, use LaTeX wherever possible, not latex;
- fix broken symbol links;
- use capitalized comments with full stops.