### PR TITLE
nit(elixir): replace comment of Elixir recipe

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -122,7 +122,7 @@
        ;;data              ; config/data formats
        ;;(dart +flutter)   ; paint ui and not much else
        ;;dhall
-       ;;elixir            ; erlang done right
+       ;;elixir            ; erlang and ruby had a baby
        ;;elm               ; care for a cup of TEA?
        emacs-lisp        ; drown in parentheses
        ;;erlang            ; an elegant language for a more civilized age


### PR DESCRIPTION
Changed the comment of the Elixir recipe. 

The current comment might annoy some Erlang developers and therefor 
was removed from an Elixir forum thread. As Elixir is standing on the shoulders 
of Erlang, let's not offend those who feed it.