### PR TITLE
docs(eshell): fix +eshell/here docstring

### DIFF
--- a/modules/term/eshell/autoload/eshell.el
+++ b/modules/term/eshell/autoload/eshell.el
@@ -113,7 +113,7 @@
 
 ;;;###autoload
 (defun +eshell/here (&optional command)
-  "Open eshell in the current buffer."
+  "Open eshell in the current window."
   (interactive "P")
   (let ((buf (+eshell--unused-buffer)))
     (with-current-buffer (switch-to-buffer buf)


### PR DESCRIPTION
This pull request corrects a mistake in the function docstring for `+eshell/here`. This function reuses the current  window but not the current buffer.

EDIT: See `+vterm/here`. 