### PR TITLE
docs(julia): update lsp environment to recent LTS 

### DIFF
--- a/modules/lang/julia/README.org
+++ b/modules/lang/julia/README.org
@@ -68,21 +68,21 @@ To instruct [[doom-package:][lsp-julia]] not to use the built-in package:
 #+end_src
 
 To find your installation of ~LanguageServer.jl~, [[doom-package:][lsp-julia]] needs to know the
-environment in which it is installed. This is set to v1.0 by default as it is
+environment in which it is installed. This is set to v1.6 by default as it is
 the current LTS:
 #+begin_src emacs-lisp
 ;; in $DOOMDIR/config.el
 (after! lsp-julia
-  (setq lsp-julia-default-environment "~/.julia/environments/v1.0"))
+  (setq lsp-julia-default-environment "~/.julia/environments/v1.6"))
 #+end_src
 
 *** =eglot-jl=
 To find your installation of ~LanguageServer.jl~, [[doom-package:][eglot-jl]] must know the
-environment in which it is installed. This is set to v1.0 by default as it is
+environment in which it is installed. This is set to v1.6 by default as it is
 the current LTS:
 #+begin_src emacs-lisp
 ;; in $DOOMDIR/config.el
-(setq eglot-jl-language-server-project "~/.julia/environments/v1.0")
+(setq eglot-jl-language-server-project "~/.julia/environments/v1.6")
 #+end_src
 
 But to let [[doom-package:][eglot-jl]] use the environment bundled with it, set it to
@@ -110,11 +110,11 @@ described above.
 
 ** Change the default environment for the Julia language server
 [[doom-package:][lsp-julia]] requires a variable be set for the Julia environment. This is set to
-v1.0 by default as it is the current LTS:
+v1.6 by default as it is the current LTS:
 #+begin_src emacs-lisp
 ;; in $DOOMDIR/config.el
 (after! lsp-julia
-  (setq lsp-julia-default-environment "~/.julia/environments/v1.0"))
+  (setq lsp-julia-default-environment "~/.julia/environments/v1.6"))
 #+end_src
 
 * Troubleshooting


### PR DESCRIPTION
This is the docs portion of the update from #6010 

As of 1 Dec, Julia v1.6 is the new LTS release. This bumps the docs to reflect this change.