### PR TITLE
fix(rss): kill-buffer-hook removes +rss-workspace-name

### DIFF
--- a/modules/app/rss/autoload.el
+++ b/modules/app/rss/autoload.el
@@ -8,7 +8,7 @@
   (interactive)
   (if (featurep! :ui workspaces)
       (progn
-        (+workspace-switch "*rss*" t)
+        (+workspace-switch +rss-workspace-name t)
         (doom/switch-to-scratch-buffer)
         (elfeed)
         (+workspace/display))
@@ -99,7 +99,7 @@
         (kill-buffer b)))
     (mapc #'kill-buffer show-buffers))
   (if (featurep! :ui workspaces)
-      (+workspace/delete "rss")
+      (+workspace/delete +rss-workspace-name)
     (when (window-configuration-p +rss--wconf)
       (set-window-configuration +rss--wconf))
     (setq +rss--wconf nil)))

--- a/modules/app/rss/config.el
+++ b/modules/app/rss/config.el
@@ -11,6 +11,8 @@
   "Automatically slice images shown in elfeed-show-mode buffers, making them
 easier to scroll through.")
 
+(defvar +rss-workspace-name "*rss*"
+  "Name of the workspace that contains the elfeed buffer.")
 
 ;;
 ;; Packages
@@ -59,9 +61,9 @@ easier to scroll through.")
       "q" #'elfeed-kill-buffer
       "r" #'elfeed-search-update--force
       (kbd "M-RET") #'elfeed-search-browse-url)
-    (map! (:map elfeed-show-mode-map
+    (map! (:map elfeed-show-mode-map)
        :n "gc" nil
-       :n "gc" #'+rss/copy-link))))
+       :n "gc" #'+rss/copy-link)))
 
 
 


### PR DESCRIPTION
Created a new symbol, `+rss-workspace-name`, which holds the value of the name of both the elfeed buffer and elfeed workspace. Then, I changed the `kill-buffer-hook` so it kills the workspace with this value. A previous commit changed the name of the workspace and buffer, but no the target of the `kill-buffer-hook`. This change fixes it avoiding repetition as well.