### PR TITLE
fix(org): don't error org-download at top level

### DIFF
--- a/modules/lang/org/contrib/dragndrop.el
+++ b/modules/lang/org/contrib/dragndrop.el
@@ -62,7 +62,7 @@
       (save-excursion
         (org-display-inline-images
          t t
-         (progn (org-back-to-heading t) (point))
+         (progn (org-back-to-heading-or-point-min t) (point))
          (progn (org-end-of-subtree t t)
                 (when (and (org-at-heading-p) (not (eobp))) (backward-char 1))
                 (point)))))))


### PR DESCRIPTION
Org-attach (and thus org-download) can work before the first headline if the user sets `org-attach-auto-tag` to `nil`. But when inserting files in this situation, the `+org--dragndrop-then-display-inline-images-a` advice will display an error message due to using `org-back-to-heading`. So I think it makes more sense to use `org-back-to-heading-or-point-min` in the advice.
