### PR TITLE
fix(dired): correct :emacs dired SHA from recipe change

### DIFF
--- a/modules/emacs/dired/packages.el
+++ b/modules/emacs/dired/packages.el
@@ -2,7 +2,7 @@
 ;;; emacs/dired/packages.el
 
 (package! diredfl :pin "4ca32658aebaf2335f0368a0fd08f52eb1aee960")
-(package! dired-git-info :pin "91d57e3a4c5104c66a3abc18e281ee55e8979176")
+(package! dired-git-info :pin "9461476a28a5fec0784260f6e318237c662c3430")
 (package! diff-hl :pin "6fa3af0843093f44e028584a93eef091ec7e79d2")
 (package! dired-rsync :pin "7940d9154d0a908693999b0e1ea351a6d365c93d")
 (when (featurep! +ranger)


### PR DESCRIPTION
straight.el's recipe changed to a mirror: https://github.com/emacs-straight/dired-git-info

Changes the pin SHA for the dired-git-info package

ref: https://github.com/emacs-straight/dired-git-info/commit/9461476a28a5fec0784260f6e318237c662c3430

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854

-->

Fixes #5913
