### PR TITLE
feat(clojure): add doctor.el for clj-kondo

### DIFF
--- a/core/cli/upgrade.el
+++ b/core/cli/upgrade.el
@@ -13,8 +13,23 @@ following shell commands:
     bin/doom clean
     bin/doom sync -u"
   :bare t
-  (let ((doom-auto-discard force-p))
+  (let ((doom-auto-discard force-p)
+        (default-directory doom-emacs-dir))
     (cond
+     ((equal (replace-regexp-in-string
+              "^\\(?:[^/]+/[^/]+/\\)?\\(.+\\)\\(?:~[0-9]+\\)?$" "\\1"
+              (cdr (doom-call-process "git" "name-rev" "--name-only" "HEAD")))
+             "develop")
+      (print! (warn "Doom's primary branch has changed to 'master'. The develop branch will no\nlonger recieve updates and will eventually be deleted.\n"))
+      (if (not (or force-p (y-or-n-p "Switch to the master branch?")))
+          (error! "Aborting...")
+        (print! (info "Switching to master branch"))
+        (let ((remote
+               (cdr (doom-call-process "git" "config" "--get" "branch.develop.remote"))))
+          (doom-call-process "git" "checkout" "--track" (format "%s/master" remote))
+          (print! (info "Reloading Doom Emacs"))
+          (throw 'exit (list "doom" "upgrade" (if force-p "-f"))))))
+
      (packages-only-p
       (doom-cli-execute "sync" "-u")
       (print! (success "Finished upgrading Doom Emacs")))

--- a/core/cli/upgrade.el
+++ b/core/cli/upgrade.el
@@ -26,6 +26,8 @@ following shell commands:
         (print! (info "Switching to master branch"))
         (let ((remote
                (cdr (doom-call-process "git" "config" "--get" "branch.develop.remote"))))
+          (doom-call-process "git" "config" (format "remote.%s.fetch" remote) (format "+refs/heads/*:refs/remotes/%s/*" remote))
+          (doom-call-process "git" "fetch" "--append" remote "master")
           (doom-call-process "git" "checkout" "--track" (format "%s/master" remote))
           (print! (info "Reloading Doom Emacs"))
           (throw 'exit (list "doom" "upgrade" (if force-p "-f"))))))

--- a/modules/lang/clojure/doctor.el
+++ b/modules/lang/clojure/doctor.el
@@ -1,0 +1,6 @@
+;; -*- lexical-binding: t; no-byte-compile: t; -*-
+;;; lang/clojure/doctor.el
+
+(when (featurep! :checkers syntax)
+  (unless (executable-find "clj-kondo")
+    (warn! "Couldn't find clj-kondo. flycheck-clj-kondo will not work.")))


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] No other pull requests exist for this issue
  - [ ] The issue is NOT in Doom's do-not-PR list: https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854

-->

I've added a `doctor.el` to the clojure module with a check for the `clj-kondo` binary, required by `flycheck-clj-kondo`.
I end up forgetting to install clj-kondo when setting up a new computer, and `doom doctor` has always been a friend.

Please let me know if there's anything that needs fixing - the warning text or other things - as this is my first contribution here :eyes: 