### PR TITLE
fix(ibuffer): Wrong number of arguments to ibuffer-find-file with ivy enabled.

### DIFF
--- a/modules/emacs/ibuffer/config.el
+++ b/modules/emacs/ibuffer/config.el
@@ -57,11 +57,11 @@
       (+ibuffer-workspace (+workspace-current-name))))
 
   (when (featurep! :completion ivy)
-    (defadvice! +ibuffer-use-counsel-maybe-a (_file &optional _wildcards)
+    (defadvice! +ibuffer-use-counsel-maybe-a (&optional _file _wildcards)
       "Use `counsel-find-file' instead of `find-file'."
       :override #'ibuffer-find-file
       (interactive)
-      (counsel-find-file
+      (counsel-find-file nil
        (let ((buf (ibuffer-current-buffer)))
          (if (buffer-live-p buf)
              (with-current-buffer buf

--- a/modules/emacs/ibuffer/config.el
+++ b/modules/emacs/ibuffer/config.el
@@ -57,16 +57,19 @@
       (+ibuffer-workspace (+workspace-current-name))))
 
   (when (featurep! :completion ivy)
-    (defadvice! +ibuffer-use-counsel-maybe-a (&optional _file _wildcards)
+    (defadvice! +ibuffer-use-counsel-maybe-a (_file &optional _wildcards)
       "Use `counsel-find-file' instead of `find-file'."
       :override #'ibuffer-find-file
-      (interactive)
-      (counsel-find-file nil
-       (let ((buf (ibuffer-current-buffer)))
-         (if (buffer-live-p buf)
-             (with-current-buffer buf
-               default-directory)
-           default-directory)))))
+      (interactive
+       (let* ((buf (ibuffer-current-buffer))
+              (default-directory (if (buffer-live-p buf)
+                                     (with-current-buffer buf
+                                       default-directory)
+                                   default-directory)))
+         (list (counsel--find-file-1 "Find file: " nil
+                                     #'identity
+                                     'counsel-find-file) t)))
+      (find-file _file _wildcards)))
 
   (map! :map ibuffer-mode-map :n "q" #'kill-current-buffer))
 


### PR DESCRIPTION
Error message on C-x C-f in `ibuffer` :

```
(wrong-number-of-arguments ((t) (_file &optional _wildcards) "Use `counsel-find-file' instead of `find-file'." (interactive) (counsel-find-file (let ((buf (ibuffer-current-buffer))) (if (buffer-live-p buf) (save-current-buffer (set-buffer buf) default-directory) default-directory)))) 0)
```

