### PR TITLE
feat(multiple-cursors): add bindings to `evil-mc-skip-*`

### DIFF
--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -95,6 +95,10 @@
        :prefix "gz"
        :nv "d" #'evil-mc-make-and-goto-next-match
        :nv "D" #'evil-mc-make-and-goto-prev-match
+       :nv "s" #'evil-mc-skip-and-goto-next-match
+       :nv "S" #'evil-mc-skip-and-goto-prev-match
+       :nv "c" #'evil-mc-skip-and-goto-next-cursor
+       :nv "C" #'evil-mc-skip-and-goto-prev-cursor
        :nv "j" #'evil-mc-make-cursor-move-next-line
        :nv "k" #'evil-mc-make-cursor-move-prev-line
        :nv "m" #'evil-mc-make-all-cursors


### PR DESCRIPTION
Hello,

This is my first PR in this wonderful project!

The default bindings for `multiple-cursors` are great, however, when making multiple cursors (from a selection for example using `evil-mc-make-and-goto-next-match`), I often like to skip some matches in some cases, something like this:

```
Make a cursor here▋and here▋but not here, then make another one here▋
```

`evil-mc` have a solution for this through `evil-mc-skip-and-goto-next-match`, `evil-mc-skip-and-goto-prev-match`, `evil-mc-skip-and-goto-next-cursor` and `evil-mc-skip-and-goto-prev-cursor`. But the default bindings do not include them. I've added bindings for these commands in my config file, but I think they should be present in Doom.

I propose to add a binding under:
-   `g z s` and `g z S`, `s` for `skip`.
-   `g z c` and `g z C`, `c` for `cursor`.
