### PR TITLE
docs: add texlive-latexextra dependency for pdflatex exports

### DIFF
--- a/modules/lang/org/README.org
+++ b/modules/lang/org/README.org
@@ -182,7 +182,7 @@ brew install gnuplot
 
 ** Arch Linux
 #+begin_src sh
-pacman -S texlive-core texlive-bin texlive-science
+pacman -S texlive-core texlive-bin texlive-science texlive-latexextra
 pacman -S gnuplot
 pacman -S jupyter # required by +jupyter
 #+end_src


### PR DESCRIPTION
Exporting an org file to pdf via LaTeX (org-export-dispatch or 'SPC m
e', then 'l p') requires texlive-latexextra (Arch package name) to be
installed on the system.

For reference, the error raised when texlive-latexextra was missing was
that the file 'wrapfig.sty' was not found. The specific error likely
depends on the contents of the exported file. Internet searches reveal
that pdflatex may also complain about 'utf8x.def' being missing; this
file is also provided by texlive-latexextra.