### PR TITLE
fix(default): smartparens rules for haskell

### DIFF
--- a/modules/config/default/config.el
+++ b/modules/config/default/config.el
@@ -215,7 +215,17 @@
       (map! :map markdown-mode-map
             :ig "*" (general-predicate-dispatch nil
                       (looking-at-p "\\*\\* *")
-                      (cmd! (forward-char 2)))))))
+                      (cmd! (forward-char 2)))))
+
+    ;; Removes haskell-mode trailing braces
+    (after! smartparens-haskell
+      (sp-with-modes '(haskell-mode haskell-interactive-mode)
+        (sp-local-pair "{-" "-}" :actions :rem)
+        (sp-local-pair "{-#" "#-}" :actions :rem)
+        (sp-local-pair "{-@" "@-}" :actions :rem)
+        (sp-local-pair "{-" "-")
+        (sp-local-pair "{-#" "#-")
+        (sp-local-pair "{-@" "@-")))))
 
 
 ;;


### PR DESCRIPTION
The default haskell-mode rules would result in an extra } appended to
the closing pair (#5448).

Fix: #5448
Close: #5450

-------

I want this to be fixed, but @celsobonutti seems to be busy, so I incorporated the review requests into a new PR. They're still credited as the commit author of course.