### PR TITLE
fix(org): move journal entry keybinds to 'SPC m j'

### DIFF
--- a/modules/lang/org/contrib/journal.el
+++ b/modules/lang/org/contrib/journal.el
@@ -55,10 +55,11 @@
          "C-p" #'org-journal-search-previous)
         :localleader
         (:map org-journal-mode-map
-         "c" #'org-journal-new-entry
-         "d" #'org-journal-new-date-entry
-         "n" #'org-journal-next-entry
-         "p" #'org-journal-previous-entry
+         (:prefix "j"
+          "c" #'org-journal-new-entry
+          "d" #'org-journal-new-date-entry
+          "n" #'org-journal-next-entry
+          "p" #'org-journal-previous-entry)
          (:prefix "s"
           "s" #'org-journal-search
           "f" #'org-journal-search-forever


### PR DESCRIPTION
Fixes #5239.

I have just started using Doom Emacs and found that many useful keybinds for org-agenda (for example 'SPC m d s' for scheduling) are not working. They are not working only when using org-journal, so moved org-journal keybinds, that are conflicting, to prefix 'SPC m j'.