### PR TITLE
fix(vterm): remove +vterm--change-directory-if-remote

### DIFF
--- a/modules/term/vterm/autoload.el
+++ b/modules/term/vterm/autoload.el
@@ -30,8 +30,7 @@ Returns the vterm buffer."
          (let ((buffer (get-buffer-create buffer-name)))
            (with-current-buffer buffer
              (unless (eq major-mode 'vterm-mode)
-               (vterm-mode))
-             (+vterm--change-directory-if-remote))
+               (vterm-mode)))
            (pop-to-buffer buffer)))
        (get-buffer buffer-name)))))
 
@@ -67,22 +66,4 @@ Returns the vterm buffer."
                default-directory
              project-root)))
     (setenv "PROOT" project-root)
-    (prog1 (funcall display-fn)
-      (+vterm--change-directory-if-remote))))
-
-(defun +vterm--change-directory-if-remote ()
-  "When `default-directory` is remote, use the corresponding
-method to prepare vterm at the corresponding remote directory."
-  (when (and (featurep 'tramp)
-             (tramp-tramp-file-p default-directory))
-    (message "default-directory is %s" default-directory)
-    (with-parsed-tramp-file-name default-directory path
-      (let ((method (cadr (assoc `tramp-login-program
-                                 (assoc path-method tramp-methods)))))
-        (vterm-send-string
-         (concat method " "
-                 (when path-user (concat path-user "@")) path-host))
-        (vterm-send-return)
-        (vterm-send-string
-         (concat "cd " path-localname))
-        (vterm-send-return)))))
+    (funcall display-fn)))


### PR DESCRIPTION
this is no longer necessary as vterm handles this
natively. moreover, it creates a redundant nested
ssh session whenever `SPC o t` is used to re-open an
existing vterm popup.

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] No other pull requests exist for this issue
  - [ ] Your PR targets the master branch (or rewrite-docs if changing org files)
  - [ ] The issue is NOT in Doom's do-not-PR list: https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854

-->