### PR TITLE
feat(clojure): add doctor.el for clj-kondo

### DIFF
--- a/modules/lang/clojure/doctor.el
+++ b/modules/lang/clojure/doctor.el
@@ -1,0 +1,6 @@
+;; -*- lexical-binding: t; no-byte-compile: t; -*-
+;;; lang/clojure/doctor.el
+
+(when (featurep! :checkers syntax)
+  (unless (executable-find "clj-kondo")
+    (warn! "Couldn't find clj-kondo. flycheck-clj-kondo will not work.")))


### PR DESCRIPTION
I've added a doctor.el to the clojure module with a check for the clj-kondo binary, required by flycheck-clj-kondo.
I end up forgetting to install clj-kondo when setting up a new computer, and doom doctor has always been a friend.

Please let me know if there's anything that needs fixing - the warning text or other things - as this is my first contribution here :eyes: 

I saw on discord we should actually target master right? This is the correct PR now (I previously targeted develop with https://github.com/hlissner/doom-emacs/pull/6029)