### PR TITLE
feat(php): replace php-boris with psysh

### DIFF
--- a/modules/lang/php/autoload.el
+++ b/modules/lang/php/autoload.el
@@ -13,3 +13,14 @@ ignore the cache."
                                (require 'json)
                                (json-read-file package-file)))
             (puthash project-root data +php-composer-conf))))))
+
+;;
+;;; Commands
+
+
+;;;###autoload
+(defun +php/open-repl ()
+  "Open PHP REPL."
+  (interactive)
+  (psysh)
+  (pop-to-buffer (current-buffer)))

--- a/modules/lang/php/config.el
+++ b/modules/lang/php/config.el
@@ -28,7 +28,7 @@
   (setq php-mode-template-compatibility nil)
 
   (set-docsets! 'php-mode "PHP" "PHPUnit" "Laravel" "CakePHP" "CodeIgniter" "Doctrine_ORM")
-  (set-repl-handler! 'php-mode #'php-boris)
+  (set-repl-handler! 'php-mode #'+php/open-repl)
   (set-lookup-handlers! 'php-mode :documentation #'php-search-documentation)
   (set-formatter! 'php-mode #'php-cs-fixer-fix)
   (set-ligatures! 'php-mode

--- a/modules/lang/php/packages.el
+++ b/modules/lang/php/packages.el
@@ -1,7 +1,7 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; lang/php/packages.el
 
-(package! php-boris :pin "f2faebf610c917f7091f7ec0cd97645629c4f819")
+(package! psysh :pin "21250984ad8137aa3440ac12e52475ef03f19fcb")
 (package! php-extras
   :recipe (:host github :repo "arnested/php-extras")
   :pin "d410c5af663c30c01d461ac476d1cbfbacb49367")


### PR DESCRIPTION
Replace the php repl handler with psysh

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854

-->

Fixes #5965
* Removed php-boris from php module packages and replaced it with [psysh](https://github.com/emacs-php/psysh.el)
* Set repl handler for php-mode to use psysh
