### PR TITLE
tweak(company): company-selection-wrap-around = t

### DIFF
--- a/modules/completion/company/config.el
+++ b/modules/completion/company/config.el
@@ -10,6 +10,7 @@
   (setq company-minimum-prefix-length 2
         company-tooltip-limit 14
         company-tooltip-align-annotations t
+        company-selection-wrap-around t
         company-require-match 'never
         company-global-modes
         '(not erc-mode


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

<!--  Fixes #0000 remove if not applicable -->
This PR do the followings:
 - Add `company-files`, which provides completion for file paths, to `company-backends`. This completion is really useful, and doesn't introduce significant CPU overhead.
 - Set value of `company-selection-wrap-around` to `t`. This behavior is the default in most code editors I know, for good reasons.