### PR TITLE
fix(rss): unbalanced parens in map!

### DIFF
--- a/modules/app/rss/config.el
+++ b/modules/app/rss/config.el
@@ -61,9 +61,9 @@ easier to scroll through.")
       "q" #'elfeed-kill-buffer
       "r" #'elfeed-search-update--force
       (kbd "M-RET") #'elfeed-search-browse-url)
-    (map! (:map elfeed-show-mode-map)
-       :n "gc" nil
-       :n "gc" #'+rss/copy-link)))
+    (map! :map elfeed-show-mode-map
+          :n "gc" nil
+          :n "gc" #'+rss/copy-link)))
 
 
 


### PR DESCRIPTION
I introduced an umbalanced parens expression in https://github.com/hlissner/doom-emacs/pull/6065, this PR fixes it.
