### PR TITLE
fix(textobjects): define *-any-quote directly

### DIFF
--- a/modules/editor/evil/autoload/textobjects.el
+++ b/modules/editor/evil/autoload/textobjects.el
@@ -53,7 +53,7 @@ This excludes the protocol and querystring."
            ("`" . "`")
            ("‘" . "’")
            ("“" . "”"))))
-    (evil-textobj-anyblock-inner-block count beg end type)))
+    (evil-textobj-anyblock--make-textobj beg end type count nil)))
 
 ;;;###autoload (autoload '+evil:outer-any-quote "editor/evil/autoload/textobjects" nil nil)
 (evil-define-text-object +evil:outer-any-quote (count &optional beg end type)
@@ -65,4 +65,4 @@ This excludes the protocol and querystring."
            ("`" . "`")
            ("‘" . "’")
            ("“" . "”"))))
-    (evil-textobj-anyblock-a-block count beg end type)))
+    (evil-textobj-anyblock--make-textobj beg end type count t)))


### PR DESCRIPTION
Fix: #5698

Defining `*-any-quote` objects via the exiting `*-block` helpers leads
to incorrect behaviour, where the trailing boundary is also included as
part of the selection (cursor on `|`, selection between `|`):

```
start: "te|st"
v i q: "|test"|
```

The expected behaviour is the same as `v i "`:
```
start: "te|st"
v i q: "|test|"
```