### PR TITLE
fix(lsp): Use variable instead removed function

### DIFF
--- a/modules/tools/lsp/+lsp.el
+++ b/modules/tools/lsp/+lsp.el
@@ -39,6 +39,8 @@ about it (it will be logged to *Messages* however).")
   (setq lsp-enable-on-type-formatting nil)
   ;; Make breadcrumbs opt-in; they're redundant with the modeline and imenu
   (setq lsp-headerline-breadcrumb-enable nil)
+  ;; Disable prompt to automatically download server
+  (setq lsp-enable-suggest-server-download nil)
 
   ;; Let doom bind the lsp keymap.
   (when (featurep! :config default +bindings)
@@ -126,23 +128,6 @@ server getting expensively restarted when reverting buffers."
                          (funcall fn))
                        (+lsp-optimization-mode -1))))
              lsp--cur-workspace))))
-
-  (defadvice! +lsp-dont-prompt-to-install-servers-maybe-a (fn &rest args)
-    :around #'lsp
-    (when (buffer-file-name)
-      (require 'lsp-mode)
-      (lsp--require-packages)
-      (if (or (lsp--filter-clients
-               (-andfn #'lsp--matching-clients?
-                       #'lsp--server-binary-present?))
-              (not (memq +lsp-prompt-to-install-server '(nil quiet))))
-          (apply fn args)
-        ;; HACK `lsp--message' overrides `inhibit-message', so use `quiet!'
-        (let ((doom-debug-p
-               (or doom-debug-p
-                   (not (eq +lsp-prompt-to-install-server 'quiet)))))
-          (doom-shut-up-a #'lsp--info "No language server available for %S"
-                          major-mode)))))
 
   (when (featurep! :ui modeline +light)
     (defvar-local lsp-modeline-icon nil)

--- a/modules/tools/lsp/packages.el
+++ b/modules/tools/lsp/packages.el
@@ -6,7 +6,7 @@
       (package! eglot :pin "55c13a91378cdd7822c99bbbf340ea76b1f0bf38")
       (when (featurep! :completion vertico)
         (package! consult-eglot :pin "f93c571dc392a8b11d35541bffde30bd9f411d30")))
-  (package! lsp-mode :pin "41173dca4d6a7fa381ba6dc154e7149cb113f7e1")
+  (package! lsp-mode :pin "03a6ab1d7db8a02233b29f2e8840803028f22ded")
   (package! lsp-ui :pin "98d0ad00b8bf1d3a7cea490002169f2286d7208c")
   (when (featurep! :completion ivy)
     (package! lsp-ivy :pin "3e87441a625d65ced5a208a0b0442d573596ffa3"))


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [X] It targets the develop branch
  - [X] No other pull requests exist for this issue
  - [X] The issue is NOT in Doom's do-not-PR list: https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  - [X] Any relevant issues and PRs have been linked to
  - [X] Commit messages conform to our conventions: https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854

-->

Latest lsp-mode is not working with doom-emacs because of a custom advice that uses a removed private function, the advice can be removed if using a recent new variable for the same purposes.

The new variable `lsp-enable-suggest-server-download` should be used to disable automatic server download, this fixes a issue where doom was using a removed private-function on its custom advice

![image](https://user-images.githubusercontent.com/7820865/147856883-f6ad5d81-8a1b-4e6e-af85-fb8eac8436ab.png)

Related issue https://github.com/hlissner/doom-emacs/issues/5904