### PR TITLE
feat(idris): add +lsp to idris language configuration

### DIFF
--- a/modules/lang/idris/config.el
+++ b/modules/lang/idris/config.el
@@ -2,6 +2,8 @@
 
 (after! idris-mode
   (add-hook 'idris-mode-hook #'turn-on-idris-simple-indent)
+  (when (featurep! +lsp)
+    (add-hook 'idris-mode-hook #'lsp!))
   (set-repl-handler! 'idris-mode 'idris-pop-to-repl)
   (set-lookup-handlers! 'idris-mode
     :documentation #'idris-docs-at-point)


### PR DESCRIPTION
<!-- 

  MAKE SURE YOUR PR MEETS THIS CRITERIA:

  * No other PRs exist for this issue.
  * Your PR is NOT in Doom's do-not-PR list:
    https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  * Your commit messages conform to our git conventions:
    https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854
  * Your PR targets the master branch (or the rewrite-docs branch for changes to
    *.org files).
  * Any relevant issues or PRs have been linked to.

-->

Now that `lsp-mode` registers an LSP client for idris I've updated the doom idris module with support for the `+lsp` flag to reflect this change.