### PR TITLE
feat(clojure): use lsp features when +lsp flag is enabled

### DIFF
--- a/modules/lang/clojure/doctor.el
+++ b/modules/lang/clojure/doctor.el
@@ -1,6 +1,7 @@
 ;; -*- lexical-binding: t; no-byte-compile: t; -*-
 ;;; lang/clojure/doctor.el
 
-(when (featurep! :checkers syntax)
+(when (and (featurep! :checkers syntax)
+           (not (featurep! +lsp)))
   (unless (executable-find "clj-kondo")
     (warn! "Couldn't find clj-kondo. flycheck-clj-kondo will not work.")))


### PR DESCRIPTION
<!-- 

  MAKE SURE YOUR PR MEETS THIS CRITERIA:

  * No other PRs exist for this issue.
  * Your PR is NOT in Doom's do-not-PR list:
    https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
  * Your commit messages conform to our git conventions:
    https://gist.github.com/hlissner/4d78e396acb897d9b2d8be07a103a854
  * Your PR targets the master branch (or the rewrite-docs branch for changes to
    *.org files).
  * Any relevant issues or PRs have been linked to.

-->

As discussed on Discord #contributing, it's pretty common to users manually disable cider and clj-refactor features even if using +lsp flag, this PR just check if +lsp is enabled and avoiding enable those features, using lsp ones
