### PR TITLE
tweak(evil): respect users' evil-collection-key-blacklist

### DIFF
--- a/modules/editor/evil/init.el
+++ b/modules/editor/evil/init.el
@@ -281,6 +281,7 @@ and complains if a module is loaded too early (during startup)."
     (setq evil-collection-key-blacklist
           (append (list doom-leader-key doom-localleader-key
                         doom-leader-alt-key)
+                  evil-collection-key-blacklist
                   (when (featurep! :tools lookup)
                     '("gd" "gf" "K"))
                   (when (featurep! :tools eval)


### PR DESCRIPTION
Fixes #6119.

By appending the value of `evil-collection-key-blacklist` (if set by user, else nil by `defvar`) when setting it.