### PR TITLE
bump: nim-mode

### DIFF
--- a/modules/lang/nim/packages.el
+++ b/modules/lang/nim/packages.el
@@ -3,7 +3,7 @@
 
 ;;; requires nim nimsuggest nimble
 
-(package! nim-mode :pin "d832d6b1fb5e69fedcdddf442d62251dd0f1f489")
+(package! nim-mode :pin "744e076f0bea1e69fedcdddf442d62251dd0f1f489")
 
 (when (featurep! :checkers syntax)
   (package! flycheck-nim :pin "ddfade51001571c2399f78bcc509e0aa8eb752a4"))


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854

-->

Includes [nim-suggest.el fix](https://github.com/nim-lang/nim-mode/commit/744e076f0bea1c5ddc49f92397d9aa98ffa7eff8) for nim-mode on Emacs 27+ (void function error).

