### PR TITLE
revert(org): gnuplot 8.0.0 does not work with org babel

### DIFF
--- a/modules/lang/org/packages.el
+++ b/modules/lang/org/packages.el
@@ -57,7 +57,7 @@
 (when (featurep! +dragndrop)
   (package! org-download :pin "947ca223643d28e189480e607df68449c15786cb"))
 (when (featurep! +gnuplot)
-  (package! gnuplot :pin "d1a6a606dcb389a7c91a6b0d9fb995434df561be")
+  (package! gnuplot :pin "7138b139d2dca9683f1a81325c643b2744aa1ea3")
   (package! gnuplot-mode :pin "601f6392986f0cba332c87678d31ae0d0a496ce7"))
 (when (featurep! +ipython) ; DEPRECATED
   (package! ob-ipython :pin "7147455230841744fb5b95dcbe03320313a77124"))


### PR DESCRIPTION
emacsorphanage/gnuplot@d1a6a60 -> emacsorphanage/gnuplot@7138b13

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] No other pull requests exist for this issue
  - [ ] Your PR targets the master branch (or rewrite-docs if changing org files)
  - [ ] The issue is NOT in Doom's do-not-PR list: https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854

-->

Temporarily fixes #6080 

Reverts bump of gnuplot from commit 2557e17, as it breaks running gnuplot blocks from org-mode (babel).
