### PR TITLE
fix(erlang): fix broken erlang-mode

### DIFF
--- a/modules/lang/erlang/config.el
+++ b/modules/lang/erlang/config.el
@@ -7,12 +7,3 @@
   :config
   (when (featurep! +lsp)
     (add-hook 'erlang-mode-local-vars-hook #'lsp!)))
-
-
-(use-package! company-erlang
-  :when (featurep! :completion company)
-  :unless (featurep! +lsp)
-  :hook (erlang-mode . company-erlang-init)
-  :config
-  (add-hook! 'erlang-mode-hook
-    (add-hook 'after-save-hook #'ivy-erlang-complete-reparse nil t)))

--- a/modules/lang/erlang/doctor.el
+++ b/modules/lang/erlang/doctor.el
@@ -1,0 +1,6 @@
+;; -*- lexical-binding: t; no-byte-compile: t; -*-
+;;; lang/erlang/doctor.el
+
+(assert! (or (not (featurep! +lsp))
+             (featurep! :tools lsp))
+         "This module requires (:tools lsp)")

--- a/modules/lang/erlang/packages.el
+++ b/modules/lang/erlang/packages.el
@@ -1,7 +1,7 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; lang/erlang/packages.el
 
-(package! erlang :pin "118cb37bd5b9e9cb792f0463e46fdb04f151dcd5")
+(package! erlang :pin "c1ab4b5424be7504cfc3c4e87a2116b7731d8f2d")
 (unless (featurep! +lsp)
   (when (featurep! :completion company)
     (package! company-erlang :pin "bc0524a16f17b66c7397690e4ca0e004f09ea6c5")))

--- a/modules/lang/erlang/packages.el
+++ b/modules/lang/erlang/packages.el
@@ -2,6 +2,3 @@
 ;;; lang/erlang/packages.el
 
 (package! erlang :pin "c1ab4b5424be7504cfc3c4e87a2116b7731d8f2d")
-(unless (featurep! +lsp)
-  (when (featurep! :completion company)
-    (package! company-erlang :pin "bc0524a16f17b66c7397690e4ca0e004f09ea6c5")))


### PR DESCRIPTION
  - [x] It targets the develop branch
  - [x] No other pull requests exist for this issue
  - [x] The issue is NOT in Doom's do-not-PR list: https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  - [x] Any relevant issues and PRs have been linked to erlang/otp#5314
  - [x] Commit messages conform to our conventions: https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854

1. Upgrade OTP version to fix broken erlang mode. See Github issue erlang/otp#5314
2. Remove `company-erlang` and `ivy-erlang-complete`. The lsp mode provides
much better function than these two packages. `ivy-erlang-complete`
would slow down the buffer enabled erlang mode when the buffer is huge
enough. It is not a good choice to integrate `ivy-erlang-complete` nowadays.