### PR TITLE
fix(multiple-cursors): fix keybinds for evil-mc-make-and-goto-next(last)-cursor

### DIFF
--- a/modules/editor/multiple-cursors/config.el
+++ b/modules/editor/multiple-cursors/config.el
@@ -155,9 +155,9 @@
   (map! :map evil-mc-key-map
         :nv "g." nil
         :nv "C-n" #'evil-mc-make-and-goto-next-cursor
-        :nv "C-N" #'evil-mc-make-and-goto-last-cursor
+        :nv "C-S-n" #'evil-mc-make-and-goto-last-cursor
         :nv "C-p" #'evil-mc-make-and-goto-prev-cursor
-        :nv "C-P" #'evil-mc-make-and-goto-first-cursor))
+        :nv "C-S-p" #'evil-mc-make-and-goto-first-cursor))
 
 
 (after! multiple-cursors-core


### PR DESCRIPTION
<!-- 

  MAKE SURE YOUR PR MEETS THIS CRITERIA:

  * No other PRs exist for this issue.
  * Your PR is NOT in Doom's do-not-PR list:
    https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  * Your commit messages conform to our git conventions:
    https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854
  * Your PR targets the master branch (or the rewrite-docs branch for changes to
    *.org files).
  * Any relevant issues or PRs have been linked to.

-->

The keybind for evil-mc-make-and-goto-last-cursor was set to "C-N". The "map!" macro doesn't account for letter capitalization when using the Control prefix so the bind for evil-mc-make-and-goto-last-cursor overrides the bind for evil-mc-make-and-goto-next-cursor. Same situation with evil-mc-make-and-goto-first-cursor overriding the bind for evil-mc-make-and-goto-prev-cursor. This fixes this by instead using "C-S-n" and "C-S-p" keybinds to make the Shift explicit.
