### PR TITLE
docs(vertico): fix #+CREATED and #+SINCE keywords

### DIFF
--- a/modules/completion/vertico/README.org
+++ b/modules/completion/vertico/README.org
@@ -2,8 +2,8 @@
 --------------------------------------------------------------------------------
 #+TITLE:    :completion vertico
 #+SUBTITLE: Tomorrow's search engine
-#+CREATED:  July 31, 2021
-#+SINCE:    21.12.0 (#5299)
+#+CREATED:  July 25, 2021
+#+SINCE:    21.12.0 (#4664)
 
 * Description :unfold:
 This module enhances the Emacs search and completion experience, and also


### PR DESCRIPTION
They were generated using a subsequent Vertico PR, not the one that
added the module.