### PR TITLE
tweak(ivy): use helpful for counsel descbinds

### DIFF
--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -228,7 +228,8 @@ results buffer.")
 
   ;; Integrate with `helpful'
   (setq counsel-describe-function-function #'helpful-callable
-        counsel-describe-variable-function #'helpful-variable)
+        counsel-describe-variable-function #'helpful-variable
+        counsel-descbinds-function #'helpful-callable)
 
   ;; Decorate `doom/help-custom-variable' results the same way as
   ;; `counsel-describe-variable' (adds value and docstring columns).


### PR DESCRIPTION
<!-- 

  MAKE SURE YOUR PR MEETS THIS CRITERIA:

  * No other PRs exist for this issue.
  * Your PR is NOT in Doom's do-not-PR list:
    https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  * Your commit messages conform to our git conventions:
    https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854
  * Your PR targets the master branch (or the rewrite-docs branch for changes to
    *.org files).
  * Any relevant issues or PRs have been linked to.

-->

Makes `counsel-descbinds` consistent with the other counsel commands.
As mentioned in #4593, `helpful-symbol` prompts are a bit annoying, so I keep `counsel-describe-symbol-function` the same.