### PR TITLE
tweak(&org-roam2): map zm to close all folds

### DIFF
--- a/modules/lang/org/contrib/roam2.el
+++ b/modules/lang/org/contrib/roam2.el
@@ -190,6 +190,7 @@ sections seems to ignore the detachment."
           :nv "zC"      #'magit-section-hide-children
           :nv "zo"      #'magit-section-show
           :nv "zO"      #'magit-section-show-children
+          :nv "zm"      #'magit-section-show-level-2-all
           :nv "zr"      #'magit-section-show-level-4-all
           :nv "C-j"     #'magit-section-forward
           :nv "C-k"     #'magit-section-backward


### PR DESCRIPTION
When I found out that `zr` works in Org-Roam buffers, I automatically assumed `zm` also does. It currently doesn't, but maybe it would be a good idea to add it?