### PR TITLE
Maintain window states in +evil--window-swap

### DIFF
--- a/modules/editor/evil/autoload/evil.el
+++ b/modules/editor/evil/autoload/evil.el
@@ -69,10 +69,7 @@ the only window, use evil-window-move-* (e.g. `evil-window-move-far-left')."
         (with-selected-window that-window
           (switch-to-buffer (doom-fallback-buffer)))
         (setq that-buffer (window-buffer that-window)))
-      (with-selected-window this-window
-        (switch-to-buffer that-buffer))
-      (with-selected-window that-window
-        (switch-to-buffer this-buffer))
+      (window-swap-states this-window that-window)
       (select-window that-window))))
 
 ;;;###autoload


### PR DESCRIPTION
Taking a look at the built in windmove functions shows that Emacs has a
built in function for swapping windows called `window-swap-states`.
Using this ensures the window state is maintained.