### PR TITLE
`:completion vertico` improvements

### DIFF
--- a/modules/completion/vertico/README.org
+++ b/modules/completion/vertico/README.org
@@ -79,15 +79,16 @@ Doom-specific additions:
 When in an active Vertico completion session, the following doom added
 keybindings are available:
 
-| Keybind               | Description                                        |
-|-----------------------+----------------------------------------------------|
-| =C-k=                 | (evil) Go to previous candidate                    |
-| =C-j=                 | (evil) Go to next candidate                        |
-| =C-M-k=               | (evil) Go to previous group                        |
-| =C-M-j=               | (evil) Go to next group                            |
-| =C-;= or =<leader> a= | Open an ~embark-act~ menu to chose a useful action |
-| =C-c C-;=             | export the current candidate list to a buffer      |
-| =C-SPC=               | Preview the current candidate                      |
+| Keybind               | Description                                                                   |
+|-----------------------+-------------------------------------------------------------------------------|
+| =C-k=                 | (evil) Go to previous candidate                                               |
+| =C-j=                 | (evil) Go to next candidate                                                   |
+| =C-M-k=               | (evil) Go to previous group                                                   |
+| =C-M-j=               | (evil) Go to next group                                                       |
+| =C-;= or =<leader> a= | Open an ~embark-act~ menu to chose a useful action                            |
+| =C-c C-;=             | ~embark-export~ the current candidate list (export to a type-specific buffer) |
+| =C-c C-s=             | ~embark-collect-snapsnot~ the current candidate list (collect verbatim)       |
+| =C-SPC=               | Preview the current candidate                                                 |
 
 ~embark-act~ will prompt you with a =which-key= menu with useful commands on the
 selected candidate or candidate list, depending on the completion category. Note

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -131,6 +131,7 @@ orderless."
    +default/search-project-for-symbol-at-point
    +default/search-cwd +default/search-other-cwd
    +default/search-notes-for-symbol-at-point
+   +default/search-emacsd
    consult--source-file consult--source-project-file consult--source-bookmark
    :preview-key (kbd "C-SPC"))
   (consult-customize

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -172,6 +172,7 @@ orderless."
         (:map minibuffer-local-map
          "C-;"               #'embark-act
          "C-c C-;"           #'embark-export
+         "C-c C-s"           #'embark-collect-snapshot
          :desc "Export to writable buffer" "C-c C-e" #'+vertico/embark-export-write)
         (:leader
          :desc "Actions" "a" #'embark-act)) ; to be moved to :config default if accepted

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -205,11 +205,11 @@ orderless."
     ("u" doom/help-package-homepage))
   (setf (alist-get 'package embark-keymap-alist) #'+vertico/embark-doom-package-map)
   (map! (:map embark-file-map
-         :desc "Open target with sudo" "s" #'doom/sudo-find-file
+         :desc "Open target with sudo"        "s"   #'doom/sudo-find-file
          (:when (featurep! :tools magit)
           :desc "Open magit-status of target" "g"   #'+vertico/embark-magit-status)
          (:when (featurep! :ui workspaces)
-          :desc "Open in new workspace" "TAB" #'+vertico/embark-open-in-new-workspace))))
+          :desc "Open in new workspace"       "TAB" #'+vertico/embark-open-in-new-workspace))))
 
 
 (use-package! marginalia

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -146,7 +146,8 @@ orderless."
         :items    ,(lambda () (mapcar #'buffer-name (org-buffer-list)))))
     (add-to-list 'consult-buffer-sources '+vertico--consult-org-source 'append))
   (map! :map consult-crm-map
-        :desc "Select candidate" "TAB" #'+vertico/crm-select
+        :desc "Select candidate" [tab] #'+vertico/crm-select
+        :desc "Select candidate and keep input" [backtab] #'+vertico/crm-select-keep-input
         :desc "Enter candidates" "RET" #'+vertico/crm-exit))
 
 

--- a/modules/completion/vertico/packages.el
+++ b/modules/completion/vertico/packages.el
@@ -4,21 +4,21 @@
 (package! vertico
   :recipe (:host github :repo "minad/vertico"
            :files ("*.el" "extensions/*.el"))
-  :pin "eedcb847869226701acaf9a36dce0a51d1b60862")
+  :pin "a8fe9a0b2e156e022136169a3159b4dad78b2439")
 
 (package! orderless :pin "1ccf74ffdbb0dd34caa63022e92f947c09c49c86")
 
-(package! consult :pin "cc8eff9578f5d089735e8b7dd7a08732890ed648")
+(package! consult :pin "0940ca016531f3412003c231b476e5023a510ff9")
 (package! consult-dir :pin "08f543ae6acbfc1ffe579ba1d00a5414012d5c0b")
 (when (featurep! :checkers syntax)
   (package! consult-flycheck :pin "0ad7e8ff15683a4d64b79c29b3fcf847edfe244b"))
 
-(package! embark :pin "e08899ef2e7fb9c1ed4b4b21e44cd368561f91f9")
-(package! embark-consult :pin "e08899ef2e7fb9c1ed4b4b21e44cd368561f91f9")
+(package! embark :pin "c9b26c2e18f01ae401df6a69b7a0c1a6bc44b90c")
+(package! embark-consult :pin "c9b26c2e18f01ae401df6a69b7a0c1a6bc44b90c")
 
-(package! marginalia :pin "2fb2787bc302a5533e09bc558c76eb914e98543b")
+(package! marginalia :pin "9229d88ae4757f3439e81f51799758c009838cb4")
 
 (package! wgrep :pin "f9687c28bbc2e84f87a479b6ce04407bb97cfb23")
 
 (when (featurep! +icons)
-  (package! all-the-icons-completion :pin "a0f34d68cc12330ab3992a7521f9caa1de3b8470"))
+  (package! all-the-icons-completion :pin "9e7d456b0934ecb568b6f05a8445e3f4ce32261f"))


### PR DESCRIPTION
- a rework of how the `completing-read-multiple` keybindings work (see commit message for details)
- module bump 
- added `C-c C-s` binding for `embark-collect-snapshot`
- all embark buffers are now handled as popups, and don't die after dismissal
- add `+default/search-emacsd` to manual preview list