### PR TITLE
tweak(vertico): ignore svn and hg dirs in file search

### DIFF
--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -27,7 +27,7 @@
                   (unless recursive "--maxdepth 1 ")
                   "--null --line-buffered --color=never --max-columns=1000 "
                   "--path-separator /   --smart-case --no-heading --line-number "
-                  "--hidden -g !.git "
+                  "--hidden -g !.git -g !.svn -g !.hg "
                   (mapconcat #'shell-quote-argument args " ")
                   " ."))
          (prompt (if (stringp prompt) (string-trim prompt) "Search"))


### PR DESCRIPTION
<!-- 

  MAKE SURE YOUR PR MEETS THIS CRITERIA:

  * No other PRs exist for this issue.
  * Your PR is NOT in Doom's do-not-PR list:
    https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  * Your commit messages conform to our git conventions:
    https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854
  * Your PR targets the master branch (or the rewrite-docs branch for changes to
    *.org files).
  * Any relevant issues or PRs have been linked to.

-->
Ignore svn and hg dirs in the `+vertico-file-search ` function, which is used for implementing `+vertico/project-search` 
