### PR TITLE
docs(vterm): update nixos install instructions

### DIFF
--- a/modules/term/vterm/README.org
+++ b/modules/term/vterm/README.org
@@ -78,7 +78,7 @@ variable ([[kbd:][SPC h v system-configuration-options]]).
   #+begin_src nix
   systemPackages = with pkgs; [
     # emacs    # no need for this, the next line includes emacs
-    ((emacsPackagesNgGen emacs).emacsWithPackages (epkgs: [
+    ((emacsPackagesFor emacs).emacsWithPackages (epkgs: [
       epkgs.vterm
     ]))
   ];
@@ -97,7 +97,7 @@ variable ([[kbd:][SPC h v system-configuration-options]]).
   
   Note: The =nixpkgs=-version used must be compatible with the packages Doom
   installs, so it might be necessary to pull in =emacs= and/or
-  =emacsPackagesNgGen= from =unstable= or another channel. Otherwise arbitrary
+  =emacsPackagesFor= from =unstable= or another channel. Otherwise arbitrary
   functionality of =vterm= might not work.
 
 ** Compilation tools for vterm-module.so


### PR DESCRIPTION
Some time late 2019 emacsPackagesNgGen was removed from NixOS. This commit updates the instructions in the vterm readme to use the modern alternative: emacsPackagesFor.
