### PR TITLE
fix(html): web-mode did rename web-mode-buffer-highlight to web-mode-reload

### DIFF
--- a/modules/lang/web/+html.el
+++ b/modules/lang/web/+html.el
@@ -88,7 +88,7 @@
 
   (map! :map web-mode-map
         (:localleader
-          :desc "Rehighlight buffer" "h" #'web-mode-buffer-highlight
+          :desc "Rehighlight buffer" "h" #'web-mode-reload
           :desc "Indent buffer"      "i" #'web-mode-buffer-indent
           (:prefix ("a" . "attribute")
             "b" #'web-mode-attribute-beginning


### PR DESCRIPTION
web-mode renamed the function to re-highlight the buffer. It is now called `web-mode-reload`. This PR fixes it.