### PR TITLE
fix(magit): unbind M-1 etc. for code-review

### DIFF
--- a/modules/tools/magit/config.el
+++ b/modules/tools/magit/config.el
@@ -234,6 +234,9 @@ ensure it is built when we actually use Forge."
   ;; especially when traversing modes in magit buffers.
   (evil-define-key* 'normal magit-status-mode-map [escape] nil)
 
+  (after! code-review
+    (undefine-key! code-review-mode-map "M-1" "M-2" "M-3" "M-4" "1" "2" "3" "4" "0"))
+
   ;; Some extra vim-isms I thought were missing from upstream
   (evil-define-key* '(normal visual) magit-mode-map
     "%"  #'magit-gitflow-popup


### PR DESCRIPTION
code-review is built on magit-sections so it will have the same default
bindings for M-1, M-2 etc. To be consistent with the rest of doom, those
should be used for switching workspace and z1, z2 etc. should be used for
toggling outlines in a magit-sections buffer such as the code-review buffer.

This only affects users with :editor (evil +everywhere) enabled.