### PR TITLE
tweak(emacs-lisp): local leader for lisp-interaction-mode

### DIFF
--- a/modules/lang/emacs-lisp/config.el
+++ b/modules/lang/emacs-lisp/config.el
@@ -112,7 +112,7 @@ employed so that flycheck still does *some* helpful linting.")
         ret)))
 
   (map! :localleader
-        :map emacs-lisp-mode-map
+        :map (emacs-lisp-mode-map lisp-interaction-mode-map)
         :desc "Expand macro" "m" #'macrostep-expand
         (:prefix ("d" . "debug")
           "f" #'+emacs-lisp/edebug-instrument-defun-on


### PR DESCRIPTION
Enable `emacs-lisp-mode`'s local leader commands for `lisp-interactive-mode`.
Those commands work in the latter mode, too.