### PR TITLE
tweak(dired): don't auto-revert when remote

### DIFF
--- a/modules/emacs/dired/config.el
+++ b/modules/emacs/dired/config.el
@@ -3,7 +3,7 @@
 (use-package! dired
   :commands dired-jump
   :init
-  (setq dired-auto-revert-buffer t  ; don't prompt to revert; just do it
+  (setq dired-auto-revert-buffer (lambda (dir) (not (file-remote-p dir)))  ; don't prompt to revert; just do it
         dired-dwim-target t  ; suggest a target for moving/copying intelligently
         dired-hide-details-hide-symlink-targets nil
         ;; Always copy/delete recursively


### PR DESCRIPTION
On slow connections `dired-auto-revert-buffer` causes excessive
slowdowns; this limits its behavior to local files.

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854

-->
