### PR TITLE
fix(grammar): `writegood-mode` in `LaTeX-mode`

### DIFF
--- a/modules/checkers/grammar/config.el
+++ b/modules/checkers/grammar/config.el
@@ -29,7 +29,7 @@
 ;; Detects weasel words, passive voice and duplicates. Proselint would be a
 ;; better choice.
 (use-package! writegood-mode
-  :hook (org-mode markdown-mode rst-mode asciidoc-mode latex-mode)
+  :hook (org-mode markdown-mode rst-mode asciidoc-mode latex-mode LaTeX-mode)
   :config
   (map! :localleader
         :map writegood-mode-map


### PR DESCRIPTION
Did I already mention that this `latex-mode` slash `LaTeX-mode`
ambiguity was a reeeeeeally bad decision upstream? Anyways, this very
small PR also loads `writegood-mode` with AucTeX, which uses
`LaTeX-mode`, and not `latex-mode`.