### PR TITLE
fix(clojure): Add clojurec-mode repl+eval handlers

### DIFF
--- a/modules/lang/clojure/config.el
+++ b/modules/lang/clojure/config.el
@@ -34,9 +34,9 @@
   :hook (clojure-mode-local-vars . cider-mode)
   :init
   (after! clojure-mode
-    (set-repl-handler! 'clojure-mode #'+clojure/open-repl :persist t)
+    (set-repl-handler! '(clojure-mode clojurec-mode) #'+clojure/open-repl :persist t)
     (set-repl-handler! 'clojurescript-mode #'+clojure/open-cljs-repl :persist t)
-    (set-eval-handler! '(clojure-mode clojurescript-mode) #'cider-eval-region))
+    (set-eval-handler! '(clojure-mode clojurescript-mode clojurec-mode) #'cider-eval-region))
 
   ;; HACK Fix raxod502/radian#446: CIDER tries to calculate the frame's
   ;;   background too early; sometimes before the initial frame has been


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [x] No other pull requests exist for this issue
  - [x] The issue is NOT in Doom's do-not-PR list: https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  - [x] Any relevant issues and PRs have been linked to
  - [x] Commit messages conform to our conventions: [[https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854]]

-->

As `clojurec-mode` is a distinct mode from `clojure-mode` when `+eval/open-repl-same-window` or `+eval/open-repl-other-window` is run in a buffer when `clojurec-mode` is the major mode the list of available REPLs will include REPLs for other languages, for example `emacs-lisp (default)`.

What's more, if you then try to select `clojure (default)` from the list you get the following error in the minibuffer:
```
and: Symbol’s function definition is void: cider-current-repl
```
(This may be an unrelated issue.)

> 👋🏻 This is my first pull request against Doom. Please let me know if I got anything wrong, or if you'd like me to submit an issue for the above behavior!