### PR TITLE
fix(nim): correct nim-mode SHA

### DIFF
--- a/modules/lang/nim/packages.el
+++ b/modules/lang/nim/packages.el
@@ -3,7 +3,7 @@
 
 ;;; requires nim nimsuggest nimble
 
-(package! nim-mode :pin "744e076f0bea1e69fedcdddf442d62251dd0f1f489")
+(package! nim-mode :pin "744e076f0bea1c5ddc49f92397d9aa98ffa7eff8")
 
 (when (featurep! :checkers syntax)
   (package! flycheck-nim :pin "ddfade51001571c2399f78bcc509e0aa8eb752a4"))


### PR DESCRIPTION
Wrong SHA in fd2788c (looks like a copy-paste mishap).

Ref: nim-lang/nim-mode@744e076
