### PR TITLE
Expanded Fortran UI

### DIFF
--- a/modules/lang/fortran/README.org
+++ b/modules/lang/fortran/README.org
@@ -29,7 +29,7 @@ In particular, this module features:
 + Support for all major Fortran varieties.
 + Auto-formatting via =fprettier=.
 + Integration with the =fpm= package manager.
-+ LSP support via [[https://github.com/hansec/fortran-language-server][fortran-language-server]].
++ LSP support via [[https://github.com/gnikit/fortls][fortls]].
 
 #+begin_quote
 After a career of writing Fortran on Mainframes and Windows machines, my
@@ -42,7 +42,7 @@ now... Cheers Dad, hope this helps.
 + [[https://github.com/fosskers][@fosskers]] (Author)
 
 ** Module Flags
-+ =+lsp= Activate =fortran-language-server= for Fortran projects.
++ =+lsp= Activate =fortls= for Fortran projects.
 
 ** Plugins
 
@@ -59,11 +59,11 @@ management tasks you will also need [[https://github.com/fortran-lang/fpm][fpm]]
 sudo pacman -S gcc-fortran
 #+end_example
 
-Whereas =fpm= is available from the AUR and thus must be installed with an
-AUR-compatible tool like [[https://github.com/fosskers/aura][Aura]]:
+Whereas =fpm= and =fortls= are available from the AUR and thus must be installed
+with an AUR-compatible tool like [[https://github.com/fosskers/aura][Aura]]:
 
 #+begin_example
-sudo aura -A fortran-fpm
+sudo aura -A fortran-fpm fortls
 #+end_example
 
 * Features

--- a/modules/lang/fortran/autoload.el
+++ b/modules/lang/fortran/autoload.el
@@ -55,6 +55,7 @@ then building will occur with fpm. Otherwise it will default to gfortran."
     (sleep-for 1))
   (compile "./a.out"))
 
+
 ;;
 ;;; FPM
 

--- a/modules/lang/fortran/autoload.el
+++ b/modules/lang/fortran/autoload.el
@@ -1,6 +1,29 @@
 ;;; lang/fortran/autoload.el -*- lexical-binding: t; -*-
 
 ;;
+;;; Generalised Building
+
+;;;###autoload
+(defun +fortran/build ()
+  "Compile a Fortran project or file.
+If the current file is detected to be within an fpm project,
+then building will occur with fpm. Otherwise it will default to gfortran."
+  (interactive)
+  (if (+fortran--fpm-toml)
+      (+fortran/fpm-build)
+    (+fortran/gfortran-compile)))
+
+;;;###autoload
+(defun +fortran/run ()
+  "Run a Fortran project or file.
+If the current file is detected to be within an fpm project,
+then building will occur with fpm. Otherwise it will default to gfortran."
+  (interactive)
+  (if (+fortran--fpm-toml)
+      (+fortran/fpm-run)
+    (+fortran/gfortran-run)))
+
+;;
 ;;; GFortran
 
 (defun +fortran--std ()
@@ -32,9 +55,16 @@
     (sleep-for 1))
   (compile "./a.out"))
 
-
 ;;
 ;;; FPM
+
+;;;###autoload
+(defun +fortran--fpm-toml ()
+  "If this is an fpm project, find its toml file."
+  (when-let* ((project-root (doom-project-root))
+              (toml (expand-file-name "fpm.toml" project-root)))
+    (when (file-exists-p toml)
+      toml)))
 
 ;;;###autoload
 (defun +fortran/fpm-build ()

--- a/modules/lang/fortran/config.el
+++ b/modules/lang/fortran/config.el
@@ -26,7 +26,13 @@
          :desc "fpm run"   "r" #'+fortran/fpm-run
          :desc "fpm test"  "t" #'+fortran/fpm-test)
         :desc "compile (gfortran)" "c" #'+fortran/gfortran-compile
-        :desc "run (gfortran)"     "r" #'+fortran/gfortran-run))
+        :desc "run (gfortran)"     "r" #'+fortran/gfortran-run)
+
+  (easy-menu-define f90-menu f90-mode-map "Simpler menu for F90 mode."
+    '("F90"
+      ["Compile" +fortran/fpm-build :active t :help "Compile with FPM"]
+      ["Run" +fortran/fpm-run :active t :help "Run the Executable"]
+      ["Test" +fortran/fpm-test :active t :help "Run the Unit Tests"])))
 
 (use-package! fortran
   ;; The `.for' extension is automatically recognized by Emacs and invokes
@@ -54,4 +60,9 @@
   (map! :map fortran-mode-map
         :localleader
         :desc "compile (gfortran)" "c" #'+fortran/gfortran-compile
-        :desc "run (gfortran)"     "r" #'+fortran/gfortran-run))
+        :desc "run (gfortran)"     "r" #'+fortran/gfortran-run)
+
+  (easy-menu-define fortran-menu fortran-mode-map "Simpler menu for Fortran mode."
+      '("Fortran"
+        ["Compile" +fortran/gfortran-compile :active t :help "Compile with gfortran"]
+        ["Run" +fortran/gfortran-run :active t :help "Run the Executable"])))

--- a/modules/lang/fortran/config.el
+++ b/modules/lang/fortran/config.el
@@ -25,8 +25,11 @@
          :desc "fpm build" "b" #'+fortran/fpm-build
          :desc "fpm run"   "r" #'+fortran/fpm-run
          :desc "fpm test"  "t" #'+fortran/fpm-test)
-        :desc "compile (gfortran)" "c" #'+fortran/gfortran-compile
-        :desc "run (gfortran)"     "r" #'+fortran/gfortran-run)
+        (:prefix ("g" . "gfortran")
+         :desc "compile" "c" #'+fortran/gfortran-compile
+         :desc "run"     "r" #'+fortran/gfortran-run)
+        :desc "build" "b" #'+fortran/build
+        :desc "run"   "r" #'+fortran/run)
 
   (easy-menu-define f90-menu f90-mode-map "Simpler menu for F90 mode."
     `("F90"
@@ -59,10 +62,11 @@
   ;; --- Keybindings --- ;;
   (map! :map fortran-mode-map
         :localleader
-        :desc "compile (gfortran)" "c" #'+fortran/gfortran-compile
-        :desc "run (gfortran)"     "r" #'+fortran/gfortran-run)
+        (:prefix ("g" . "gfortran")
+         :desc "compile" "c" #'+fortran/gfortran-compile
+         :desc "run"     "r" #'+fortran/gfortran-run))
 
   (easy-menu-define fortran-menu fortran-mode-map "Simpler menu for Fortran mode."
-      '("Fortran"
-        ["Compile" +fortran/gfortran-compile :active t :help "Compile with gfortran"]
-        ["Run" +fortran/gfortran-run :active t :help "Run the Executable"])))
+    '("Fortran"
+      ["Compile" +fortran/gfortran-compile :active t :help "Compile with gfortran"]
+      ["Run" +fortran/gfortran-run :active t :help "Run the Executable"])))

--- a/modules/lang/fortran/config.el
+++ b/modules/lang/fortran/config.el
@@ -29,10 +29,10 @@
         :desc "run (gfortran)"     "r" #'+fortran/gfortran-run)
 
   (easy-menu-define f90-menu f90-mode-map "Simpler menu for F90 mode."
-    '("F90"
-      ["Compile" +fortran/fpm-build :active t :help "Compile with FPM"]
-      ["Run" +fortran/fpm-run :active t :help "Run the Executable"]
-      ["Test" +fortran/fpm-test :active t :help "Run the Unit Tests"])))
+    `("F90"
+      ["Compile" +fortran/build :active t :help "Compile the Project"]
+      ["Run" +fortran/run :active t :help "Run the Executable"]
+      ["Test" +fortran/fpm-test :active (+fortran--fpm-toml) :help "Run the Unit Tests"])))
 
 (use-package! fortran
   ;; The `.for' extension is automatically recognized by Emacs and invokes


### PR DESCRIPTION
This PR expands the Fortran module to allow build tool control through modeline menus.

Note: This contains a commit of #6176 , which should be merged first.