### PR TITLE
tweak(python): update eglot with `+pyright` flag

### DIFF
--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -332,8 +332,3 @@
   (use-package! lsp-pyright
     :when (featurep! +pyright)
     :after lsp-mode))
-
-(eval-when! (and (featurep! +pyright)
-                 (featurep! :tools lsp +eglot))
-  (after! eglot
-    (add-to-list 'eglot-server-programs '(python-mode . ("pyright-langserver" "--stdio")))))


### PR DESCRIPTION
[this PR](https://github.com/joaotavora/eglot/pull/742/) has preconfigured pyright in eglot. So these lines can be removed.

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] No other pull requests exist for this issue
  - [ ] Your PR targets the master branch (or rewrite-docs if changing org files)
  - [ ] The issue is NOT in Doom's do-not-PR list: https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854

-->
revert #5355 
