### PR TITLE
bump: code-review

### DIFF
--- a/modules/tools/magit/packages.el
+++ b/modules/tools/magit/packages.el
@@ -6,5 +6,5 @@
     (package! forge :pin "402773ef7e83ddfab64bfee23daea2776d50dbc1"))
   (package! magit-gitflow :pin "cc41b561ec6eea947fe9a176349fb4f771ed865b")
   (package! magit-todos :pin "60152d5c4e4b73e72e15f23ca16e8cc7734906bc")
-  (package! code-review :pin "b0bedbdb30e019ed8c40fedf1087c3ad28e72c59"
+  (package! code-review :pin "6e55248a1ff509fb2836bd04929966949e7cbc2f"
     :recipe (:files ("graphql" "code-review*.el"))))


### PR DESCRIPTION
wandersoncferreira/code-review@b0bedbd -> wandersoncferreira/code-review@6e55248

Stop using obsolete `defgeneric` and use `cl-defgeneric` instead. See
wandersoncferreira/code-review#162 .

Necessary for emacs 29.0.50