### PR TITLE
tweak(rss): use asterisk around workspace name

### DIFF
--- a/modules/app/rss/autoload.el
+++ b/modules/app/rss/autoload.el
@@ -8,7 +8,7 @@
   (interactive)
   (if (featurep! :ui workspaces)
       (progn
-        (+workspace-switch "rss" t)
+        (+workspace-switch "*rss*" t)
         (doom/switch-to-scratch-buffer)
         (elfeed)
         (+workspace/display))


### PR DESCRIPTION
This is to make it conform to the convention that all other app
workspaces conform to (plus it was bugging me)