### PR TITLE
bump: :tools lsp

### DIFF
--- a/modules/tools/lsp/+lsp.el
+++ b/modules/tools/lsp/+lsp.el
@@ -133,7 +133,7 @@ server getting expensively restarted when reverting buffers."
       (require 'lsp-mode)
       (lsp--require-packages)
       (if (or (lsp--filter-clients
-               (-andfn #'lsp--matching-clients?
+               (-andfn #'lsp--supports-buffer?
                        #'lsp--server-binary-present?))
               (not (memq +lsp-prompt-to-install-server '(nil quiet))))
           (apply fn args)

--- a/modules/tools/lsp/autoload/lsp-mode.el
+++ b/modules/tools/lsp/autoload/lsp-mode.el
@@ -28,7 +28,7 @@
      (require 'lsp-mode)
      (list (completing-read
             "Select server: "
-            (or (mapcar #'lsp--client-server-id (lsp--filter-clients (-andfn #'lsp--matching-clients?
+            (or (mapcar #'lsp--client-server-id (lsp--filter-clients (-andfn #'lsp--supports-buffer?
                                                                              #'lsp--server-binary-present?)))
                 (user-error "No available LSP clients for %S" major-mode))))))
   (require 'lsp-mode)

--- a/modules/tools/lsp/packages.el
+++ b/modules/tools/lsp/packages.el
@@ -6,7 +6,7 @@
       (package! eglot :pin "55c13a91378cdd7822c99bbbf340ea76b1f0bf38")
       (when (featurep! :completion vertico)
         (package! consult-eglot :pin "f93c571dc392a8b11d35541bffde30bd9f411d30")))
-  (package! lsp-mode :pin "41173dca4d6a7fa381ba6dc154e7149cb113f7e1")
+  (package! lsp-mode :pin "2736652be86f7e83f1fe08e7158a3d1d8f1bb965")
   (package! lsp-ui :pin "98d0ad00b8bf1d3a7cea490002169f2286d7208c")
   (when (featurep! :completion ivy)
     (package! lsp-ivy :pin "3e87441a625d65ced5a208a0b0442d573596ffa3"))


### PR DESCRIPTION
Fixes #5927

This supersedes https://github.com/hlissner/doom-emacs/pull/5928 (a newer version) and fixes the issues "introduced" by the bump

emacs-lsp/lsp-mode@41173dca4d6a -> emacs-lsp/lsp-mode@2736652be86

https://github.com/emacs-lsp/lsp-mode/commit/20045c1cb607701237beff62b9e7c2c4a69a5e79 introduces a "breaking" change (quoted since private), renaming `lsp--matching-clients?` to `lsp--supports-buffer`

Co-authored-by: Alexandr Burtsev <me@aburtsev.ru>