### PR TITLE
fix(javascript): incorrect lsp formatting for tsx

### DIFF
--- a/modules/lang/javascript/config.el
+++ b/modules/lang/javascript/config.el
@@ -122,7 +122,10 @@
                     'jsx-tide)))))
   :config
   (when (fboundp 'web-mode)
-    (define-derived-mode typescript-tsx-mode web-mode "TypeScript-TSX"))
+    (define-derived-mode typescript-tsx-mode web-mode "TypeScript-TSX")
+    (when (featurep! +lsp)
+      (after! lsp-mode
+        (add-to-list 'lsp--formatting-indent-alist '(typescript-tsx-mode . typescript-indent-level)))))
 
   (set-docsets! '(typescript-mode typescript-tsx-mode)
     :add "TypeScript" "AngularTS")


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854

-->

Fixes https://github.com/emacs-lsp/lsp-mode/discussions/3308

lsp-mode doesn't detect the correct indentation, since it treats the derived tsx-mode as a web-mode. This change modifies the lsp-mode internal alist to recognize tsx-mode correctly. Ideally lsp-mode would have a better way to modify its known mode lists but I couldn't see it.
