### PR TITLE
fix(evil): wrong-number-of-arguments when run-hooks window-selection-change-functions

### DIFF
--- a/modules/editor/evil/autoload/advice.el
+++ b/modules/editor/evil/autoload/advice.el
@@ -152,7 +152,7 @@ more information on modifiers."
     (select-window (split-window origwin count 'below))
     (unless evil-split-window-below
       (select-window origwin)))
-  (run-hooks 'window-selection-change-functions)
+  (run-hook-with-args 'window-selection-change-functions nil)
   (recenter)
   (when (and (not count) evil-auto-balance-windows)
     (balance-windows (window-parent)))
@@ -171,7 +171,7 @@ more information on modifiers."
     (select-window (split-window origwin count 'right))
     (unless evil-vsplit-window-right
       (select-window origwin)))
-  (run-hooks 'window-selection-change-functions)
+  (run-hook-with-args 'window-selection-change-functions nil)
   (recenter)
   (when (and (not count) evil-auto-balance-windows)
     (balance-windows (window-parent)))


### PR DESCRIPTION
`window-selection-change-functions` expects hooks to have one argument.

Edit: functions such as `treemacs--follow-project` (by `treemacs-project-follow-mode`) will raise errors after calling `evil-window-vsplit`.