### PR TITLE
bump: :tools lsp

### DIFF
--- a/modules/tools/lsp/packages.el
+++ b/modules/tools/lsp/packages.el
@@ -13,4 +13,4 @@
   (when (featurep! :completion helm)
     (package! helm-lsp :pin "c2c6974dadfac459b1a69a1217441283874cea92"))
   (when (featurep! :completion vertico)
-    (package! consult-lsp :pin "f4f195046b97be5ce0406e0723921b3393d9442e")))
+    (package! consult-lsp :pin "0dfc9d55876d4cf7c32f8a663fe6343927f78052")))


### PR DESCRIPTION
gagbo/consult-lsp@f4f195046b97 -> gagbo/consult-lsp@0dfc9d55876d

Fixes an issue where the diagnostics list from `consult-lsp-diagnostics`
weren't sorted by severity properly

Ref: gagbo/consult-lsp#21
