### PR TITLE
feat(org): add org-pretty-table for +pretty

### DIFF
--- a/modules/lang/org/contrib/pretty.el
+++ b/modules/lang/org/contrib/pretty.el
@@ -22,3 +22,6 @@
   :hook (org-mode . org-fancy-priorities-mode)
   :hook (org-agenda-mode . org-fancy-priorities-mode)
   :config (setq org-fancy-priorities-list '("⚑" "⬆" "■")))
+
+(use-package! org-pretty-table ; "prettier" tables
+  :hook (org-mode . org-pretty-table-mode))

--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -72,7 +72,10 @@
 (when (featurep! +pretty)
   (package! org-appear :pin "a4d10fc346ba14f487eb7aa95761b9295089ba55")
   (package! org-superstar :pin "03be6c0a3081c46a59b108deb8479ee24a6d86c0")
-  (package! org-fancy-priorities :pin "7f677c6c14ecf05eab8e0efbfe7f1b00ae68eb1d"))
+  (package! org-fancy-priorities :pin "7f677c6c14ecf05eab8e0efbfe7f1b00ae68eb1d")
+  (package! org-pretty-table
+    :recipe (:host github :repo "Fuco1/org-pretty-table")
+    :pin "7bd68b420d3402826fea16ee5099d04aa9879b78"))
 (when (featurep! +present)
   (package! centered-window
     :recipe (:host github :repo "anler/centered-window-mode")


### PR DESCRIPTION
The contents of this pull request prettify tables for users of `(org +pretty)`. This is done through the `org-pretty-table` package. This package uses overlays to replace the '-', '+', and '|' characters in tables with unicode glyphs