### PR TITLE
fix(tmux): +tmux/rerun fails due to malformed +tmux-last-command

### DIFF
--- a/modules/tools/tmux/autoload/tmux.el
+++ b/modules/tools/tmux/autoload/tmux.el
@@ -28,7 +28,7 @@
       (unwind-protect
           (if (= 0 (setq code (quiet! (shell-command cmdstr output errors))))
               (with-current-buffer output
-                (setq +tmux-last-command `(,cmdstr ,@args))
+                (setq +tmux-last-command `(,(substring cmdstr (+ 1 (length bin))) ,@args))
                 (buffer-string))
             (error "[%d] tmux $ %s (%s)"
                    code
@@ -61,7 +61,7 @@ but do not execute them."
 ;;;###autoload
 (defun +tmux/rerun ()
   "Rerun the last command executed by `+tmux' and `+tmux/run'."
-  (interactive "P")
+  (interactive)
   (unless +tmux-last-command
     (user-error "No last command to run"))
   (apply #'+tmux +tmux-last-command))


### PR DESCRIPTION
### What did you expect to happen?

Executing `+tmux/rerun` after `+tmux/run`, should rerun the shell command specified in the `+tmux/run` call.

### What actually happened?

The following backtrace appears after executing `M-x +tmux/rerun`

```elisp
Debugger entered--Lisp error: (wrong-number-of-arguments ((t) nil "Rerun the last command executed by `+tmux' and `+t..." (interactive "P") (if +tmux-last-command nil (user-error "No last command to run")) (apply #'+tmux +tmux-last-command)) 1)
  +tmux/rerun(nil)
  funcall-interactively(+tmux/rerun nil)
  command-execute(+tmux/rerun record)
  execute-extended-command(nil "+tmux/rerun" #("tmux" 0 4 (ws-butler-chg chg)))
  funcall-interactively(execute-extended-command nil "+tmux/rerun" #("tmux" 0 4 (ws-butler-chg chg)))
  command-execute(execute-extended-command)
```

### Describe your attempts to resolve the issue?

Running `doom sync`, `doom upgrade`, `doom build` didn't fix the issue. 
I was able to reproduce the error in the sandbox (`C-c C-p`).

### Possible solution

After replacing `(interactive "P")` with `(interactive)` a new error occurs. This time from the `+tmux` function:

```elisp
Debugger entered--Lisp error: (error "[1] tmux $ unknown command: /run/current-system/sw/bin/tmux\n (/run/current-system/sw/bin/tmux /run/current-system/sw/bin/tmux send-keys C-u pwd Enter)")
  error("[%d] tmux $ %s (%s)" 1 "unknown command: /run/current-system/sw/bin/tmux\n" "/run/current-system/sw/bin/tmux /run/current-system/sw/bin/tmux send-keys C-u pwd Enter")
  (if (= 0 (setq code (quiet! (shell-command cmdstr output errors)))) (with-current-buffer output (setq +tmux-last-command `(,cmdstr ,@args)) (buffer-string)) (error "[%d] tmux $ %s (%s)" code (with-current-buffer errors (buffer-string)) cmdstr))
  (unwind-protect (if (= 0 (setq code (quiet! (shell-command cmdstr output errors)))) (with-current-buffer output (setq +tmux-last-command `(,cmdstr ,@args)) (buffer-string)) (error "[%d] tmux $ %s (%s)" code (with-current-buffer errors (buffer-string)) cmdstr)) (and (kill-buffer output) (kill-buffer errors)))
  (let* ((args (mapcar #'shell-quote-argument (delq nil args))) (cmdstr (format "%s %s" bin (if args (apply #'format command args) command))) (output (get-buffer-create " *tmux stdout*")) (errors (get-buffer-create " *tmux stderr*")) code) (unwind-protect (if (= 0 (setq code (quiet! (shell-command cmdstr output errors)))) (with-current-buffer output (setq +tmux-last-command `(,cmdstr ,@args)) (buffer-string)) (error "[%d] tmux $ %s (%s)" code (with-current-buffer errors (buffer-string)) cmdstr)) (and (kill-buffer output) (kill-buffer errors))))
  (let ((bin (executable-find "tmux"))) (unless bin (error "Could not find tmux executable")) (let* ((args (mapcar #'shell-quote-argument (delq nil args))) (cmdstr (format "%s %s" bin (if args (apply #'format command args) command))) (output (get-buffer-create " *tmux stdout*")) (errors (get-buffer-create " *tmux stderr*")) code) (unwind-protect (if (= 0 (setq code (quiet! (shell-command cmdstr output errors)))) (with-current-buffer output (setq +tmux-last-command `(... ...)) (buffer-string)) (error "[%d] tmux $ %s (%s)" code (with-current-buffer errors (buffer-string)) cmdstr)) (and (kill-buffer output) (kill-buffer errors)))))
  +tmux("/run/current-system/sw/bin/tmux send-keys C-u pwd ...")
  apply(+tmux "/run/current-system/sw/bin/tmux send-keys C-u pwd ...")
  +tmux/rerun()
  funcall-interactively(+tmux/rerun)
  command-execute(+tmux/rerun)
```

It looks like that the `+tmux` function stores the shell command with the `tmux` executable path to `+tmux-last-command`.  
Value of `+tmux-last-command` after `+tmux/run`.

```elisp
("/run/current-system/sw/bin/tmux send-keys C-u pwd Enter")
```

After running `+tmux/rerun` another `tmux` call gets prepended.

```elisp
("/run/current-system/sw/bin/tmux /run/current-system/sw/bin/tmux send-keys C-u pwd Enter")
```

I fixed this by dropping the first `(+ 1 (length bin))` chars before saving the command in `+tmux-last-command`.  
After these fixes, the command is stored in `+tmux-last-command` without the `tmux` executable path.

```elisp
("send-keys C-u pwd Enter")
 ```
