### PR TITLE
tweak(cc): default to +lsp

### DIFF
--- a/init.example.el
+++ b/init.example.el
@@ -113,7 +113,7 @@
        :lang
        ;;agda              ; types of types of types of types...
        ;;beancount         ; mind the GAAP
-       ;;cc                ; C > C++ == 1
+       ;;(cc +lsp)         ; C > C++ == 1
        ;;clojure           ; java with a lisp
        ;;common-lisp       ; if you've seen one lisp, you've seen them all
        ;;coq               ; proofs-as-programs


### PR DESCRIPTION
Without +lsp, both irony-mode and rtags require extra configuration for
system header path on macOS.

With +lsp, clangd works well out of the box, and it's easier to
configure than two separate daemons.

Ref: https://github.com/Sarcasm/irony-mode/wiki/Mac-OS-X-issues-and-workaround
Ref: Andersbakken/rtags#811
