### PR TITLE
docs(bidi): fix #+DATE field in readme

### DIFF
--- a/modules/input/bidi/README.org
+++ b/modules/input/bidi/README.org
@@ -1,5 +1,5 @@
 #+TITLE:   input/bidi
-#+DATE:    September 28, 2021
+#+DATE:    April 22, 2022
 #+SINCE:   v3.0.0
 #+STARTUP: inlineimages nofold
 


### PR DESCRIPTION
-------

I missed fixing this before the merge, and the docs branch isn't up to date enough to have the bidi readme yet.