### PR TITLE
fix(org): #+ constructs hidden forever

### DIFF
--- a/modules/lang/org/contrib/present.el
+++ b/modules/lang/org/contrib/present.el
@@ -38,6 +38,7 @@ headings as titles, and you have more freedom to place them wherever you like.")
   (add-hook 'org-tree-slide-after-narrow-hook #'org-display-inline-images)
   (add-hook 'org-tree-slide-mode-hook #'+org-present-prettify-slide-h)
   (add-hook 'org-tree-slide-play-hook #'+org-present-hide-blocks-h)
+  (add-hook 'org-tree-slide-stop-hook #'+org-present-hide-blocks-h)
 
   (when (featurep! :editor evil)
     (map! :map org-tree-slide-mode-map


### PR DESCRIPTION
Leaving org-tree-slide-mode did not unhide #+ constructs.
Now +org-present-hide-blocks-h is triggered when leaving the mode as
well, fixing the behaviour.