### PR TITLE
bump: org-roam

### DIFF
--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -93,7 +93,7 @@
     ;; FIXME A :recipe isn't strictly necessary, but without it, our package
     ;;       bumper fails to distinguish between org-roam v1 and v2.
     :recipe (:host github :repo "org-roam/org-roam")
-    :pin "a2e46db80848cb17185f257a397370a22cd686bb")))
+    :pin "abe63b436035049923ae96639b9b856697047779")))
 
 ;;; Babel
 (package! ob-async :pin "9aac486073f5c356ada20e716571be33a350a982")


### PR DESCRIPTION
org-roam/org-roam@a2e46db80848 -> org-roam/org-roam@abe63b436035

Recent Emacs master removed the `###autoload` cookie
about `ucs-normalize-NFD-string`, which will cause org-roam
not able to create nodes. org-roam has fixed this thus a bump
is needed.

Also, org-roam has introduced the way to customize how
contents are retrived. This should fix #5766.

Ref: https://github.com/org-roam/org-roam/issues/1981
Ref: https://github.com/org-roam/org-roam/pull/1990

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854

-->

Fixes #5766 <!-- remove if not applicable -->
