### PR TITLE
feat(vertico): add +childframe option similar to ivy

### DIFF
--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -246,3 +246,10 @@ orderless."
 (use-package! wgrep
   :commands wgrep-change-to-wgrep-mode
   :config (setq wgrep-auto-save-buffer t))
+
+
+(use-package! vertico-posframe
+  :when (featurep! +childframe)
+  :hook (vertico-mode . vertico-posframe-mode)
+  :config
+  (add-hook 'doom-after-reload-hook #'posframe-delete-all))

--- a/modules/completion/vertico/packages.el
+++ b/modules/completion/vertico/packages.el
@@ -22,3 +22,8 @@
 
 (when (featurep! +icons)
   (package! all-the-icons-completion :pin "286e2c064a1298be0d8d4100dc91d7a7a554d04a"))
+
+(when (featurep! +childframe)
+  (package! vertico-posframe
+    :recipe (:host github :repo "tumashu/vertico-posframe")
+    :pin "7ca364d319e7ba8ccba26a0d57513f3e66f1b05b"))


### PR DESCRIPTION
-------

This adds `vertico-posframe` to match the similar feature in ivy. I tried to copy the variables from ivy but they didn't seem to be needed? Let me know if there's any feedback, thanks!