### PR TITLE
fix(default): only use `woman` on macOS

### DIFF
--- a/modules/config/default/autoload/default.el
+++ b/modules/config/default/autoload/default.el
@@ -18,10 +18,13 @@ If ARG (universal argument), runs `compile' from the current directory."
 
 ;;;###autoload
 (defun +default/man-or-woman ()
-  "Invoke `man' if man is installed, otherwise use `woman'."
+  "Invoke `man' if man is installed and the platform is not MacOS, otherwise use `woman'.
+
+`man -k \"^\"` is very slow on MacOS, which is what `Man-completion-table' uses to
+generate `completing-read' candidates."
   (interactive)
   (call-interactively
-   (if (executable-find "man")
+   (if (and (not IS-MAC) (executable-find "man"))
        #'man
      #'woman)))
 

--- a/modules/config/default/config.el
+++ b/modules/config/default/config.el
@@ -51,6 +51,16 @@
       (setq-local epa-file-encrypt-to (default-value 'epa-file-encrypt-to)))))
 
 
+(after! woman
+  ;; The woman-manpath default value does not necessarily match man. If we have
+  ;; man available but aren't using it for performance reasons, we can extract
+  ;; it's manpath.
+  (when (executable-find "man")
+    (setq woman-manpath
+          (split-string (cdr (doom-call-process "man" "--path"))
+                        path-separator t))))
+
+
 (use-package! drag-stuff
   :defer t
   :init


### PR DESCRIPTION
`man -k "^"` is very slow on macOS, which is what `M-x man` uses for `completing-read`: https://github.com/emacs-mirror/emacs/blob/3af9e84ff59811734dcbb5d55e04e1fdb7051e77/lisp/man.el#L932

```
sh-3.2$ time man -k "^" > /dev/null

real	0m1.599s
user	0m0.391s
sys	0m1.209s
```

It's possible that this could just be a me issue, so if anyone else with a mac can fact-check this that would be great!
