### PR TITLE
bump: :lang java

### DIFF
--- a/modules/lang/java/packages.el
+++ b/modules/lang/java/packages.el
@@ -5,7 +5,7 @@
 (package! groovy-mode :pin "84f89b68ec8f79bce0b3f5b29af155a85124e3a6")
 
 (when (featurep! +meghanada)
-  (package! meghanada :pin "6c57e8a0ae27e2929bb12572cf33059cd4ecbc04"))
+  (package! meghanada :pin "59c46cabb7eee715fe810ce59424934a1286df84"))
 
 (when (featurep! +eclim)
   (package! eclim :pin "222ddd48fcf0ee01592dec77c58e0cf3f2ea1100")


### PR DESCRIPTION
mopemope/meghanada-emacs@6c57e8a0ae27 -> mopemope/meghanada-emacs@59c46cabb7ee

Fix CVE-2021-44228
