### PR TITLE
fix(vertico): vertico-resume to vertico-repeat.

### DIFF
--- a/modules/completion/vertico/autoload/vertico.el
+++ b/modules/completion/vertico/autoload/vertico.el
@@ -282,5 +282,5 @@ If prefix ARG is provided, select which session to resume."
   (interactive "P")
   (call-interactively
    (if arg
-       #'vertico-resume-select
-     #'vertico-resume-last)))
+       #'vertico-repeat-select
+     #'vertico-repeat-last)))


### PR DESCRIPTION
Change vertico-resume-* to vertico-repeat-*.

I think it was a typo, since vertico-resume-* does not exist at https://github.com/minad/vertico/blob/main/extensions/vertico-repeat.el