### PR TITLE
docs(haskell): fix docs for alternative formatter

### DIFF
--- a/modules/lang/haskell/README.org
+++ b/modules/lang/haskell/README.org
@@ -76,7 +76,7 @@ After installing your preferred formatter, make sure to set
 Make sure to configure the lsp to use your perfered formatter, e.g.:
 #+begin_src emacs-lisp
 ;; ~/.doom.d/config.el
-(after!
+(after! lsp-haskell
   (setq lsp-haskell-formatting-provider "brittany"))
 #+end_src
 


### PR DESCRIPTION
Small fixup to use the proper form when setting an alternative formatter using the `after!` macro.

_Small note:_ This PR targets the `rewrite-docs` branch as per [the Discord message here](https://discord.com/channels/406534637242810369/406624667496087572/927300806250754048)
