### PR TITLE
tweak(web): detect and set angular in web-mode

### DIFF
--- a/modules/lang/web/config.el
+++ b/modules/lang/web/config.el
@@ -43,7 +43,10 @@
 (when (featurep! :lang javascript)
   (def-project-mode! +web-angularjs-mode
     :modes '(+javascript-npm-mode)
-    :when (+javascript-npm-dep-p 'angular))
+    :when (+javascript-npm-dep-p '(angular @angular/core))
+    :on-enter
+    (when (derived-mode-p 'web-mode)
+      (web-mode-set-engine "angular")))
 
   (def-project-mode! +web-react-mode
     :modes '(+javascript-npm-mode)


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [x ] No other pull requests exist for this issue
  - [x] The issue is NOT in Doom's do-not-PR list: https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  - [x] Any relevant issues and PRs have been linked to
  - [x] Commit messages conform to our conventions: https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854

-->

Hi 

Just send in a small tweak regarding angular and the ionic framework.


Here are the details: 

- Add @angular/core in detecting angular to set the web-angularjs minor
mode

- At the same time set the web-mode-engine to "angular" so that
`format-all` uses prettier to format ionic `*.page.html` files in
addition to `*.component.html` files.

When `format-all` sees the web-mode-engine is set to "angular", it
applies `prettier` as opposed to `html-tidy`, as `tidy` doesn't
recognise angular component tags and hence errors out. The current
web-mode only sets the engine to "angular" for "*.components.html".
However, ionic angular uses file names such as "*.page.html", setting
engine will apply prettier to these html fils.

Many thanks

Marty
