### PR TITLE
Fortran: Intel Support

### DIFF
--- a/modules/lang/fortran/README.org
+++ b/modules/lang/fortran/README.org
@@ -9,7 +9,9 @@
   - [[#module-flags][Module Flags]]
   - [[#plugins][Plugins]]
 - [[#prerequisites][Prerequisites]]
-  - [[#arch-linux][Arch Linux]]
+  - [[#general][General]]
+    - [[#arch-linux][Arch Linux]]
+  - [[#installing-intel-fortran][Installing Intel Fortran]]
 - [[#features][Features]]
 - [[#configuration][Configuration]]
 - [[#troubleshooting][Troubleshooting]]
@@ -30,6 +32,7 @@ In particular, this module features:
 + Auto-formatting via =fprettier=.
 + Integration with the =fpm= package manager.
 + LSP support via [[https://github.com/gnikit/fortls][fortls]].
++ Optional Intel Fortran support via the =+intel= flag.
 
 #+begin_quote
 After a career of writing Fortran on Mainframes and Windows machines, my
@@ -43,15 +46,18 @@ now... Cheers Dad, hope this helps.
 
 ** Module Flags
 + =+lsp= Activate =fortls= for Fortran projects.
++ =+intel= Use the =ifort= compiler by default.
 
 ** Plugins
 
 * Prerequisites
 
+** General
+
 For minimum functionality, this module requires =gfortran=. For most project
 management tasks you will also need [[https://github.com/fortran-lang/fpm][fpm]], the Fortran Package Manager.
 
-** Arch Linux
+*** Arch Linux
 
 =gfortran= is available from the official repositories:
 
@@ -65,6 +71,39 @@ with an AUR-compatible tool like [[https://github.com/fosskers/aura][Aura]]:
 #+begin_example
 sudo aura -A fortran-fpm fortls
 #+end_example
+
+** Installing Intel Fortran
+
+Activating the =+intel= flag won't automatically install Intel Fortan for you.
+Here's how to do it on *nix systems.
+
+You can of course install the entire High-performance Computing kit from Intel,
+which includes Fortran, but the installation footprint is quite large. Instead,
+you're able to install just Fortran and its core facilities on their own as a
+[[https://www.intel.com/content/www/us/en/developer/articles/tool/oneapi-standalone-components.html#fortran][standalone component]]. Download this script, and make it executable via:
+
+#+begin_example
+chmod +x l_fortran-compiler_p_2022.0.3.83_offline.sh
+#+end_example
+
+The filepath will of course change with time, so alter the above command
+accordingly. Now run the script _as a normal user_ (non-sudo) and follow the
+instructions of the installer. This will install =ifort=, etc., in a local
+filepath of your choosing.
+
+To actually use =ifort= and have it link to its libraries properly, we must run a
+script provided by Intel to set certain environment variables:
+
+#+begin_example
+. ~/intel/oneapi/setvars.sh
+#+end_example
+
+(Modify according to where you installed Intel Fortran.) Now =ifort= should be
+runnable in your terminal as you'd expect. _To persist this, add that line to
+your Bash Profile, etc., and log out and in again._ Now Doom will be able to use
+=ifort= too.
+
+Good luck and happy computing!
 
 * Features
 # An in-depth list of features, how to use them, and their dependencies.

--- a/modules/lang/fortran/autoload.el
+++ b/modules/lang/fortran/autoload.el
@@ -6,22 +6,44 @@
 ;;;###autoload
 (defun +fortran/build ()
   "Compile a Fortran project or file.
-If the current file is detected to be within an fpm project,
-then building will occur with fpm. Otherwise it will default to gfortran."
+
+If the current file is detected to be within an fpm project, then
+building will occur with fpm. Otherwise it will default to ifort
+or gfortran, depending on what feature flags are set."
   (interactive)
-  (if (+fortran--fpm-toml)
-      (+fortran/fpm-build)
-    (+fortran/gfortran-compile)))
+  (cond ((+fortran--fpm-toml) (+fortran/fpm-build))
+        ((featurep! +intel) (+fortran/ifort-compile))
+        (t (+fortran/gfortran-compile))))
 
 ;;;###autoload
 (defun +fortran/run ()
   "Run a Fortran project or file.
-If the current file is detected to be within an fpm project,
-then building will occur with fpm. Otherwise it will default to gfortran."
+
+If the current file is detected to be within an fpm project, then
+building will occur with fpm. Otherwise it will default to ifort
+or gfortran, depending on what feature flags are set."
   (interactive)
-  (if (+fortran--fpm-toml)
-      (+fortran/fpm-run)
-    (+fortran/gfortran-run)))
+  (cond ((+fortran--fpm-toml) (+fortran/fpm-run))
+        ((featurep! +intel) (+fortran/ifort-run))
+        (t (+fortran/gfortran-run))))
+
+;; Intel Fortran
+;;;###autoload
+(defun +fortran/ifort-compile ()
+  "Compile the current buffer using ifort."
+  (interactive)
+  (compile (format "ifort %s"
+                   (buffer-file-name))))
+
+;;;###autoload
+(defun +fortran/ifort-run ()
+  "Run the current buffer using ifort."
+  (interactive)
+  (delete-file "./a.out")
+  (+fortran/ifort-compile)
+  (while (not (file-exists-p "./a.out"))
+    (sleep-for 1))
+  (compile "./a.out"))
 
 ;;
 ;;; GFortran

--- a/modules/lang/fortran/config.el
+++ b/modules/lang/fortran/config.el
@@ -8,9 +8,11 @@
   :config
   ;; --- Compilation --- ;;
   ;; Used by `compile' (SPC c c)
-  (setq-hook! 'f90-mode-hook
-    compile-command "gfortran "
-    compilation-buffer-name-function #'+fortran-compilation-buffer-name-fn)
+  (let ((cmd (cond ((featurep! +intel) "ifort ")
+                   (t "gfortran "))))
+    (setq-hook! 'f90-mode-hook
+      compile-command cmd
+      compilation-buffer-name-function #'+fortran-compilation-buffer-name-fn))
   (set-popup-rule! "^\\*fortran-compilation" :side 'right :size 0.5 :quit t)
 
   ;; --- LSP Configuration --- ;;

--- a/modules/lang/fortran/config.el
+++ b/modules/lang/fortran/config.el
@@ -33,6 +33,13 @@
         :desc "build" "b" #'+fortran/build
         :desc "run"   "r" #'+fortran/run)
 
+  (when (featurep! +intel)
+    (map! :map f90-mode-map
+          :localleader
+          (:prefix ("i" . "ifort")
+           :desc "compile" "c" #'+fortran/ifort-compile
+           :desc "run"     "r" #'+fortran/ifort-run)))
+
   (easy-menu-define f90-menu f90-mode-map "Simpler menu for F90 mode."
     `("F90"
       ["Compile" +fortran/build :active t :help "Compile the Project"]
@@ -50,16 +57,12 @@
 
   ;; --- Compilation --- ;;
   ;; Used by `compile' (SPC c c)
-  (setq-hook! 'fortran-mode-hook ; TODO These work for f90 but not for fortran.
-    compile-command "gfortran -std=legacy "
-    compilation-buffer-name-function #'+fortran-compilation-buffer-name-fn)
+  (let ((cmd (cond ((featurep! +intel) "ifort ")
+                   (t "gfortran -std=legacy "))))
+    (setq-hook! 'fortran-mode-hook
+      compile-command cmd
+      compilation-buffer-name-function #'+fortran-compilation-buffer-name-fn))
   (set-popup-rule! "^\\*fortran-compilation" :side 'right :size 0.5 :quit t)
-
-  ;; --- LSP --- ;;
-  ;; Strangely, the built-in flycheck support seems to give better hints than the LSP.
-  ;; (when (featurep! +lsp)
-  ;;   (setq lsp-clients-fortls-args '("--enable_code_actions" "--hover_signature"))
-  ;;   (add-hook 'fortran-mode-local-vars-hook #'lsp! 'append)))
 
   ;; --- Keybindings --- ;;
   (map! :map fortran-mode-map
@@ -68,7 +71,14 @@
          :desc "compile" "c" #'+fortran/gfortran-compile
          :desc "run"     "r" #'+fortran/gfortran-run))
 
+  (when (featurep! +intel)
+    (map! :map fortran-mode-map
+          :localleader
+          (:prefix ("i" . "ifort")
+           :desc "compile" "c" #'+fortran/ifort-compile
+           :desc "run"     "r" #'+fortran/ifort-run)))
+
   (easy-menu-define fortran-menu fortran-mode-map "Simpler menu for Fortran mode."
     '("Fortran"
-      ["Compile" +fortran/gfortran-compile :active t :help "Compile with gfortran"]
-      ["Run" +fortran/gfortran-run :active t :help "Run the Executable"])))
+      ["Compile" +fortran/build :active t :help "Compile with Project"]
+      ["Run" +fortran/run :active t :help "Run the Executable"])))

--- a/modules/lang/fortran/doctor.el
+++ b/modules/lang/fortran/doctor.el
@@ -5,7 +5,12 @@
              (featurep! :tools lsp))
          "This module requires (:tools lsp)")
 
-(when (not (executable-find "gfortran"))
+(when (and (featurep! +intel)
+           (not (executable-find "ifort")))
+  (warn! "Couldn't find Intel ifort - compilation will not work."))
+
+(when (and (not (featurep! +intel))
+           (not (executable-find "gfortran")))
   (warn! "Couldn't find gfortran - compilation will not work."))
 
 (unless (executable-find "fpm")


### PR DESCRIPTION
This PR extend the `fortran` module with a new `+intel` flag, enabling support for the well-known Intel Fortran. This establishes Doom as the only alternative to Eclipse for off-the-shelf IDE support on Linux.

### TODO

- [x] `doom doctor` checks
- [x] Generalized `build`/`run` functions detect `ifort`
- [x] Extra `map!` entries based on `+intel`
- [x] Testing 