### PR TITLE
Fix .gitignore for eaf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 test/.local*/
 test/result
 
+# possible eaf installation
+site-lisp/
+
 # emacs tempfiles that shouldn't be there
 .dap-breakpoints
 .org-id-locations


### PR DESCRIPTION
Emacs application framework is installed in the site-lisp/ directory, whenever you doom upgrade you have to remove the directory and reinstall it after.
