### PR TITLE
feat(magit): replace github-review for code-review

### DIFF
--- a/modules/tools/magit/autoload.el
+++ b/modules/tools/magit/autoload.el
@@ -153,9 +153,9 @@ kill all magit buffers for this repo."
             (kill-buffer buf)))))))
 
 ;;;###autoload
-(defun +magit/start-github-review (arg)
+(defun +magit/start-code-review (arg)
   (interactive "P")
   (call-interactively
     (if (or arg (not (featurep 'forge)))
-        #'github-review-start
-      #'github-review-forge-pr-at-point)))
+        #'code-review-start
+      #'code-review-forge-pr-at-point)))

--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -188,14 +188,23 @@ ensure it is built when we actually use Forge."
             (add-hook hook #'forge-bug-reference-setup)))))))
 
 
-(use-package! github-review
+(use-package! code-review
   :after magit
+  :init
+  ;; TODO This needs to either a) be cleaned up or better b) better map things
+  ;; to fit
+  (after! evil-collection-magit
+    (dolist (binding evil-collection-magit-mode-map-bindings)
+      (pcase-let* ((`(,states _ ,evil-binding ,fn) binding))
+        (dolist (state states)
+          (evil-collection-define-key state 'code-review-mode-map evil-binding fn))))
+    (evil-set-initial-state 'code-review-mode evil-default-state))
   :config
   (transient-append-suffix 'magit-merge "i"
-    '("y" "Review pull request" +magit/start-github-review))
+    '("y" "Review pull request" +magit/start-code-review))
   (after! forge
     (transient-append-suffix 'forge-dispatch "c u"
-      '("c r" "Review pull request" +magit/start-github-review))))
+      '("c r" "Review pull request" +magit/start-code-review))))
 
 
 (use-package! magit-todos

--- a/modules/tools/magit/packages.el
+++ b/modules/tools/magit/packages.el
@@ -6,4 +6,5 @@
     (package! forge :pin "41efa674cff0b447efbc103494fd61ec9b9156ae"))
   (package! magit-gitflow :pin "cc41b561ec6eea947fe9a176349fb4f771ed865b")
   (package! magit-todos :pin "60152d5c4e4b73e72e15f23ca16e8cc7734906bc")
-  (package! github-review :pin "725fbc7b385228f53a7ddc46a92c1276bab4aea8"))
+  (package! code-review :pin "f1a79c20ae51d23f76067a1e5a2f5c1c4db42ec9"
+    :recipe (:files ("graphql" "code-review*.el"))))

--- a/modules/tools/magit/packages.el
+++ b/modules/tools/magit/packages.el
@@ -1,10 +1,10 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; tools/magit/packages.el
 
-(when (package! magit :pin "877c389ca0161959081fa2c77045ce1ae9463be4")
+(when (package! magit :pin "65c4485e19bf570ebcb81fbaa6352c4e94bb05da")
   (when (featurep! +forge)
-    (package! forge :pin "41efa674cff0b447efbc103494fd61ec9b9156ae"))
+    (package! forge :pin "402773ef7e83ddfab64bfee23daea2776d50dbc1"))
   (package! magit-gitflow :pin "cc41b561ec6eea947fe9a176349fb4f771ed865b")
   (package! magit-todos :pin "60152d5c4e4b73e72e15f23ca16e8cc7734906bc")
-  (package! code-review :pin "f1a79c20ae51d23f76067a1e5a2f5c1c4db42ec9"
+  (package! code-review :pin "b0bedbdb30e019ed8c40fedf1087c3ad28e72c59"
     :recipe (:files ("graphql" "code-review*.el"))))


### PR DESCRIPTION
code-review is considered to be a superset of github-review, and as well
as supporting more forges (gitlab support is WIP) also better fits in
with magit.

Fix: #5812 