### PR TITLE
fix(evil): correct typesetting quotations in latex

### DIFF
--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -277,6 +277,18 @@ directives. By default, this only recognizes C directives.")
     (embrace-add-pair ?$ "${" "}"))
 
   (defun +evil-embrace-latex-mode-hook-h ()
+    (dolist (pair '((?\' . ("`" . "\'"))
+                    (?\" . ("``" . "\'\'"))))
+      (delete (car pair) evil-embrace-evil-surround-keys)
+      ;; Avoid `embrace-add-pair' because it would overwrite the default
+      ;; rules, which we want for other modes
+      (push (cons (car pair) (make-embrace-pair-struct
+                              :key (car pair)
+                              :left (cadr pair)
+                              :right (cddr pair)
+                              :left-regexp (regexp-quote (cadr pair))
+                              :right-regexp (regexp-quote (cddr pair))))
+            embrace--pairs-list))
     (embrace-add-pair-regexp ?l "\\[a-z]+{" "}" #'+evil--embrace-latex))
 
   (defun +evil-embrace-lisp-mode-hook-h ()


### PR DESCRIPTION
Use `evil-embrace` for typsetting quotations in latex instead of
`evil-surround`.

Single quotation marks are produced in LaTeX using ` and ' . Double quotation marks are produced by typing `` and ''. 

This should be an upstream fix for `evil-embrace` but looking at the latest commit of https://github.com/cute-jumper/embrace.el, I think it's better to send a PR to doom.