### PR TITLE
bump: :tools lsp

### DIFF
--- a/modules/tools/lsp/packages.el
+++ b/modules/tools/lsp/packages.el
@@ -6,7 +6,7 @@
       (package! eglot :pin "f77518711507810b779d87190d0ca0183fc02e10")
       (when (featurep! :completion vertico)
         (package! consult-eglot :pin "f93c571dc392a8b11d35541bffde30bd9f411d30")))
-  (package! lsp-mode :pin "c6482c1bbfa366a1fc52c32c03164ac77f297022")
+  (package! lsp-mode :pin "4acf72202d47dd7f0166c69220e1f734d133db89")
   (package! lsp-ui :pin "96b1ecbfbf87a775f05b5f0b55253376a3bd61e7")
   (when (featurep! :completion ivy)
     (package! lsp-ivy :pin "3e87441a625d65ced5a208a0b0442d573596ffa3"))


### PR DESCRIPTION
Adds support for the new version of rust-analyzer (inlay hints)