### PR TITLE
`:completion vertico` updates

### DIFF
--- a/modules/completion/vertico/README.org
+++ b/modules/completion/vertico/README.org
@@ -87,7 +87,7 @@ keybindings are available:
 | =C-M-j=               | (evil) Go to next group                                                       |
 | =C-;= or =<leader> a= | Open an ~embark-act~ menu to chose a useful action                            |
 | =C-c C-;=             | ~embark-export~ the current candidate list (export to a type-specific buffer) |
-| =C-c C-s=             | ~embark-collect-snapsnot~ the current candidate list (collect verbatim)       |
+| =C-c C-l=             | ~embark-collect~ the current candidate list (collect verbatim)       |
 | =C-SPC=               | Preview the current candidate                                                 |
 
 ~embark-act~ will prompt you with a =which-key= menu with useful commands on the

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -173,7 +173,7 @@ orderless."
         (:map minibuffer-local-map
          "C-;"               #'embark-act
          "C-c C-;"           #'embark-export
-         "C-c C-s"           #'embark-collect-snapshot
+         "C-c C-l"           #'embark-collect
          :desc "Export to writable buffer" "C-c C-e" #'+vertico/embark-export-write)
         (:leader
          :desc "Actions" "a" #'embark-act)) ; to be moved to :config default if accepted

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -235,17 +235,6 @@ orderless."
             '(projectile-switch-to-buffer . buffer)
             '(projectile-switch-project . project-file))
 
-  ;; HACK minad/marginalia#127 adds annotation to read-library-name, but
-  ;;   compression errors (or any errors while reading compressed files) will
-  ;;   break completion entirely. This advice suppresses those errors and
-  ;;   degrades gracefully.
-  ;; TODO PR error handling upstream.
-  (defadvice! +vertico--suppress-errors-a (fn &rest args)
-    :around #'marginalia--library-doc
-    (letf! ((#'jka-compr-error #'ignore))
-      (ignore-errors (apply fn args)))))
-
-
 (use-package! embark-consult
   :after (embark consult)
   :config

--- a/modules/completion/vertico/packages.el
+++ b/modules/completion/vertico/packages.el
@@ -4,11 +4,11 @@
 (package! vertico
   :recipe (:host github :repo "minad/vertico"
            :files ("*.el" "extensions/*.el"))
-  :pin "7ec0f0c0769496edf4c8376950c2fdeb44b98102")
+  :pin "46e8e0565079b7161ada4beb94c8938ee9c04bfb")
 
 (package! orderless :pin "8f64537f556f26492fe5ee401d8d578d7d88684b")
 
-(package! consult :pin "36b8bc7065005778db83f12a594b6929bfd3319c")
+(package! consult :pin "d30213aa209391e03b1c1011df92d91a1fc5ef32")
 (package! consult-dir :pin "08f543ae6acbfc1ffe579ba1d00a5414012d5c0b")
 (when (featurep! :checkers syntax)
   (package! consult-flycheck :pin "9b40f136c017fadf6239d7602d16bf73b4ad5198"))
@@ -16,9 +16,9 @@
 (package! embark :pin "2890e535f55b1f08f379fd761b263fa337a72185")
 (package! embark-consult :pin "2890e535f55b1f08f379fd761b263fa337a72185")
 
-(package! marginalia :pin "a514c024ac2796ec9d52f65c1f51b51f96bcb1c7")
+(package! marginalia :pin "dbc37b373e734269bd75d1763e7309863508bf10")
 
 (package! wgrep :pin "f9687c28bbc2e84f87a479b6ce04407bb97cfb23")
 
 (when (featurep! +icons)
-  (package! all-the-icons-completion :pin "9e7d456b0934ecb568b6f05a8445e3f4ce32261f"))
+  (package! all-the-icons-completion :pin "286e2c064a1298be0d8d4100dc91d7a7a554d04a"))

--- a/modules/tools/lsp/packages.el
+++ b/modules/tools/lsp/packages.el
@@ -13,4 +13,4 @@
   (when (featurep! :completion helm)
     (package! helm-lsp :pin "c2c6974dadfac459b1a69a1217441283874cea92"))
   (when (featurep! :completion vertico)
-    (package! consult-lsp :pin "5a3c4e3f4233feff3f141df38f93d1be80259301")))
+    (package! consult-lsp :pin "a8eb3a062feb2715f174500d0624d3a85e000cf7")))


### PR DESCRIPTION
refactor!(vertico): fix embark-collect and rebind to C-c C-l

BREAKING CHANGE: `embark-collect-snapshot` has been renamed upstream to
`embark-collect`. Since the `C-s` mnemonic doesn't really make sense
anymore, I've moved the binding to `C-c C-l`, which has the nice bonus
of being next to the similar `C-c C-;`, and being nicer.

--

bump: :completion vertico consult-lsp

gagbo/consult-lsp@5a3c4e3f4233 -> gagbo/consult-lsp@a8eb3a062feb
iyefrat/all-the-icons-completion@9e7d456b0934 -> iyefrat/all-the-icons-completion@286e2c064a12
minad/consult@36b8bc706500 -> minad/consult@d30213aa2093
minad/marginalia@a514c024ac27 -> minad/marginalia@dbc37b373e73
minad/vertico@7ec0f0c07694 -> minad/vertico@46e8e0565079

--

fix(vertico): update +vertico-workspace-buffer-state to new api

also adapt upstream improvements

--

refactor(vertico): don't suppress compression errors

This was fixed upstream

Ref: minad/marginalia#132