### PR TITLE
bump: :tools lsp

### DIFF
--- a/modules/tools/lsp/packages.el
+++ b/modules/tools/lsp/packages.el
@@ -6,7 +6,7 @@
       (package! eglot :pin "28092ba3af6041a44227b92397c148a902413d1c")
       (when (featurep! :completion vertico)
         (package! consult-eglot :pin "f93c571dc392a8b11d35541bffde30bd9f411d30")))
-  (package! lsp-mode :pin "3d6a01dde958db77a4597bf52e079f5b96469527")
+  (package! lsp-mode :pin "355c9e183c9b3a2872487a3068c5902326b58be4")
   (package! lsp-ui :pin "e5d464537286b494334bab1056f8699a650d9d1f")
   (when (featurep! :completion ivy)
     (package! lsp-ivy :pin "3e87441a625d65ced5a208a0b0442d573596ffa3"))


### PR DESCRIPTION
emacs-lsp/lsp-mode@3d6a01dde958 -> emacs-lsp/lsp-mode@355c9e183c9b

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] It targets the develop branch
  - [x] No other pull requests exist for this issue
  - [x] The issue is NOT in Doom's do-not-PR list: https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  - [x] Any relevant issues and PRs have been linked to
  - [x] Commit messages conform to our conventions: https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854

-->

Bumps lsp-mode to include the revert fixing eldoc.

Ref: emacs-lsp/lsp-mode#3295