### PR TITLE
fix: ccls interfering with lsp mode in other modes

### DIFF
--- a/modules/lang/cc/config.el
+++ b/modules/lang/cc/config.el
@@ -276,7 +276,7 @@ If rtags or rdm aren't available, fail silently instead of throwing a breaking e
 (use-package! ccls
   :when (featurep! +lsp)
   :unless (featurep! :tools lsp +eglot)
-  :hook (lsp-lens-mode . ccls-code-lens-mode)
+  :hook ((c-mode-local-vars c++-mode-local-vars objc-mode-local-vars) . +cc-init-ccls-code-lens-mode-maybe-h)
   :init
   (defvar ccls-sem-highlight-method 'font-lock)
   (after! projectile
@@ -287,6 +287,10 @@ If rtags or rdm aren't available, fail silently instead of throwing a breaking e
   ;; loads, rather than `ccls' loads.
   (after! lsp-mode (require 'ccls))
   :config
+  (defun +cc-init-ccls-code-lens-mode-maybe-h ()
+    (when (and (boundp 'lsp-lens-mode) lsp-lens-mode)
+      (ccls-code-lens-mode)
+      ))
   (set-evil-initial-state! 'ccls-tree-mode 'emacs)
   ;; Disable `ccls-sem-highlight-method' if `lsp-enable-semantic-highlighting'
   ;; is nil. Otherwise, it appears ccls bypasses it.


### PR DESCRIPTION
When init.el had both (cc +lsp) and (clojure +lsp), documentation
wouldn't show in the echo area, or would flash and be replaced by the
text: Error processing message (wrong-type-argument hash-table-p nil).

ccls-code-lens-mode was being enabled in the clojure buffers and I would
assume the same can happen with other languages when using LSP.

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854

-->

Restricted ccls-code-lens-mode to cc modes.
