### PR TITLE
Fix a regression in 451be94fb8c7

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -316,7 +316,7 @@ Also adds support for a `:sync' parameter to override `:async'."
                (string-match-p "^ \\*temp" (buffer-name)))
         (let ((beg (org-babel-where-is-src-block-result))
               (end (org-babel-result-end)))
-          (org-display-inline-images nil nil (min beg end) (max beg end))))))
+          (if beg (org-display-inline-images nil nil (min beg end) (max beg end)))))))
 
   (after! python
     (unless org-babel-python-command


### PR DESCRIPTION
<!--

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [X] No other pull requests exist for this issue
  - [X] Your PR targets the master branch (or rewrite-docs if changing org files)
  - [X] The issue is NOT in Doom's do-not-PR list: https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  - [X] Any relevant issues and PRs have been linked to
  - [X] Commit messages conform to our conventions: https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854

-->

Fix a regression introduced in 451be94fb8c7, which passed an invalid input to
min when refreshing if there were no org-babel result blocks.
