### PR TITLE
feat(org): keybinds for removing RESULTS blocks

### DIFF
--- a/modules/lang/org/autoload/org-babel.el
+++ b/modules/lang/org/autoload/org-babel.el
@@ -67,6 +67,19 @@
 
 
 ;;
+;;; Commands
+
+;;;###autoload
+(defun +org/remove-result-blocks (remove-all)
+  "Remove all result blocks located after current point."
+  (interactive "P")
+  (let ((pos (point)))
+    (org-babel-map-src-blocks nil
+      (if (or remove-all (< pos end-block))
+          (org-babel-remove-result)))))
+
+
+;;
 ;;; Hooks
 
 ;;;###autoload

--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -844,6 +844,8 @@ between the two."
         "h" #'org-toggle-heading
         "i" #'org-toggle-item
         "I" #'org-id-get-create
+        "k" #'org-babel-remove-result
+        "K" #'+org/remove-result-blocks
         "n" #'org-store-link
         "o" #'org-set-property
         "q" #'org-set-tags-command


### PR DESCRIPTION
Added new keybinds for easy removal of RESULTS blocks in org-mode.
`SPC m k` - delete RESULTS block under cursor
`SPC m K` - delete all RESULTS blocks under cursor
`SPC u SPC m K` - delete all RESULTS blocks in buffer