### PR TITLE
bump: update squashed hash in emacs-undo-fu-session

### DIFF
--- a/modules/emacs/undo/packages.el
+++ b/modules/emacs/undo/packages.el
@@ -4,4 +4,4 @@
 (if (featurep! +tree)
     (package! undo-tree :pin "e326c6135e62f5fe8536528d3acd5e798f847407")
   (package! undo-fu :pin "ab8bc10e424bccc847800c31ab41888db789d55d")
-  (package! undo-fu-session :pin "edf050d6133478d04fc06cc65914517b18d6bcc6"))
+  (package! undo-fu-session :pin "3e810c7c9ab75d2b6f92c7c876290abbc164e750"))


### PR DESCRIPTION
ideasman42/emacs-undo-fu-session@edf050d61334 -> ideasman42/emacs-undo-fu-session@3e810c7c9ab7

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] No other pull requests exist for this issue
  - [ ] Your PR targets the master branch (or rewrite-docs if changing org files)
  - [ ] The issue is NOT in Doom's do-not-PR list: https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  - [ ] Any relevant issues and PRs have been linked to
  - [ ] Commit messages conform to our conventions: https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854

-->


I changed the commit hash for undo-fu-session, as upstream seems to have squashed the commit:
[edf050d6](https://gitlab.com/ideasman42/emacs-undo-fu-session/-/commit/edf050d6133478d04fc06cc65914517b18d6bcc6) -> [3e810c7c](https://gitlab.com/ideasman42/emacs-undo-fu-session/-/commit/3e810c7c9ab75d2b6f92c7c876290abbc164e750)

Only 3e810c7c is attached to [master](https://gitlab.com/ideasman42/emacs-undo-fu-session/-/commits/master).

There are no changes between these two commits with the exception of a log line, but I was getting some warnings that the edf050d6 object could not be found when running doom upgrade a few times:

First run of doom upgrade
```
      > (80/291) Re-cloning emacs-undo-fu-session...
        > Cloning emacs-undo-fu-session...
          Warning (straight): Could not reset to commit "edf050d6133478d04fc06cc65914517b18d6bcc6" in repository "emacs-undo-fu-session"
      ✓ (80/291) emacs-undo-fu-session: 1810251 -> edf050d [1 commit(s)]
          ERROR: Couldn't collect commit list because: fatal: bad object edf050d6133478d04fc06cc65914517b18d6bcc6

```

Second run and subsequent runs:
```
      > (80/291) Re-cloning emacs-undo-fu-session...
        > Cloning emacs-undo-fu-session...
          Warning (straight): Could not reset to commit "edf050d6133478d04fc06cc65914517b18d6bcc6" in repository "emacs-undo-fu-session"
      ✓ (80/291) emacs-undo-fu-session: 3e810c7 -> edf050d [1 commit(s)]
          ERROR: Couldn't collect commit list because: fatal: bad object edf050d6133478d04fc06cc65914517b18d6bcc6
```

Deleting emacs-undo-fu-session and rerunning doom upgrade is a workaround for getting rid of the warning. This should probably be merged as it seems to be using the latest commit from master instead of pinning.