### PR TITLE
fix(org): tab indentation of section breaks in math environment

### DIFF
--- a/modules/lang/org/autoload/org.el
+++ b/modules/lang/org/autoload/org.el
@@ -375,6 +375,10 @@ Made for `org-tab-first-hook' in evil-mode."
   (cond ((not (and (bound-and-true-p evil-local-mode)
                    (evil-insert-state-p)))
          nil)
+          ((and org-cdlatex-mode
+                (or (org-inside-LaTeX-fragment-p)
+                    (org-inside-latex-macro-p)))
+           nil)
         ((org-at-item-p)
          (if (eq this-command 'org-shifttab)
              (org-outdent-item-tree)
@@ -441,7 +445,10 @@ of the time I just want to peek into the current subtree -- at most, expand
 All my (performant) foldings needs are met between this and `org-show-subtree'
 (on zO for evil users), and `org-cycle' on shift-TAB if I need it."
   (interactive "P")
-  (unless (eq this-command 'org-shifttab)
+    (unless (or (eq this-command 'org-shifttab)
+                (and org-cdlatex-mode
+                     (or (org-inside-LaTeX-fragment-p)
+                         (org-inside-latex-macro-p))))
     (save-excursion
       (org-beginning-of-line)
       (let (invisible-p)


### PR DESCRIPTION
In org mode while using cdlatex to write math, if one 
writes a math expression in a section (i.e. heading), 
then a `tab` indents the section instead of performing 
a `cdlatex-tab`.
This fix takes care of this issue to have the wanted 
behavior: if in math environment and hit `tab` while 
in section, execute `cdlatex-tab`.