### PR TITLE
bump: :core to fix emacs 29 problem with general.el

### DIFF
--- a/core/packages.el
+++ b/core/packages.el
@@ -48,5 +48,5 @@
 (package! project :pin "a546cce47c434b0b4bf24bf1d5ed6e4623492072")
 
 ;; core-keybinds.el
-(package! general :pin "26f1d4c4e258c40e6b70ce831a04800c914f29b3")
+(package! general :pin "9651024e7f40a8ac5c3f31f8675d3ebe2b667344")
 (package! which-key :pin "4790a14683a2f3e4f72ade197c78e4c0af1cdd4b")


### PR DESCRIPTION


<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854

-->

Fixes #5785

This should fix the general-unbind-non-prefix-key issue when using general.el on Emacs 29
