### PR TITLE
fix(ruby): enable web-mode for erb files

### DIFF
--- a/modules/lang/ruby/config.el
+++ b/modules/lang/ruby/config.el
@@ -35,6 +35,10 @@
         "{" #'ruby-toggle-block))
 
 
+(use-package! web-mode
+  :when (featurep! :lang web)
+  :mode "\\.erb\\'")
+
 (use-package! robe
   :defer t
   :init


### PR DESCRIPTION
<!--

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [X] It targets the develop branch
  - [X] No other pull requests exist for this issue
  - [X] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [X] Any relevant issues and PRs have been linked to
  - [X] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

.erb files in bare Doom were being opened in HTML mode, which mangles formatting
on save. This ensures that when ruby and web features are enabled, they open in
the more full-featured web-mode editor.
