### PR TITLE
fix(sh): disable meta fetch by default on mac OS

### DIFF
--- a/modules/lang/sh/config.el
+++ b/modules/lang/sh/config.el
@@ -78,7 +78,9 @@
   :after sh-script
   :config
   (set-company-backend! 'sh-mode '(company-shell company-files))
-  (setq company-shell-delete-duplicates t))
+  (setq company-shell-delete-duplicates t
+        ;; whatis lookups are exceptionally slow on macOS (#5860)
+        company-shell-dont-fetch-meta IS-MAC))
 
 (use-package! fish-mode
   :when (featurep! +fish)


### PR DESCRIPTION
The `whatis` command is excessively slow on mac OS, rendering
company-shell unusable.

re: #5839