### PR TITLE
fix(web): typo

### DIFF
--- a/modules/lang/web/+html.el
+++ b/modules/lang/web/+html.el
@@ -98,7 +98,7 @@
             "s" #'web-mode-attribute-select
             "k" #'web-mode-attribute-kill
             "p" #'web-mode-attribute-previous
-            "p" #'web-mode-attribute-transpose)
+            "t" #'web-mode-attribute-transpose)
           (:prefix ("b" . "block")
             "b" #'web-mode-block-beginning
             "c" #'web-mode-block-close


### PR DESCRIPTION
web-mode-attribute-transpose should be bind to SPC m a t, instead of SPC m a p
