### PR TITLE
fix(python): usage of obsolete alias letf

### DIFF
--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -325,7 +325,7 @@
   (defadvice! +python--inhibit-pip-requirements-fetch-packages-a (fn &rest args)
     "No-op `pip-requirements-fetch-packages', which can be expensive."
     :around #'pip-requirements-mode
-    (letf ((#'pip-requirements-fetch-packages #'ignore))
+    (cl-letf ((#'pip-requirements-fetch-packages #'ignore))
       (apply fn args))))
 
 

--- a/modules/lang/python/config.el
+++ b/modules/lang/python/config.el
@@ -325,7 +325,7 @@
   (defadvice! +python--inhibit-pip-requirements-fetch-packages-a (fn &rest args)
     "No-op `pip-requirements-fetch-packages', which can be expensive."
     :around #'pip-requirements-mode
-    (cl-letf ((#'pip-requirements-fetch-packages #'ignore))
+    (letf! ((#'pip-requirements-fetch-packages #'ignore))
       (apply fn args))))
 
 


### PR DESCRIPTION
Doom doctor croaks:

  > Checking Doom Emacs...
      .config/emacs/modules/lang/python/config.el: Warning: ‘letf’ is an obsolete alias (as of 27.1); use ‘cl-letf’ instead.
