### PR TITLE
bump: :emacs dired

### DIFF
--- a/modules/emacs/dired/packages.el
+++ b/modules/emacs/dired/packages.el
@@ -2,7 +2,7 @@
 ;;; emacs/dired/packages.el
 
 (package! diredfl :pin "4ca32658aebaf2335f0368a0fd08f52eb1aee960")
-(package! dired-git-info :pin "9461476a28a5fec0784260f6e318237c662c3430")
+(package! dired-git-info :pin "91d57e3a4c5104c66a3abc18e281ee55e8979176")
 (package! diff-hl :pin "6fa3af0843093f44e028584a93eef091ec7e79d2")
 (package! dired-rsync :pin "7940d9154d0a908693999b0e1ea351a6d365c93d")
 (when (featurep! +ranger)


### PR DESCRIPTION
I just had `doom sync` fail during checkout of `dired-git-info`. It looks like the repo's git history has been rewritten, so that the previously-pinned commit no longer exists. I've updated the hash to point to the "new" `master` (which is still timestamped Dec 2019).