### PR TITLE
fix(lib): add-hook! fails when passed a function quoted list

### DIFF
--- a/core/core-lib.el
+++ b/core/core-lib.el
@@ -641,9 +641,9 @@ This macro accepts, in order:
     (while rest
       (let* ((next (pop rest))
              (first (car-safe next)))
-        (push (cond ((memq first '(function nil))
+        (push (cond ((null first)
                      next)
-                    ((eq first 'quote)
+                    ((memq first '(function quote))
                      (let ((quoted (cadr next)))
                        (if (atom quoted)
                            next


### PR DESCRIPTION
-------

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [X] It targets the develop branch
  - [X] No other pull requests exist for this issue
  - [X] The issue is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [X] Any relevant issues and PRs have been linked to
  - [X] Commit messages conform to our conventions: https://doomemacs.org/d/how2commit

-->

I.e., diverges from what documented at demos.org:
```emacs-lisp
(add-hook! some-mode #'(enable-something and-another))
```
which should be expanded something like
```emacs-lisp
(add-hook 'some-mode-hook #'enable-something)
(add-hook 'some-mode-hook #'and-another)
```
but actually, ends up
```emacs-lisp
(add-hook 'some-mode-hook #'(enable-something and-another))
```

This commit addresses this issue.