### PR TITLE
feat(ivy): use variables for counsel-file-jump fd and rg args

### DIFF
--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -14,6 +14,18 @@ When 'everything, also preview virtual buffers")
   "A plist mapping ivy/counsel commands to commands that generate an editable
 results buffer.")
 
+(defvar +ivy--counsel-file-jump-fd-args
+  '("H" "-I" "--color=never" "--type" "file" "--type" "symlink" "--follow")
+  "List of args to be passed to `fd' when used for `counsel-file-jump'.
+
+See `+ivy--counsel-file-jump-use-fd-rg-a'.")
+
+(defvar +ivy--counsel-file-jump-rg-args
+  '("--files" "--follow" "--color=never" "--hidden" "-g!.git" "--no-messages")
+  "List of args to be passed to `rg' when used for `counsel-file-jump'.
+
+See `+ivy--counsel-file-jump-use-fd-rg-a'.")
+
 
 ;;
 ;;; Packages
@@ -287,10 +299,10 @@ results buffer.")
     :override #'counsel--find-return-list
     (cl-destructuring-bind (find-program . args)
         (cond ((when-let (fd (executable-find (or doom-projectile-fd-binary "fd") t))
-                 (append (list fd "-H" "-I" "--color=never" "--type" "file" "--type" "symlink" "--follow")
+                 (append (list fd) +ivy--counsel-file-jump-fd-args
                          (if IS-WINDOWS '("--path-separator=/")))))
               ((executable-find "rg" t)
-               (append (list "rg" "--files" "--follow" "--color=never" "--hidden" "-g!.git" "--no-messages")
+               (append (list "rg") +ivy--counsel-file-jump-rg-args
                        (cl-loop for dir in projectile-globally-ignored-directories
                                 collect "--glob"
                                 collect (concat "!" dir))


### PR DESCRIPTION
Define variables for the arguments passed to `fd` and `rg` in the `+ivy--counsel-file-jump-use-fd-rg-a` advice, located in Ivy's `config.el`.. This change allows the user to easily customize the arguments passed to the `fd` and `rg` commands. For example, I want to see all non-hidden files (including those not in a git repo): `(setq +ivy--counsel-file-jump-fd-args '("-I" "--color=never"))`.

Without these variables, to achieve default behavior users need to either:

1. Modify the source of `modules/completion/ivy/config.el`.
2. Remove the advice, losing a valuable feature (using `fd`/`rg` in `counsel-file-jump`).

This is a minor but useful change for someone used to `counsel-file-jump` coming from Vanilla Emacs. Thanks for your time and consideration!

Relevant to [#385e60cd26bda9cd5deaeb03f24484b18deea9d7](https://github.com/hlissner/doom-emacs/commit/385e60cd26bda9cd5deaeb03f24484b18deea9d7), `fix(ivy): include hidden files in counsel-file-jump`. 