### PR TITLE
fix(org): make `org-download-delete' work

### DIFF
--- a/modules/lang/org/contrib/dragndrop.el
+++ b/modules/lang/org/contrib/dragndrop.el
@@ -33,7 +33,6 @@
                      ((executable-find "gnome-screenshot") "gnome-screenshot -a -f %s"))))
 
         org-download-heading-lvl nil
-        org-download-link-format "[[download:%s]]\n"
         org-download-annotate-function (lambda (_link) "")
         org-download-link-format-function
         (lambda (filename)


### PR DESCRIPTION
`org-download-delete` gets the file path by searching link like [[file:...]], so modifying `org-download-link-format` make it not work. (seems to be a bug of org-download)