### PR TITLE
fix(popup): report-emacs-bug and its saved  files are treated as popups.

### DIFF
--- a/modules/ui/popup/config.el
+++ b/modules/ui/popup/config.el
@@ -164,7 +164,7 @@ prevent the popup(s) from messing up the UI (or vice versa)."
     ("^\\*CPU-Profiler-Report "    :side bottom :vslot 100 :slot 1 :height 0.4 :width 0.5 :quit nil)
     ("^\\*Memory-Profiler-Report " :side bottom :vslot 100 :slot 2 :height 0.4 :width 0.5 :quit nil)
     ("^\\*Process List\\*" :side bottom :vslot 101 :size 0.25 :select t :quit t)
-    ("^\\*\\(?:Proced\\|timer-list\\|Abbrevs\\|Output\\|Occur\\|unsent mail\\)\\*" :ignore t)))
+    ("^\\*\\(?:Proced\\|timer-list\\|Abbrevs\\|Output\\|Occur\\|unsent mail.*?\\|message\\)\\*" :ignore t)))
 
 (add-hook 'doom-init-ui-hook #'+popup-mode 'append)
 


### PR DESCRIPTION
Steps to reproduce:
1. `report-emacs-bug`
2. Switch to buffer `*unsent mail to bug-gnu-emacs@gnu.org*`
3. Save the buffer, then kill it
4. Open the saved message

Observed:
- After step 1, the new buffer is poped up briefly, then replaced by `*Bug Help*` buffer and doesn't appear.
- After step 4, the buffer (whose name is `*message*-yyyymmdd-hhmmss`) who holds the saved message file is treated as a popup and at the bottom.