### PR TITLE
Minor python updates

### DIFF
--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -79,10 +79,13 @@
         (setq-local flycheck-python-flake8-executable "flake8"))))
 
   (define-key python-mode-map (kbd "DEL") nil) ; interferes with smartparens
-  (sp-local-pair 'python-mode "'" nil
-                 :unless '(sp-point-before-word-p
-                           sp-point-after-word-p
-                           sp-point-before-same-p))
+  ;; Automatically close f-strings
+  (sp-with-modes 'python-mode
+    (sp-local-pair  "f\"" "\"")
+    (sp-local-pair  "f\"\"\"" "\"\"\"")
+    (sp-local-pair  "f'''" "'''")
+    (sp-local-pair  "f'" "'"))
+  (setq sp-python-insert-colon-in-function-definitions nil) ; interferes with snippet
 
   ;; Affects pyenv and conda
   (when (featurep! :ui modeline)

--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -7,7 +7,7 @@
   "Command to initialize the jupyter REPL for `+python/open-jupyter-repl'.")
 
 (after! projectile
-  (pushnew! projectile-project-root-files "setup.py" "requirements.txt"))
+  (pushnew! projectile-project-root-files "pyproject.toml" "requirements.txt" "setup.py"))
 
 
 ;;


### PR DESCRIPTION
Fixes https://github.com/hlissner/doom-emacs/issues/3327

This PR changes three small things in the python module config:

- adjust smartparens to automatically close f-strings (#3327)
-  adjust smartparens to not insert a trailing `:` in functions (clashes with `def` snippet)
- Add `pyproject.toml` to the list of project files

I've had these changes in my stripped-down python module for a while and haven't experienced any issue. Also gave it a quick test with the python module from this PR.