### PR TITLE
docs: update getting_started.org

### DIFF
--- a/docs/getting_started.org
+++ b/docs/getting_started.org
@@ -115,8 +115,14 @@ Linux distributions. In the unusual case that 27.1 or newer is unavailable on
 your system, you'll have to [[https://www.gnu.org/software/emacs/manual/html_node/efaq/Installing-Emacs.html][build it from source]] instead.
 
 **** Ubuntu
-Emacs 27.x is not available through Ubuntu's package manager out-of-the-box, but
-is available through a PPA:
+Emacs 27.x is available through Ubuntu's package manager out-of-the-box for versions 21.04 and newer:
+
+#+BEGIN_SRC bash
+apt-get update
+apt-get install emacs
+#+END_SRC
+
+For ubuntu versions 20.04 or older, it is available through a PPA:
 
 #+BEGIN_SRC bash
 add-apt-repository ppa:kelleyk/emacs


### PR DESCRIPTION
Emacs 27.x is available in Ubuntu’s repo for versions 21.04+

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854

-->