### PR TITLE
fix(magit): move code-review files to etc dir

### DIFF
--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -199,6 +199,8 @@ ensure it is built when we actually use Forge."
         (dolist (state states)
           (evil-collection-define-key state 'code-review-mode-map evil-binding fn))))
     (evil-set-initial-state 'code-review-mode evil-default-state))
+  (setq code-review-db-database-file (concat doom-etc-dir "code-review/code-review-db-file.sqlite")
+        code-review-log-file (concat doom-etc-dir "code-review/code-review-error.log"))
   :config
   (transient-append-suffix 'magit-merge "i"
     '("y" "Review pull request" +magit/start-code-review))


### PR DESCRIPTION
The database and log file of `code-review` were put directly inside `.emacs.d`causing the repository to appear dirty. This PR moves the files inside the `.local/etc/code-review` folder to comply with the rest of doom functionality. 
The issue was introduced in 2d3a68df496f when switching to `code-review`.
