### PR TITLE
crystal: enabled spec shortcuts for crystal

### DIFF
--- a/modules/lang/crystal/config.el
+++ b/modules/lang/crystal/config.el
@@ -5,7 +5,14 @@
     :definition #'crystal-def-jump
     :references #'crystal-tool-imp)
   (when (featurep! +lsp)
-    (add-hook 'crystal-mode-local-vars-hook #'lsp!)))
+    (add-hook 'crystal-mode-local-vars-hook #'lsp!))
+  (map! :localleader
+        :map crystal-mode-map
+        :prefix "t"
+        "a" #'crystal-spec-all
+        "v" #'crystal-spec-buffer
+        "s" #'crystal-spec-line
+        "t" #'crystal-spec-switch))
 
 
 (use-package! flycheck-crystal


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [X] It targets the develop branch
  - [X] No other pull requests exist for this issue
  - [X] The issue is NOT in Doom's do-not-PR list: https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  - [X] Any relevant issues and PRs have been linked to
  - [X] Commit messages conform to our conventions: https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854

-->

This adds some Crystal shortcuts mostly for specs that are modeled on ruby-mode.
