### PR TITLE
 Add :send-region and :send-buffer options to `set-repl-handler!`

### DIFF
--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -26,7 +26,10 @@
     (when (executable-find "Microsoft.Python.LanguageServer")
       (set-eglot-client! 'python-mode '("Microsoft.Python.LanguageServer"))))
   :config
-  (set-repl-handler! 'python-mode #'+python/open-repl :persist t)
+  (set-repl-handler! 'python-mode #'+python/open-repl
+    :persist t
+    :send-region #'python-shell-send-region
+    :send-buffer #'python-shell-send-buffer)
   (set-docsets! '(python-mode inferior-python-mode) "Python 3" "NumPy" "SciPy" "Pandas")
 
   (set-ligatures! 'python-mode

--- a/modules/tools/eval/autoload/eval.el
+++ b/modules/tools/eval/autoload/eval.el
@@ -114,7 +114,10 @@
 
 ;;;###autoload
 (defun +eval/buffer-or-region ()
-  "Evaluate the whole buffer."
+  "Evaluate the region if it's active, otherwise evaluate the whole buffer.
+
+If a REPL is open the code will be evaluated in it, otherwise a quickrun
+runner will be used."
   (interactive)
   (call-interactively
    (if (use-region-p)

--- a/modules/tools/eval/autoload/eval.el
+++ b/modules/tools/eval/autoload/eval.el
@@ -73,7 +73,9 @@
                           (buffer-file-name (buffer-base-buffer))))
                         "emacs")
                  (alist-get 'emacs-lisp-mode +eval-runners)))
-        (+eval/region (point-min) (point-max))
+        (if-let ((buffer-handler (plist-get (cdr (alist-get major-mode +eval-repls)) :send-buffer)))
+            (funcall buffer-handler)
+          (+eval/region (point-min) (point-max)))
       (quickrun))))
 
 ;;;###autoload
@@ -85,7 +87,9 @@
                 (ignore-errors
                   (get-buffer-window (or (+eval--ensure-in-repl-buffer)
                                          t))))
-           (+eval/send-region-to-repl beg end))
+           (funcall (or (plist-get (cdr (alist-get major-mode +eval-repls)) :send-region)
+                        #'+eval/send-region-to-repl)
+                    beg end))
           ((let ((runner
                   (or (alist-get major-mode +eval-runners)
                       (and (require 'quickrun nil t)

--- a/modules/tools/eval/autoload/settings.el
+++ b/modules/tools/eval/autoload/settings.el
@@ -22,7 +22,14 @@ PLIST is a property list that map special attributes to this repl. These are
 recognized:
 
   :persist BOOL
-    If non-nil, this REPL won't be killed when its window is closed."
+    If non-nil, this REPL won't be killed when its window is closed.
+  :send-region FUNC
+    A function that accepts a BEG and END, and sends the contents of the region
+    to the REPL. Defaults to `+eval/send-region-to-repl'.
+  :send-buffer FUNC
+    A function of no arguments that sends the contents of the buffer to the REPL.
+    Defaults to `+eval/region', which will run the :send-region specified function
+    or `+eval/send-region-to-repl'."
   (declare (indent defun))
   (dolist (mode (doom-enlist modes))
     (setf (alist-get mode +eval-repls)


### PR DESCRIPTION
Implements the `:send-region` and `:send-buffer` handlers as mentioned on the roadmap [here](https://discourse.doomemacs.org/t/development-roadmap/42#v2201-2), and sneaks in a fix for the Python REPL :)

Fixes #4375