### PR TITLE
Remove *Messages* spam

### DIFF
--- a/modules/lang/graphql/config.el
+++ b/modules/lang/graphql/config.el
@@ -5,15 +5,14 @@
     '((t (:foreground "#E10098")))
     "Face for GraphQL icon."
     :group 'all-the-icons-faces)
-
   ;; Define a doom-modeline compatiable major-mode icon
   (after! all-the-icons
     (setf (alist-get "graphql" all-the-icons-extension-icon-alist)
-          '(all-the-icons-fileicon "graphql" :v-adjust -0.05 :face 'all-the-icons-rhodamine))
+          '(all-the-icons-fileicon "graphql" :v-adjust -0.05 :face all-the-icons-rhodamine))
     (setf (alist-get "gql" all-the-icons-extension-icon-alist)
-          '(all-the-icons-fileicon "graphql" :v-adjust -0.05 :face 'all-the-icons-rhodamine))
+          '(all-the-icons-fileicon "graphql" :v-adjust -0.05 :face all-the-icons-rhodamine))
     (setf (alist-get 'graphql-mode all-the-icons-mode-icon-alist)
-          '(all-the-icons-fileicon "graphql" :v-adjust -0.05 :face 'all-the-icons-rhodamine)))
+          '(all-the-icons-fileicon "graphql" :v-adjust -0.05 :face all-the-icons-rhodamine)))
   (if (featurep! +lsp)
       (add-hook 'graphql-mode-local-vars-hook #'lsp! 'append)
     (set-company-backend! 'graphql-mode 'company-graphql))


### PR DESCRIPTION
The faces were defined wrong, so every time a buffer came into focus, it
would spam `*Messages*`.

I had it during testing but I assumed it was leftovers from my previous failures.