### PR TITLE
fix(company): +company--backends minor mode detection

### DIFF
--- a/modules/completion/company/autoload.el
+++ b/modules/completion/company/autoload.el
@@ -56,7 +56,8 @@ Examples:
        (append (cl-loop for (mode . backends) in +company-backend-alist
                         if (or (eq major-mode mode)  ; major modes
                                (and (boundp mode)
-                                    (symbol-value mode))) ; minor modes
+                                    (symbol-value mode)
+                                    (memq mode minor-mode-list))) ; minor modes
                         append backends)
                (nreverse backends))))))
 


### PR DESCRIPTION
the old condition will append any backends added by
`set-company-backend!` once the major-mode in loaded

I see "minor modes" in comments, but the detection also detect major modes.

-------

<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [x] No other pull requests exist for this issue
  - [ ] Your PR targets the master branch (or rewrite-docs if changing org files)
  - [x] The issue is NOT in Doom's do-not-PR list: https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  - [ ] Any relevant issues and PRs have been linked to
  - [x] Commit messages conform to our conventions: https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854

-->

With config

``` emacs-lisp
(setq +company-backend-alist
  '((prog-mode company-capf)))
(after! js2-mode (set-company-backend! js2-mode 'company-tabnine-capf))
```

1. Open a elisp file. `company-backends` in local buffer is `'(company-capf)`
2. Open a js file. `company-backends` in local buffer is `'(company-tabnine-capf company-capf)`
3. Open another elisp file. `company-backends` in local buffer is `'(company-tabnine-capf company-capf)`

The `company-backends` in step 3 should be same with step 1.