### PR TITLE
fix(default): replace vertico-repeat with vertico-repeat-last

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -490,7 +490,7 @@
         "C-S-s"        #'swiper-helm
         "C-S-r"        #'helm-resume)
       (:when (featurep! :completion vertico)
-        "C-S-r"        #'vertico-repeat)
+        "C-S-r"        #'vertico-repeat-last)
 
       ;;; objed
       (:when (featurep! :editor objed +manual)


### PR DESCRIPTION
vertico-repeat was replaced by vertico-repeat-last in https://github.com/minad/vertico/commit/a92b1e47ffe343e2c3096e2ea61af013a8a02af9.