### PR TITLE
Fix type in org README capture example

### DIFF
--- a/modules/lang/org/README.org
+++ b/modules/lang/org/README.org
@@ -224,7 +224,7 @@ will spawn a temporary daemon for you.
 Alternatively, you can call ~+org-capture/open-frame~ directly, e.g.
 
 #+BEGIN_SRC sh
-emacsclient --eval '(+org-capture/open-frame INTIAL-INPUT KEY)'
+emacsclient --eval '(+org-capture/open-frame INITIAL-INPUT KEY)'
 #+END_SRC
 
 ** Built-in custom link types


### PR DESCRIPTION
Fix typo in org module README