### PR TITLE
Add graphviz/dot check to plantuml/doctor.el

### DIFF
--- a/modules/lang/plantuml/doctor.el
+++ b/modules/lang/plantuml/doctor.el
@@ -5,6 +5,9 @@
   ;; java
   (unless (executable-find "java")
     (warn! "Couldn't find java. PlantUML preview or syntax checking won't work"))
+  ;; graphviz
+  (unless (executable-find "dot")
+    (warn! "Couldn't fiind dot. PlantUML might not show any output"))
   ;; plantuml.jar
   (unless (file-exists-p plantuml-jar-path)
     (warn! "Couldn't find plantuml.jar. Install it with M-x plantuml-download-jar")))

--- a/modules/lang/plantuml/doctor.el
+++ b/modules/lang/plantuml/doctor.el
@@ -7,7 +7,7 @@
     (warn! "Couldn't find java. PlantUML preview or syntax checking won't work"))
   ;; graphviz
   (unless (executable-find "dot")
-    (warn! "Couldn't fiind dot. PlantUML might not show any output"))
+    (warn! "Couldn't find dot. PlantUML will only show outputs for sequence and activity diagrams"))
   ;; plantuml.jar
   (unless (file-exists-p plantuml-jar-path)
     (warn! "Couldn't find plantuml.jar. Install it with M-x plantuml-download-jar")))


### PR DESCRIPTION
As it is stated in the plantuml [quickstart](https://plantuml.com/starting) guide, plantuml has a soft dependency, which is graphviz/dot.
However, for like 90% of its functionality (10% being sequence diagrams) is required. Therefore it is safe to say it must be in the doctor.el of the module.

Also, it depends on libawt and one other libawt_xawt.so not just "java". The point is, it requires a full openjdk-jre installation not a headless version. Headless version does not provide the second file so java throws a long exception.

I am not gonna add that to the doctor.el. But I suggest it is needed. A pseudo-code like this is my mind but since I was not sure I didn't try to add it for I know there are more aware guys here who can do this in a more optimized manner:

```lisp
(when 
 (grep-in-text (doom-process (concat plantuml-java-path plantuml-java-flags plantuml-jar-path))
  :for "libawt_xawt.so")
 (warn!
  (concat
   "Couldn't find libawt_xawt.so! It appears some Java libraries are missing "
   "(try installing a full Java installation rather than a headless version)")))
```

P.S: sorry for the hasty p/r and 2 commits, if it is a headache to merge the commits please let me know and I will make a new and clean p/r.