### PR TITLE
perf(lookup): defer consult-xref

### DIFF
--- a/modules/tools/lookup/config.el
+++ b/modules/tools/lookup/config.el
@@ -182,6 +182,7 @@ Dictionary.app behind the scenes to get definitions.")
 
   (use-package! consult-xref
     :when (featurep! :completion vertico)
+    :defer t
     :init
     (setq xref-show-xrefs-function       #'consult-xref
           xref-show-definitions-function #'consult-xref)))


### PR DESCRIPTION
`consult-xref` is autoloaded anyway. There are some packages that
require `xref` (such as lispy through requiring etags) so without
deferring, loading those packages may cause `consult.el` to be loaded.
