### PR TITLE
fix(vertico): completion category of +default/find-file-under-here

### DIFF
--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -223,7 +223,7 @@ orderless."
     (add-hook 'marginalia-mode-hook #'all-the-icons-completion-marginalia-setup))
   (advice-add #'marginalia--project-root :override #'doom-project-root)
   (pushnew! marginalia-command-categories
-            '(+default/find-file-under-here. file)
+            '(+default/find-file-under-here . file)
             '(doom/find-file-in-emacsd . project-file)
             '(doom/find-file-in-other-project . project-file)
             '(doom/find-file-in-private-config . file)


### PR DESCRIPTION
`(car. cdr)` -> `(car . cdr)`

Fix dotted pair syntax in `marginalia-command-categories` for `+default/find-file-under-here`, so all the completion-category-driven machinery works as intended.
